### PR TITLE
Sprint 2.1: multi-host reachability and remote session cache

### DIFF
--- a/crates/scmux-daemon/Cargo.toml
+++ b/crates/scmux-daemon/Cargo.toml
@@ -28,7 +28,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 anyhow.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-reqwest.workspace = true

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -1,7 +1,8 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Request, State},
     http::StatusCode,
-    response::{Html, Json},
+    middleware::{from_fn_with_state, Next},
+    response::{Html, Json, Response},
     routing::{get, post},
     Router,
 };
@@ -15,6 +16,7 @@ use crate::tmux::{self, HostTarget};
 use crate::AppState;
 
 pub fn router(state: Arc<AppState>) -> Router {
+    let middleware_state = Arc::clone(&state);
     Router::new()
         .route("/", get(dashboard_index))
         .route("/health", get(health))
@@ -29,6 +31,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/sessions/:name/stop", post(stop_session))
         .route("/sessions/:name/jump", post(jump_session))
         .layer(CorsLayer::permissive())
+        .layer(from_fn_with_state(middleware_state, touch_last_api_access))
         .with_state(state)
 }
 
@@ -48,6 +51,7 @@ struct SessionSummary {
     id: i64,
     name: String,
     project: Option<String>,
+    host_id: i64,
     status: String,
     cron_schedule: Option<String>,
     auto_start: bool,
@@ -130,6 +134,15 @@ async fn dashboard_index() -> Html<&'static str> {
     Html(DASHBOARD_HTML)
 }
 
+async fn touch_last_api_access(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    state.mark_api_access();
+    next.run(request).await
+}
+
 async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
     let host_id = state.host_id;
     let running: i64 = tokio::task::spawn_blocking(move || {
@@ -156,27 +169,28 @@ async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionSu
     let sessions = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<SessionSummary>> {
         let db = state.db.lock().unwrap();
         let mut stmt = db.prepare(
-            "SELECT s.id, s.name, s.project, s.cron_schedule, s.auto_start,
+            "SELECT s.id, s.name, s.project, s.host_id, s.cron_schedule, s.auto_start,
                     COALESCE(ss.status, 'stopped') as status,
                     COALESCE(ss.panes_json, '[]') as panes_json,
                     ss.polled_at
                  FROM sessions s
                  LEFT JOIN session_status ss ON ss.session_id = s.id
-                 WHERE s.host_id = ?1 AND s.enabled = 1
-                 ORDER BY s.project, s.name",
+                 WHERE s.enabled = 1
+                 ORDER BY s.host_id, s.project, s.name",
         )?;
 
-        let rows = stmt.query_map(params![state.host_id], |r| {
-            let panes_str: String = r.get(6)?;
+        let rows = stmt.query_map([], |r| {
+            let panes_str: String = r.get(7)?;
             Ok(SessionSummary {
                 id: r.get(0)?,
                 name: r.get(1)?,
                 project: r.get(2)?,
-                cron_schedule: r.get(3)?,
-                auto_start: r.get(4)?,
-                status: r.get(5)?,
+                host_id: r.get(3)?,
+                cron_schedule: r.get(4)?,
+                auto_start: r.get(5)?,
+                status: r.get(6)?,
                 panes: serde_json::from_str(&panes_str).unwrap_or(serde_json::json!([])),
-                polled_at: r.get(7)?,
+                polled_at: r.get(8)?,
             })
         })?;
 
@@ -199,7 +213,7 @@ async fn get_session(
 
         let row = db
             .query_row(
-                "SELECT s.id, s.name, s.project, s.cron_schedule, s.auto_start,
+                "SELECT s.id, s.host_id, s.name, s.project, s.cron_schedule, s.auto_start,
                     s.config_json,
                     COALESCE(ss.status, 'stopped'),
                     COALESCE(ss.panes_json, '[]'),
@@ -209,18 +223,19 @@ async fn get_session(
              WHERE s.name = ?1 AND s.host_id = ?2 AND s.enabled = 1",
                 params![name, state.host_id],
                 |r| {
-                    let panes_str: String = r.get(7)?;
-                    let config_str: String = r.get(5)?;
+                    let panes_str: String = r.get(8)?;
+                    let config_str: String = r.get(6)?;
                     Ok((
                         r.get::<_, i64>(0)?,
-                        r.get::<_, String>(1)?,
-                        r.get::<_, Option<String>>(2)?,
+                        r.get::<_, i64>(1)?,
+                        r.get::<_, String>(2)?,
                         r.get::<_, Option<String>>(3)?,
-                        r.get::<_, bool>(4)?,
+                        r.get::<_, Option<String>>(4)?,
+                        r.get::<_, bool>(5)?,
                         config_str,
-                        r.get::<_, String>(6)?,
+                        r.get::<_, String>(7)?,
                         panes_str,
-                        r.get::<_, Option<String>>(8)?,
+                        r.get::<_, Option<String>>(9)?,
                     ))
                 },
             )
@@ -228,6 +243,7 @@ async fn get_session(
 
         let (
             id,
+            host_id,
             name,
             project,
             cron_schedule,
@@ -265,6 +281,7 @@ async fn get_session(
                 id,
                 name,
                 project,
+                host_id,
                 cron_schedule,
                 auto_start,
                 status,
@@ -551,6 +568,10 @@ async fn get_dashboard_config(
 }
 
 async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
+    let reachability = {
+        let map = state.reachability.lock().expect("reachability lock");
+        map.clone()
+    };
     let hosts = tokio::task::spawn_blocking(move || {
         let db_conn = state.db.lock().unwrap();
         let mut stmt = db_conn.prepare(
@@ -559,19 +580,29 @@ async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
         )?;
         let rows = stmt
             .query_map([], |r| {
+                let id: i64 = r.get(0)?;
                 let is_local: bool = r.get(5)?;
                 let address: String = r.get(2)?;
                 let api_port: u16 = r.get(4)?;
-                let last_seen: Option<String> = r.get(6)?;
+                let db_last_seen: Option<String> = r.get(6)?;
+                let reach = reachability.get(&id);
+                let reachable = if is_local {
+                    true
+                } else {
+                    reach.map(|entry| entry.reachable).unwrap_or(false)
+                };
+                let last_seen = reach
+                    .and_then(|entry| entry.last_seen.clone())
+                    .or(db_last_seen);
                 Ok(HostSummary {
-                    id: r.get(0)?,
+                    id,
                     name: r.get(1)?,
                     address: address.clone(),
                     ssh_user: r.get(3)?,
                     api_port,
                     is_local,
-                    last_seen: last_seen.clone(),
-                    reachable: is_local || last_seen.is_some(),
+                    last_seen,
+                    reachable,
                     url: format!("http://{address}:{api_port}"),
                 })
             })?

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -32,6 +32,17 @@ pub struct SessionPatch {
     pub azure_project: Option<Option<String>>,
 }
 
+#[derive(Debug, Clone)]
+pub struct RemoteSessionUpsert {
+    pub name: String,
+    pub project: Option<String>,
+    pub cron_schedule: Option<String>,
+    pub auto_start: bool,
+    pub status: String,
+    pub panes_json: String,
+    pub polled_at: Option<String>,
+}
+
 pub fn open(path: &str) -> Result<Connection> {
     let conn = Connection::open(path)?;
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
@@ -70,6 +81,18 @@ pub fn seed_hosts_from_config(conn: &Connection, hosts: &[HostConfig]) -> anyhow
             ],
         )?;
     }
+    Ok(())
+}
+
+pub fn update_host_last_seen(
+    conn: &Connection,
+    host_id: i64,
+    last_seen: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "UPDATE hosts SET last_seen = ?1 WHERE id = ?2",
+        params![last_seen, host_id],
+    )?;
     Ok(())
 }
 
@@ -203,6 +226,60 @@ pub fn session_id(conn: &Connection, host_id: i64, name: &str) -> anyhow::Result
     Ok(value)
 }
 
+pub fn upsert_remote_session(
+    conn: &Connection,
+    host_id: i64,
+    session: &RemoteSessionUpsert,
+) -> anyhow::Result<()> {
+    let config_json = serde_json::json!({ "session_name": session.name }).to_string();
+    conn.execute(
+        "INSERT INTO sessions (
+            name, project, host_id, config_json, cron_schedule, auto_start, enabled
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)
+         ON CONFLICT(name, host_id) DO UPDATE SET
+            project = excluded.project,
+            cron_schedule = excluded.cron_schedule,
+            auto_start = excluded.auto_start,
+            enabled = 1",
+        params![
+            session.name,
+            session.project,
+            host_id,
+            config_json,
+            session.cron_schedule,
+            session.auto_start
+        ],
+    )?;
+
+    let session_id: i64 = conn.query_row(
+        "SELECT id FROM sessions WHERE name = ?1 AND host_id = ?2",
+        params![session.name, host_id],
+        |r| r.get(0),
+    )?;
+
+    conn.execute(
+        "INSERT INTO session_status (session_id, status, panes_json, polled_at)
+         VALUES (
+            ?1,
+            ?2,
+            ?3,
+            COALESCE(?4, datetime('now'))
+         )
+         ON CONFLICT(session_id) DO UPDATE SET
+            status = excluded.status,
+            panes_json = excluded.panes_json,
+            polled_at = excluded.polled_at",
+        params![
+            session_id,
+            session.status,
+            session.panes_json,
+            session.polled_at
+        ],
+    )?;
+
+    Ok(())
+}
+
 pub fn log_session_event(
     conn: &Connection,
     session_id: i64,
@@ -260,7 +337,7 @@ fn migrate(conn: &Connection) -> Result<()> {
             api_port   INTEGER NOT NULL DEFAULT 7700,
             is_local   BOOLEAN NOT NULL DEFAULT 0,
             created_at DATETIME NOT NULL DEFAULT (datetime('now')),
-            last_seen  DATETIME
+            last_seen  TEXT
         );
 
         CREATE TABLE IF NOT EXISTS sessions (
@@ -330,7 +407,22 @@ fn migrate(conn: &Connection) -> Result<()> {
           BEGIN
             UPDATE sessions SET updated_at = datetime('now') WHERE id = OLD.id;
           END;
-    "#)
+    "#)?;
+    ensure_hosts_last_seen_column(conn)?;
+    Ok(())
+}
+
+fn ensure_hosts_last_seen_column(conn: &Connection) -> Result<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(hosts)")?;
+    let has_last_seen = stmt
+        .query_map([], |r| r.get::<_, String>(1))?
+        .filter_map(Result::ok)
+        .any(|name| name == "last_seen");
+
+    if !has_last_seen {
+        conn.execute("ALTER TABLE hosts ADD COLUMN last_seen TEXT", [])?;
+    }
+    Ok(())
 }
 
 fn validate_config_session_name(name: &str, config_json: &str) -> anyhow::Result<()> {

--- a/crates/scmux-daemon/src/hosts.rs
+++ b/crates/scmux-daemon/src/hosts.rs
@@ -1,0 +1,244 @@
+use crate::{db, AppState};
+use anyhow::Context;
+use chrono::Utc;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+const ACTIVE_API_WINDOW_MS: u64 = 60_000;
+const REMOTE_FETCH_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Clone, Default)]
+pub struct HostReachability {
+    pub host_id: i64,
+    pub reachable: bool,
+    pub last_seen: Option<String>,
+    pub consecutive_failures: u32,
+}
+
+#[derive(Debug, Clone)]
+struct HostRow {
+    id: i64,
+    name: String,
+    address: String,
+    api_port: u16,
+    is_local: bool,
+    last_seen: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteSessionResponse {
+    name: String,
+    project: Option<String>,
+    #[serde(default)]
+    cron_schedule: Option<String>,
+    #[serde(default)]
+    auto_start: bool,
+    #[serde(default = "default_status")]
+    status: String,
+    #[serde(default = "default_panes")]
+    panes: serde_json::Value,
+    #[serde(default)]
+    polled_at: Option<String>,
+}
+
+fn default_status() -> String {
+    "stopped".to_string()
+}
+
+fn default_panes() -> serde_json::Value {
+    serde_json::json!([])
+}
+
+pub async fn probe_host(address: &str) -> bool {
+    let mut command = Command::new(ping_bin());
+    if cfg!(target_os = "macos") {
+        command.args(["-c", "1", "-t", "10", address]);
+    } else {
+        command.args(["-c", "1", "-W", "10", address]);
+    }
+    command
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+pub async fn fetch_remote_sessions(
+    address: &str,
+    port: u16,
+) -> anyhow::Result<Vec<db::RemoteSessionUpsert>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(REMOTE_FETCH_TIMEOUT_SECS))
+        .build()
+        .context("build reqwest client")?;
+    let url = format!("http://{address}:{port}/sessions");
+    let rows = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("non-success status from {url}"))?
+        .json::<Vec<RemoteSessionResponse>>()
+        .await
+        .with_context(|| format!("decode JSON from {url}"))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| db::RemoteSessionUpsert {
+            name: row.name,
+            project: row.project,
+            cron_schedule: row.cron_schedule,
+            auto_start: row.auto_start,
+            status: row.status,
+            panes_json: serde_json::to_string(&row.panes).unwrap_or_else(|_| "[]".to_string()),
+            polled_at: row.polled_at,
+        })
+        .collect())
+}
+
+pub fn apply_probe_result(mut previous: HostReachability, probe_ok: bool) -> HostReachability {
+    if probe_ok {
+        previous.reachable = true;
+        previous.consecutive_failures = 0;
+        previous.last_seen = Some(Utc::now().to_rfc3339());
+        return previous;
+    }
+
+    previous.consecutive_failures = previous.consecutive_failures.saturating_add(1);
+    if previous.reachable && previous.consecutive_failures >= 3 {
+        previous.reachable = false;
+    }
+    previous
+}
+
+pub async fn poll_hosts(state: Arc<AppState>) -> anyhow::Result<()> {
+    let hosts = load_hosts(Arc::clone(&state)).await?;
+    let mut next = {
+        let map = state.reachability.lock().expect("reachability lock");
+        map.clone()
+    };
+
+    for host in hosts {
+        let previous = next.get(&host.id).cloned().unwrap_or(HostReachability {
+            host_id: host.id,
+            reachable: host.is_local,
+            last_seen: host.last_seen.clone(),
+            consecutive_failures: 0,
+        });
+
+        let updated = if host.is_local {
+            HostReachability {
+                host_id: host.id,
+                reachable: true,
+                last_seen: previous.last_seen,
+                consecutive_failures: 0,
+            }
+        } else {
+            let probe_ok = probe_host(&host.address).await;
+            let updated = apply_probe_result(previous, probe_ok);
+
+            if probe_ok {
+                if let Some(last_seen) = updated.last_seen.clone() {
+                    let state2 = Arc::clone(&state);
+                    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+                        let db_conn = state2.db.lock().expect("db lock");
+                        db::update_host_last_seen(&db_conn, host.id, &last_seen)?;
+                        Ok(())
+                    })
+                    .await??;
+                }
+
+                match fetch_remote_sessions(&host.address, host.api_port).await {
+                    Ok(remote_sessions) => {
+                        let state2 = Arc::clone(&state);
+                        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+                            let db_conn = state2.db.lock().expect("db lock");
+                            for session in &remote_sessions {
+                                db::upsert_remote_session(&db_conn, host.id, session)?;
+                            }
+                            Ok(())
+                        })
+                        .await??;
+                    }
+                    Err(err) => {
+                        warn!(
+                            "remote session fetch failed host={} address={}: {}",
+                            host.name, host.address, err
+                        );
+                    }
+                }
+            }
+            updated
+        };
+
+        debug!(
+            "host poll id={} name={} reachable={} failures={}",
+            updated.host_id, host.name, updated.reachable, updated.consecutive_failures
+        );
+        next.insert(host.id, updated);
+    }
+
+    let mut map = state.reachability.lock().expect("reachability lock");
+    *map = next;
+    Ok(())
+}
+
+pub async fn should_use_active_interval(state: &Arc<AppState>) -> anyhow::Result<bool> {
+    let now_ms = state.monotonic_millis();
+    let last_access = state
+        .last_api_access
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let api_recent = last_access > 0 && now_ms.saturating_sub(last_access) <= ACTIVE_API_WINDOW_MS;
+    if !api_recent {
+        return Ok(false);
+    }
+
+    let state2 = Arc::clone(state);
+    let running: i64 = tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
+        let db_conn = state2.db.lock().expect("db lock");
+        let value = db_conn.query_row(
+            "SELECT COUNT(*) FROM session_status WHERE status = 'running'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(value)
+    })
+    .await??;
+    Ok(running > 0)
+}
+
+async fn load_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostRow>> {
+    tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<HostRow>> {
+        let db_conn = state.db.lock().expect("db lock");
+        let mut stmt = db_conn.prepare(
+            "SELECT id, name, address, api_port, is_local, last_seen
+             FROM hosts
+             ORDER BY is_local DESC, name",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(HostRow {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    address: r.get(2)?,
+                    api_port: r.get(3)?,
+                    is_local: r.get(4)?,
+                    last_seen: r.get(5)?,
+                })
+            })?
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>();
+        Ok(rows)
+    })
+    .await?
+}
+
+fn ping_bin() -> String {
+    std::env::var("SCMUX_PING_BIN").unwrap_or_else(|_| "ping".to_string())
+}

--- a/crates/scmux-daemon/src/lib.rs
+++ b/crates/scmux-daemon/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod config;
 pub mod db;
+pub mod hosts;
 pub mod logging;
 pub mod scheduler;
 pub mod tmux;
@@ -10,4 +11,20 @@ pub struct AppState {
     pub db: std::sync::Mutex<rusqlite::Connection>,
     pub host_id: i64,
     pub config: config::Config,
+    pub reachability: std::sync::Mutex<std::collections::HashMap<i64, hosts::HostReachability>>,
+    pub last_api_access: std::sync::atomic::AtomicU64,
+    pub started_at: std::time::Instant,
+}
+
+impl AppState {
+    pub fn monotonic_millis(&self) -> u64 {
+        self.started_at.elapsed().as_millis() as u64
+    }
+
+    pub fn mark_api_access(&self) {
+        self.last_api_access.store(
+            self.monotonic_millis(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
 }

--- a/crates/scmux-daemon/src/main.rs
+++ b/crates/scmux-daemon/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use scmux_daemon::config::Config;
-use scmux_daemon::{api, db, logging, scheduler, AppState};
+use scmux_daemon::{api, db, hosts, logging, scheduler, AppState};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
@@ -93,6 +93,9 @@ async fn main() -> anyhow::Result<()> {
         db: std::sync::Mutex::new(conn),
         host_id,
         config,
+        reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        last_api_access: std::sync::atomic::AtomicU64::new(0),
+        started_at: std::time::Instant::now(),
     });
 
     // Poll loop — every 15 seconds
@@ -118,6 +121,27 @@ async fn main() -> anyhow::Result<()> {
             if let Err(e) = db::write_health(&health_state).await {
                 tracing::error!("health write error: {e}");
             }
+        }
+    });
+
+    // Host reachability loop — adaptive interval based on API activity and live sessions
+    let host_poll_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = hosts::poll_hosts(Arc::clone(&host_poll_state)).await {
+                tracing::warn!("host poll error: {e}");
+            }
+
+            let active = hosts::should_use_active_interval(&host_poll_state)
+                .await
+                .unwrap_or(false);
+            let sleep_secs = if active {
+                health_interval_secs
+            } else {
+                health_interval_secs.saturating_mul(10)
+            }
+            .max(1);
+            tokio::time::sleep(tokio::time::Duration::from_secs(sleep_secs)).await;
         }
     });
 

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -54,6 +54,9 @@ impl ApiHarness {
                 },
                 hosts: Vec::new(),
             },
+            reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+            last_api_access: std::sync::atomic::AtomicU64::new(0),
+            started_at: std::time::Instant::now(),
         });
 
         let router = api::router(Arc::clone(&state));
@@ -213,6 +216,7 @@ async fn t_a_03_get_sessions_returns_sessions_with_correct_status_and_panes() {
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Vec<Value> = response.json().await.expect("json");
     assert_eq!(body.len(), 1);
+    assert!(body[0]["host_id"].as_i64().is_some());
     assert_eq!(body[0]["status"], "running");
     assert!(body[0]["panes"].is_array());
     assert!(!body[0]["panes"].as_array().expect("panes").is_empty());

--- a/crates/scmux-daemon/tests/integration_tests.rs
+++ b/crates/scmux-daemon/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Duration, Timelike, Utc};
 use scmux_daemon::config::{Config, DaemonConfig, PollingConfig};
-use scmux_daemon::{db, scheduler, AppState};
+use scmux_daemon::{db, hosts, scheduler, AppState};
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -40,6 +40,9 @@ fn build_state() -> (Arc<AppState>, TempDir) {
         db: std::sync::Mutex::new(conn),
         host_id,
         config: test_config(),
+        reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        last_api_access: std::sync::atomic::AtomicU64::new(0),
+        started_at: std::time::Instant::now(),
     });
     (state, tmp)
 }
@@ -117,6 +120,18 @@ fn event_count(state: &Arc<AppState>, session_id: i64, event: &str, trigger: &st
             |r| r.get(0),
         )
         .expect("event count")
+}
+
+fn insert_remote_host(state: &Arc<AppState>, name: &str, address: &str, api_port: u16) -> i64 {
+    let db_conn = state.db.lock().expect("db lock");
+    db_conn
+        .execute(
+            "INSERT INTO hosts (name, address, ssh_user, api_port, is_local)
+             VALUES (?1, ?2, 'tester', ?3, 0)",
+            rusqlite::params![name, address, api_port],
+        )
+        .expect("insert remote host");
+    db_conn.last_insert_rowid()
 }
 
 #[tokio::test]
@@ -339,4 +354,75 @@ async fn t_i_09_write_health_prunes_older_than_seven_days() {
         )
         .expect("old row count");
     assert_eq!(old_count, 0);
+}
+
+#[tokio::test]
+async fn t_i_10_poll_hosts_unreachable_test_net_returns_ok() {
+    let (state, _tmp) = build_state();
+    insert_remote_host(&state, "ti10-remote", "192.0.2.1", 7700);
+
+    let _guard = env_lock().lock().await;
+    let script = write_script("#!/bin/sh\nexit 1\n");
+    let prev = set_env_var("SCMUX_PING_BIN", script.to_string_lossy().as_ref());
+
+    let result = hosts::poll_hosts(Arc::clone(&state)).await;
+    restore_env_var("SCMUX_PING_BIN", prev);
+    result.expect("poll hosts");
+}
+
+#[tokio::test]
+async fn t_i_11_three_failures_mark_host_unreachable() {
+    let (state, _tmp) = build_state();
+    let remote_id = insert_remote_host(&state, "ti11-remote", "192.0.2.1", 7700);
+
+    let _guard = env_lock().lock().await;
+    let script = write_script("#!/bin/sh\nexit 1\n");
+    let prev = set_env_var("SCMUX_PING_BIN", script.to_string_lossy().as_ref());
+
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts #1");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts #2");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts #3");
+    restore_env_var("SCMUX_PING_BIN", prev);
+
+    let map = state.reachability.lock().expect("reachability lock");
+    let entry = map.get(&remote_id).expect("remote host entry");
+    assert!(!entry.reachable);
+    assert!(entry.consecutive_failures >= 3);
+}
+
+#[tokio::test]
+async fn t_i_12_success_after_failures_marks_host_reachable() {
+    let (state, _tmp) = build_state();
+    let remote_id = insert_remote_host(&state, "ti12-remote", "127.0.0.1", 1);
+
+    let _guard = env_lock().lock().await;
+    let fail_script = write_script("#!/bin/sh\nexit 1\n");
+    let success_script = write_script("#!/bin/sh\nexit 0\n");
+    let prev = set_env_var("SCMUX_PING_BIN", fail_script.to_string_lossy().as_ref());
+
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts fail #1");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts fail #2");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts fail #3");
+    let _ = set_env_var("SCMUX_PING_BIN", success_script.to_string_lossy().as_ref());
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts success");
+    restore_env_var("SCMUX_PING_BIN", prev);
+
+    let map = state.reachability.lock().expect("reachability lock");
+    let entry = map.get(&remote_id).expect("remote host entry");
+    assert!(entry.reachable);
+    assert_eq!(entry.consecutive_failures, 0);
 }


### PR DESCRIPTION
## Summary
- add `hosts` poller with sequential ping debounce (3 fail -> unreachable, 1 success -> reachable)
- add remote `/sessions` fetch + local cache upsert keyed by `(name, host_id)` using local host ids
- add `AppState` reachability map and atomic `last_api_access` (monotonic ms)
- wire adaptive host poll interval in daemon main loop
- expose `host_id` in `GET /sessions`, and host reachability data via `GET /hosts` / dashboard config
- move `reqwest` to runtime dependencies
- add T-I-10..T-I-12 integration tests

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
