### PR TITLE
Sprint 2.2: live dashboard wired to daemon APIs

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,47 +1,50 @@
 # scmux Dashboard
 
-React single-file dashboard for monitoring and jumping to tmux agent teams.
+`dashboard/team-dashboard.jsx` is the live dashboard UI for `scmux-daemon`.
 
-## Features
+## Daemon URL Discovery
 
-- **Grid / List / Grouped** views
-- Per-session pane status (active / idle / stopped)
-- Open PRs with links
-- Jump modal — fires WezTerm SSH command to attach to session
-- Filter by status (running / idle / stopped) and project
-- Search sessions by name
+The dashboard resolves the daemon base URL from `window.location.origin`.
 
-## Running
+- Normal daemon-served mode: uses the page origin directly.
+- Local file/dev fallback: if origin is `null` or protocol is `file:`, uses `http://localhost:7878`.
 
-The dashboard is a single React JSX file (`team-dashboard.jsx`). To run:
+## Multi-Host Polling Model
+
+The browser only calls the local daemon.
+
+- `GET /dashboard-config.json` on initial load
+  - reads `default_terminal`
+  - reads `poll_interval_ms`
+  - seeds host metadata
+- `GET /sessions` and `GET /hosts` every `poll_interval_ms`
+  - sessions are cross-referenced by `host_id`
+  - host reachability and `last_seen` are taken from `/hosts`
+  - unreachable host sessions render monochrome in the UI
+
+## Opening the Dashboard
+
+Recommended path:
+
+1. Start daemon:
 
 ```bash
-# Option 1: Vite
-npm create vite@latest dashboard -- --template react
-cp team-dashboard.jsx src/App.jsx
-npm run dev
-
-# Option 2: Serve as artifact in Claude.ai
-# Paste team-dashboard.jsx contents into a Claude artifact
+scmux-daemon
 ```
 
-## Connecting to scmux-daemon
+2. Open in browser:
 
-Replace the static `TEAMS` array with a `useEffect` fetch from your daemon:
-
-```js
-useEffect(() => {
-  fetch('http://localhost:7700/sessions')
-    .then(r => r.json())
-    .then(setTeams);
-}, []);
+```text
+http://localhost:7700/
 ```
 
-For multiple hosts, fetch from each and merge with a `host` field added to each session.
+## Local Development
 
-## Jump Command
+You can iterate on the JSX file with a static server while keeping daemon APIs running:
 
-The jump modal shows the WezTerm command for the selected session:
+```bash
+cd dashboard
+python3 -m http.server 8080
+```
 
-- **Local:** `wezterm start -- tmux attach -t <session-name>`
-- **Remote:** `wezterm ssh user@host -- tmux attach -t <session-name>`
+Then open `http://localhost:8080/` and ensure a daemon is running on `http://localhost:7878` (fallback URL), or serve from daemon origin directly.

--- a/dashboard/team-dashboard.jsx
+++ b/dashboard/team-dashboard.jsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const PROJECT_COLORS = {
   "radiant-p3": "#3b82f6",
-  "atm": "#10b981",
-  "beads": "#f59e0b",
-  "provenance": "#8b5cf6",
+  atm: "#10b981",
+  beads: "#f59e0b",
+  provenance: "#8b5cf6",
   "synaptic-canvas": "#ec4899",
   "claude-history": "#06b6d4",
   "ui-platform": "#f97316",
@@ -19,93 +19,492 @@ const STATUS_DOT = {
   running: { color: "#10b981", pulse: true },
 };
 
-const TEAMS = [
-  { name: "ui-template", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 42, title: "Add template renderer", url: "#" }, { num: 43, title: "Fix layout props", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "2m ago" }, { name: "architect", status: "idle", lastActivity: "8m ago" }, { name: "implementer", status: "active", lastActivity: "1m ago" }] },
-  { name: "p3-backend", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 55, title: "Subagent session extraction", url: "#" }], panes: [{ name: "architect", status: "active", lastActivity: "30s ago" }, { name: "implementer", status: "active", lastActivity: "1m ago" }, { name: "tester", status: "idle", lastActivity: "12m ago" }] },
-  { name: "p3-calibration", project: "radiant-p3", sessionStatus: "running", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "5m ago" }, { name: "implementer", status: "idle", lastActivity: "9m ago" }, { name: "tester", status: "active", lastActivity: "2m ago" }] },
-  { name: "atm-daemon", project: "atm", sessionStatus: "running", prs: [{ num: 12, title: "Slack bridge plugin", url: "#" }], panes: [{ name: "rust-dev", status: "active", lastActivity: "4m ago" }, { name: "tui", status: "idle", lastActivity: "22m ago" }, { name: "tester", status: "idle", lastActivity: "18m ago" }] },
-  { name: "atm-tui", project: "atm", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "32m ago" }, { name: "implementer", status: "idle", lastActivity: "45m ago" }, { name: "tester", status: "stopped", lastActivity: "1h ago" }] },
-  { name: "atm-slack-bridge", project: "atm", sessionStatus: "stopped", prs: [{ num: 8, title: "Socket mode per agent", url: "#" }], panes: [{ name: "architect", status: "stopped", lastActivity: "3h ago" }, { name: "implementer", status: "stopped", lastActivity: "3h ago" }] },
-  { name: "dagu-bootstrap", project: "atm", sessionStatus: "running", prs: [], panes: [{ name: "team-lead", status: "active", lastActivity: "1m ago" }, { name: "architect", status: "active", lastActivity: "3m ago" }, { name: "implementer", status: "idle", lastActivity: "7m ago" }] },
-  { name: "codex-mcp", project: "atm", sessionStatus: "idle", prs: [{ num: 3, title: "JSON-RPC wrapper", url: "#" }], panes: [{ name: "team-lead", status: "idle", lastActivity: "1h ago" }, { name: "implementer", status: "idle", lastActivity: "1h ago" }] },
-  { name: "beads-editor", project: "beads", sessionStatus: "stopped", prs: [], panes: [{ name: "react-flow", status: "stopped", lastActivity: "1d ago" }, { name: "architect", status: "stopped", lastActivity: "1d ago" }] },
-  { name: "beads-molecules", project: "beads", sessionStatus: "stopped", prs: [{ num: 7, title: "Jinja2 conditionals", url: "#" }], panes: [{ name: "team-lead", status: "stopped", lastActivity: "2d ago" }, { name: "implementer", status: "stopped", lastActivity: "2d ago" }] },
-  { name: "kuzu-schema", project: "provenance", sessionStatus: "running", prs: [{ num: 21, title: "File provenance links", url: "#" }, { num: 22, title: "Agent ID indexing", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "3m ago" }, { name: "architect", status: "active", lastActivity: "5m ago" }, { name: "tester", status: "idle", lastActivity: "11m ago" }] },
-  { name: "neo4j-migration", project: "provenance", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "40m ago" }, { name: "implementer", status: "idle", lastActivity: "50m ago" }] },
-  { name: "genealogy-graph", project: "provenance", sessionStatus: "stopped", prs: [], panes: [{ name: "team-lead", status: "stopped", lastActivity: "5d ago" }, { name: "researcher", status: "stopped", lastActivity: "5d ago" }] },
-  { name: "sc-marketplace", project: "synaptic-canvas", sessionStatus: "running", prs: [{ num: 33, title: "Tier 2 packaging", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "1m ago" }, { name: "implementer", status: "active", lastActivity: "2m ago" }, { name: "tester", status: "active", lastActivity: "4m ago" }] },
-  { name: "sc-hooks", project: "synaptic-canvas", sessionStatus: "idle", prs: [], panes: [{ name: "architect", status: "idle", lastActivity: "25m ago" }, { name: "implementer", status: "idle", lastActivity: "30m ago" }] },
-  { name: "sc-plugin-devkit", project: "synaptic-canvas", sessionStatus: "stopped", prs: [{ num: 19, title: "Pytest fixture harness", url: "#" }], panes: [{ name: "team-lead", status: "stopped", lastActivity: "4h ago" }, { name: "tester", status: "stopped", lastActivity: "4h ago" }] },
-  { name: "claude-history-cli", project: "claude-history", sessionStatus: "running", prs: [{ num: 53, title: "Subagent extraction", url: "#" }, { num: 54, title: "PreCompact hooks", url: "#" }, { num: 55, title: "PostCompact workflow", url: "#" }], panes: [{ name: "rust-dev", status: "active", lastActivity: "2m ago" }, { name: "tester", status: "idle", lastActivity: "14m ago" }, { name: "architect", status: "idle", lastActivity: "20m ago" }] },
-  { name: "history-search", project: "claude-history", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "55m ago" }, { name: "implementer", status: "idle", lastActivity: "1h ago" }] },
-  { name: "ui-components", project: "ui-platform", sessionStatus: "running", prs: [{ num: 9, title: "Design system tokens", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "6m ago" }, { name: "implementer", status: "active", lastActivity: "8m ago" }, { name: "tester", status: "idle", lastActivity: "15m ago" }] },
-  { name: "ui-design-system", project: "ui-platform", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "6h ago" }, { name: "implementer", status: "stopped", lastActivity: "6h ago" }] },
-  { name: "dolt-agent-reg", project: "dolt-registry", sessionStatus: "running", prs: [{ num: 4, title: "CLI management interface", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "3m ago" }, { name: "architect", status: "idle", lastActivity: "9m ago" }, { name: "implementer", status: "active", lastActivity: "5m ago" }] },
-  { name: "dolt-cam-db", project: "dolt-registry", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "35m ago" }, { name: "implementer", status: "idle", lastActivity: "40m ago" }] },
-  { name: "dolt-req-db", project: "dolt-registry", sessionStatus: "stopped", prs: [{ num: 2, title: "ADR schema migration", url: "#" }], panes: [{ name: "architect", status: "stopped", lastActivity: "8h ago" }, { name: "implementer", status: "stopped", lastActivity: "8h ago" }] },
-  { name: "adr-tracker", project: "dolt-registry", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "2h ago" }, { name: "implementer", status: "idle", lastActivity: "2h ago" }] },
-  { name: "roslyn-rdf", project: "radiant-p3", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "3d ago" }, { name: "implementer", status: "stopped", lastActivity: "3d ago" }] },
-  { name: "nurbs-sensor", project: "radiant-p3", sessionStatus: "idle", prs: [{ num: 61, title: "NURBS bias correction", url: "#" }], panes: [{ name: "team-lead", status: "idle", lastActivity: "1h ago" }, { name: "implementer", status: "idle", lastActivity: "1h ago" }] },
-  { name: "bayer-cnn", project: "radiant-p3", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "2d ago" }, { name: "implementer", status: "stopped", lastActivity: "2d ago" }] },
-  { name: "rust-imgproc", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 17, title: "UnaryMap shape impl", url: "#" }], panes: [{ name: "rust-dev", status: "active", lastActivity: "1m ago" }, { name: "architect", status: "active", lastActivity: "3m ago" }, { name: "tester", status: "idle", lastActivity: "10m ago" }] },
-  { name: "mip-schema", project: "synaptic-canvas", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "4d ago" }, { name: "implementer", status: "stopped", lastActivity: "4d ago" }] },
-  { name: "p3-perf-bench", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 71, title: "Benchmark harness", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "4m ago" }, { name: "implementer", status: "active", lastActivity: "6m ago" }, { name: "tester", status: "active", lastActivity: "8m ago" }] },
-];
+const DEFAULT_BASE_URL = "http://localhost:7878";
+const DEFAULT_POLL_MS = 15_000;
+
+function daemonBaseUrl() {
+  if (typeof window === "undefined") {
+    return DEFAULT_BASE_URL;
+  }
+  const { origin, protocol } = window.location;
+  if (!origin || origin === "null" || protocol === "file:") {
+    return DEFAULT_BASE_URL;
+  }
+  return origin;
+}
 
 function Dot({ status, size = 7 }) {
   const s = STATUS_DOT[status] || STATUS_DOT.stopped;
   return (
-    <span style={{ position: "relative", display: "inline-flex", alignItems: "center", justifyContent: "center", width: size, height: size, flexShrink: 0 }}>
-      {s.pulse && <span style={{ position: "absolute", inset: 0, borderRadius: "50%", backgroundColor: s.color, opacity: 0.35, animation: "ping 1.5s cubic-bezier(0,0,0.2,1) infinite" }} />}
-      <span style={{ width: size, height: size, borderRadius: "50%", backgroundColor: s.color, display: "block" }} />
+    <span
+      style={{
+        position: "relative",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: size,
+        height: size,
+        flexShrink: 0,
+      }}
+    >
+      {s.pulse && (
+        <span
+          style={{
+            position: "absolute",
+            inset: 0,
+            borderRadius: "50%",
+            backgroundColor: s.color,
+            opacity: 0.35,
+            animation: "ping 1.5s cubic-bezier(0,0,0.2,1) infinite",
+          }}
+        />
+      )}
+      <span
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          backgroundColor: s.color,
+          display: "block",
+        }}
+      />
     </span>
   );
 }
 
-function JumpModal({ team, onClose }) {
-  if (!team) return null;
-  const pc = PROJECT_COLORS[team.project] || "#3b82f6";
-  const cmd = `wezterm start -- tmux attach -t ${team.name}`;
-  return (
-    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.8)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 200, backdropFilter: "blur(6px)" }} onClick={onClose}>
-      <div style={{ background: "#0d1117", border: `1px solid ${pc}50`, borderRadius: 12, padding: 28, minWidth: 380, fontFamily: "inherit" }} onClick={e => e.stopPropagation()}>
-        <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.12em", marginBottom: 6 }}>JUMP TO SESSION</div>
-        <div style={{ fontSize: 20, color: "#f1f5f9", fontWeight: 700, marginBottom: 3 }}>{team.name}</div>
-        <div style={{ fontSize: 11, color: pc, marginBottom: 20 }}>{team.project}</div>
+function normalizePanes(session) {
+  const panes = Array.isArray(session.panes) ? session.panes : [];
+  return panes.map((pane, index) => ({
+    name: pane.name || `pane-${index}`,
+    status: pane.status || "idle",
+    lastActivity: pane.last_activity || pane.lastActivity || "unknown",
+    currentCommand: pane.current_command || pane.currentCommand || "",
+  }));
+}
 
-        <div style={{ background: "#060810", borderRadius: 6, padding: "10px 14px", marginBottom: 20, fontSize: 11, color: "#475569" }}>
-          <span style={{ color: "#334155" }}>$ </span>{cmd}
+function parseCiPayload(raw) {
+  if (!raw) {
+    return null;
+  }
+  if (typeof raw === "object") {
+    return raw;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeCi(session) {
+  const source = Array.isArray(session.session_ci)
+    ? session.session_ci
+    : Array.isArray(session.ci)
+      ? session.ci
+      : [];
+
+  return source
+    .map((entry) => {
+      const payload = parseCiPayload(entry.data_json || entry.data || entry.payload);
+      return {
+        provider: entry.provider || "unknown",
+        status: entry.status || "unknown",
+        payload,
+        toolMessage: entry.tool_message || entry.message || null,
+      };
+    })
+    .filter((entry) => entry.provider !== "unknown");
+}
+
+function extractPrs(session, ciEntries) {
+  if (Array.isArray(session.prs)) {
+    return session.prs;
+  }
+
+  const github = ciEntries.find((entry) => entry.provider === "github");
+  if (!github || !github.payload) {
+    return [];
+  }
+
+  if (Array.isArray(github.payload.prs)) {
+    return github.payload.prs;
+  }
+
+  return [];
+}
+
+function extractOpenPrCount(session, ciEntries) {
+  const direct = Array.isArray(session.prs) ? session.prs.length : null;
+  if (direct !== null) {
+    return direct;
+  }
+
+  const github = ciEntries.find((entry) => entry.provider === "github");
+  if (!github) {
+    return 0;
+  }
+  if (github.payload && Array.isArray(github.payload.prs)) {
+    return github.payload.prs.length;
+  }
+  const numericCandidates = [
+    github.payload?.open_pr_count,
+    github.payload?.open_prs,
+    github.payload?.pr_count,
+  ];
+  const numeric = numericCandidates.find((value) => Number.isFinite(value));
+  return Number.isFinite(numeric) ? Number(numeric) : 0;
+}
+
+function relativeTime(iso) {
+  if (!iso) {
+    return "unknown";
+  }
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) {
+    return "unknown";
+  }
+  const elapsedSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (elapsedSec < 60) {
+    return `${elapsedSec}s ago`;
+  }
+  if (elapsedSec < 3600) {
+    return `${Math.floor(elapsedSec / 60)}m ago`;
+  }
+  if (elapsedSec < 86400) {
+    return `${Math.floor(elapsedSec / 3600)}h ago`;
+  }
+  return `${Math.floor(elapsedSec / 86400)}d ago`;
+}
+
+function buildJumpCommand(session, host) {
+  if (!host || host.is_local) {
+    return `tmux attach -t ${session.name}`;
+  }
+  const sshUser = host.ssh_user || "<ssh_user>";
+  return `ssh ${sshUser}@${host.address} tmux attach -t ${session.name}`;
+}
+
+function sessionStyle(session) {
+  const baseOpacity = session.status === "stopped" ? 0.55 : 1;
+  if (!session.host || session.host.reachable) {
+    return { opacity: baseOpacity };
+  }
+
+  return {
+    opacity: baseOpacity * 0.75,
+    filter: "grayscale(1)",
+  };
+}
+
+function hostLabel(host) {
+  if (!host) {
+    return "unknown-host";
+  }
+  return host.name || host.address || `host-${host.id}`;
+}
+
+function hostBadge(host) {
+  if (!host) {
+    return "unknown";
+  }
+  if (host.reachable) {
+    return host.is_local ? "local" : "reachable";
+  }
+  return `last seen ${relativeTime(host.last_seen)}`;
+}
+
+function CiBadges({ session }) {
+  if (!session.ciEntries.length) {
+    return null;
+  }
+
+  return (
+    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+      {session.ciEntries.map((entry, index) => {
+        if (entry.status === "tool_unavailable") {
+          return (
+            <span
+              key={`${entry.provider}-${index}`}
+              title={entry.toolMessage || "Install required CLI tool"}
+              style={{
+                fontSize: 9,
+                color: "#94a3b8",
+                background: "#1e293b",
+                borderRadius: 3,
+                padding: "1px 6px",
+              }}
+            >
+              {entry.provider}: unavailable
+            </span>
+          );
+        }
+
+        if (entry.provider === "github") {
+          return (
+            <span
+              key={`${entry.provider}-${index}`}
+              style={{
+                fontSize: 9,
+                color: "#60a5fa",
+                background: "#172554",
+                borderRadius: 3,
+                padding: "1px 6px",
+              }}
+            >
+              GH PRs: {session.openPrCount}
+            </span>
+          );
+        }
+
+        if (entry.provider === "azure") {
+          return (
+            <span
+              key={`${entry.provider}-${index}`}
+              style={{
+                fontSize: 9,
+                color: "#38bdf8",
+                background: "#082f49",
+                borderRadius: 3,
+                padding: "1px 6px",
+              }}
+            >
+              Azure: {entry.status}
+            </span>
+          );
+        }
+
+        return null;
+      })}
+    </div>
+  );
+}
+
+function JumpModal({ baseUrl, defaultTerminal, session, onClose }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState(null);
+
+  useEffect(() => {
+    if (!session) {
+      return undefined;
+    }
+
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [session, onClose]);
+
+  useEffect(() => {
+    setFeedback(null);
+    setSubmitting(false);
+  }, [session]);
+
+  if (!session) {
+    return null;
+  }
+
+  const pc = PROJECT_COLORS[session.project] || "#3b82f6";
+  const cmd = buildJumpCommand(session, session.host);
+
+  const handleJump = async () => {
+    setSubmitting(true);
+    try {
+      const response = await fetch(
+        `${baseUrl}/sessions/${encodeURIComponent(session.name)}/jump`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            terminal: defaultTerminal,
+            host_id: session.host_id,
+          }),
+        },
+      );
+      const body = await response.json();
+      if (!response.ok) {
+        setFeedback({ ok: false, message: body.message || `HTTP ${response.status}` });
+      } else {
+        setFeedback({ ok: body.ok, message: body.message || "No message" });
+      }
+    } catch (error) {
+      setFeedback({ ok: false, message: String(error) });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.8)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 200,
+        backdropFilter: "blur(6px)",
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: "#0d1117",
+          border: `1px solid ${pc}50`,
+          borderRadius: 12,
+          padding: 24,
+          minWidth: 360,
+          maxWidth: 680,
+          width: "92vw",
+          fontFamily: "inherit",
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.12em", marginBottom: 6 }}>
+          JUMP TO SESSION
+        </div>
+        <div style={{ fontSize: 20, color: "#f1f5f9", fontWeight: 700, marginBottom: 3 }}>
+          {session.name}
+        </div>
+        <div style={{ fontSize: 11, color: pc, marginBottom: 6 }}>
+          {session.project || "unassigned"} on {hostLabel(session.host)}
+        </div>
+        <div style={{ fontSize: 10, color: "#64748b", marginBottom: 16 }}>
+          {session.host?.reachable ? "host reachable" : `host unreachable (${hostBadge(session.host)})`}
         </div>
 
-        <div style={{ marginBottom: 18 }}>
-          <div style={{ fontSize: 10, color: "#1e2535", letterSpacing: "0.1em", marginBottom: 8 }}>PANES</div>
-          {team.panes.map((p, i) => (
-            <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, padding: "4px 0", borderBottom: i < team.panes.length - 1 ? "1px solid #0d1117" : "none" }}>
-              <Dot status={p.status} size={6} />
-              <span style={{ fontSize: 12, color: "#94a3b8", flex: 1 }}>{p.name}</span>
-              <span style={{ fontSize: 10, color: "#334155" }}>{p.lastActivity}</span>
+        <div
+          style={{
+            background: "#060810",
+            borderRadius: 6,
+            padding: "10px 14px",
+            marginBottom: 18,
+            fontSize: 11,
+            color: "#94a3b8",
+            overflowX: "auto",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <span style={{ color: "#334155" }}>$ </span>
+          {cmd}
+        </div>
+
+        <div style={{ marginBottom: 16 }}>
+          <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.1em", marginBottom: 8 }}>
+            PANES
+          </div>
+          {session.panes.length === 0 && (
+            <div style={{ fontSize: 11, color: "#475569" }}>No panes reported.</div>
+          )}
+          {session.panes.map((pane, index) => (
+            <div
+              key={`${pane.name}-${index}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "4px 0",
+                borderBottom: index < session.panes.length - 1 ? "1px solid #0f172a" : "none",
+              }}
+            >
+              <Dot status={pane.status} size={6} />
+              <span style={{ fontSize: 12, color: "#94a3b8", flex: 1 }}>{pane.name}</span>
+              <span style={{ fontSize: 10, color: "#475569" }}>{pane.lastActivity}</span>
             </div>
           ))}
         </div>
 
-        {team.prs.length > 0 && (
-          <div style={{ marginBottom: 20 }}>
-            <div style={{ fontSize: 10, color: "#1e2535", letterSpacing: "0.1em", marginBottom: 8 }}>OPEN PRS</div>
-            {team.prs.map((pr, i) => (
-              <a key={i} href={pr.url} style={{ display: "flex", alignItems: "center", gap: 8, padding: "5px 0", textDecoration: "none", borderBottom: i < team.prs.length - 1 ? "1px solid #0d1117" : "none" }}>
-                <span style={{ fontSize: 10, color: pc, background: `${pc}18`, borderRadius: 3, padding: "2px 6px", flexShrink: 0 }}>#{pr.num}</span>
-                <span style={{ fontSize: 11, color: "#64748b", flex: 1 }}>{pr.title}</span>
+        {session.prs.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.1em", marginBottom: 8 }}>
+              OPEN PRS
+            </div>
+            {session.prs.map((pr, index) => (
+              <a
+                key={`${pr.url || "pr"}-${index}`}
+                href={pr.url || "#"}
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "5px 0",
+                  textDecoration: "none",
+                  borderBottom: index < session.prs.length - 1 ? "1px solid #0f172a" : "none",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: pc,
+                    background: `${pc}18`,
+                    borderRadius: 3,
+                    padding: "2px 6px",
+                    flexShrink: 0,
+                  }}
+                >
+                  #{pr.num || "?"}
+                </span>
+                <span style={{ fontSize: 11, color: "#94a3b8", flex: 1 }}>
+                  {pr.title || "Untitled PR"}
+                </span>
                 <span style={{ fontSize: 11, color: "#334155" }}>↗</span>
               </a>
             ))}
           </div>
         )}
 
+        {feedback && (
+          <div
+            style={{
+              fontSize: 11,
+              marginBottom: 14,
+              color: feedback.ok ? "#34d399" : "#f87171",
+            }}
+          >
+            {feedback.message}
+          </div>
+        )}
+
         <div style={{ display: "flex", gap: 8 }}>
-          <button style={{ flex: 1, padding: "10px 0", background: pc, border: "none", borderRadius: 6, color: "#fff", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", letterSpacing: "0.05em" }}>
-            Open in WezTerm →
+          <button
+            onClick={handleJump}
+            disabled={submitting}
+            style={{
+              flex: 1,
+              padding: "10px 0",
+              background: pc,
+              border: "none",
+              borderRadius: 6,
+              color: "#fff",
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: submitting ? "default" : "pointer",
+              fontFamily: "inherit",
+              letterSpacing: "0.05em",
+              opacity: submitting ? 0.7 : 1,
+            }}
+          >
+            {submitting ? "Launching..." : "Open in iTerm2 ->"}
           </button>
-          <button style={{ padding: "10px 16px", background: "transparent", border: "1px solid #1e2535", borderRadius: 6, color: "#475569", fontSize: 12, cursor: "pointer", fontFamily: "inherit" }} onClick={onClose}>
+          <button
+            style={{
+              padding: "10px 16px",
+              background: "transparent",
+              border: "1px solid #1e2535",
+              borderRadius: 6,
+              color: "#475569",
+              fontSize: 12,
+              cursor: "pointer",
+              fontFamily: "inherit",
+            }}
+            onClick={onClose}
+          >
             esc
           </button>
         </div>
@@ -114,81 +513,147 @@ function JumpModal({ team, onClose }) {
   );
 }
 
-function GridCard({ team, onJump }) {
-  const pc = PROJECT_COLORS[team.project] || "#6b7280";
-  const activePanes = team.panes.filter(p => p.status === "active").length;
-  const isStopped = team.sessionStatus === "stopped";
+function GridCard({ session, onJump }) {
+  const pc = PROJECT_COLORS[session.project] || "#6b7280";
+  const activePanes = session.panes.filter((pane) => pane.status === "active").length;
   return (
-    <div onClick={() => onJump(team)} style={{ background: "#0d1117", border: "1px solid #131820", borderRadius: 8, overflow: "hidden", cursor: "pointer", opacity: isStopped ? 0.5 : 1, transition: "border-color 0.15s, transform 0.1s" }}
-      onMouseEnter={e => { e.currentTarget.style.borderColor = pc + "55"; e.currentTarget.style.transform = "translateY(-1px)"; }}
-      onMouseLeave={e => { e.currentTarget.style.borderColor = "#131820"; e.currentTarget.style.transform = "translateY(0)"; }}
+    <div
+      onClick={() => onJump(session)}
+      style={{
+        background: "#0d1117",
+        border: "1px solid #131820",
+        borderRadius: 8,
+        overflow: "hidden",
+        cursor: "pointer",
+        transition: "border-color 0.15s, transform 0.1s",
+        ...sessionStyle(session),
+      }}
+      onMouseEnter={(event) => {
+        event.currentTarget.style.borderColor = `${pc}55`;
+        event.currentTarget.style.transform = "translateY(-1px)";
+      }}
+      onMouseLeave={(event) => {
+        event.currentTarget.style.borderColor = "#131820";
+        event.currentTarget.style.transform = "translateY(0)";
+      }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 12px", borderBottom: "1px solid #0a0e14" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 12px",
+          borderBottom: "1px solid #0a0e14",
+        }}
+      >
         <div style={{ width: 3, height: 26, borderRadius: 2, background: pc, flexShrink: 0 }} />
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 12, fontWeight: 600, color: "#e2e8f0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{team.name}</div>
-          <div style={{ fontSize: 10, color: pc, opacity: 0.8 }}>{team.project}</div>
+          <div
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: "#e2e8f0",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {session.name}
+          </div>
+          <div style={{ fontSize: 10, color: pc, opacity: 0.8 }}>
+            {(session.project || "unassigned") + " | " + hostLabel(session.host)}
+          </div>
         </div>
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 3, flexShrink: 0 }}>
-          <Dot status={team.sessionStatus} size={7} />
-          {!isStopped && <span style={{ fontSize: 9, color: "#334155" }}>{activePanes}/{team.panes.length}</span>}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 3 }}>
+          <Dot status={session.status} size={7} />
+          <span style={{ fontSize: 9, color: "#334155" }}>
+            {activePanes}/{session.panes.length}
+          </span>
         </div>
       </div>
-      <div style={{ padding: "6px 12px 8px" }}>
-        {team.panes.map((pane, i) => (
-          <div key={i} style={{ display: "flex", alignItems: "center", gap: 6, padding: "2px 0" }}>
+
+      <div style={{ padding: "6px 12px 10px" }}>
+        {session.panes.slice(0, 4).map((pane, index) => (
+          <div key={`${pane.name}-${index}`} style={{ display: "flex", alignItems: "center", gap: 6, padding: "2px 0" }}>
             <Dot status={pane.status} size={5} />
-            <span style={{ fontSize: 10, color: pane.status === "active" ? "#94a3b8" : "#2d3748", flex: 1 }}>{pane.name}</span>
-            <span style={{ fontSize: 9, color: "#1a2030" }}>{pane.lastActivity}</span>
+            <span style={{ fontSize: 10, color: "#94a3b8", flex: 1 }}>{pane.name}</span>
+            <span style={{ fontSize: 9, color: "#334155" }}>{pane.lastActivity}</span>
           </div>
         ))}
-        {team.prs.length > 0 && (
-          <div style={{ marginTop: 6, paddingTop: 5, borderTop: "1px solid #0a0e14", display: "flex", gap: 3, flexWrap: "wrap" }}>
-            {team.prs.map((pr, i) => (
-              <span key={i} style={{ fontSize: 9, color: pc, background: `${pc}18`, borderRadius: 3, padding: "1px 5px" }}>#{pr.num}</span>
-            ))}
-          </div>
-        )}
+
+        <div style={{ marginTop: 8, display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+          <CiBadges session={session} />
+          <span style={{ fontSize: 9, color: "#475569" }}>{hostBadge(session.host)}</span>
+        </div>
       </div>
     </div>
   );
 }
 
-function ListView({ teams, onJump }) {
+function ListView({ sessions, onJump }) {
   return (
-    <div style={{ padding: "0 24px 24px" }}>
-      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+    <div style={{ padding: "0 24px 24px", overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12, minWidth: 780 }}>
         <thead>
           <tr style={{ borderBottom: "1px solid #131820" }}>
-            {["", "Session", "Project", "Status", "Panes", "Active", "Open PRs", "Last Activity"].map((h, i) => (
-              <th key={i} style={{ padding: "8px 12px", textAlign: "left", fontSize: 10, color: "#1e2535", letterSpacing: "0.1em", fontWeight: 600 }}>{h}</th>
-            ))}
+            {["", "Session", "Project", "Host", "Status", "Panes", "Active", "Open PRs", "Last Activity"].map(
+              (header) => (
+                <th
+                  key={header}
+                  style={{
+                    padding: "8px 12px",
+                    textAlign: "left",
+                    fontSize: 10,
+                    color: "#1e2535",
+                    letterSpacing: "0.1em",
+                    fontWeight: 600,
+                  }}
+                >
+                  {header}
+                </th>
+              ),
+            )}
           </tr>
         </thead>
         <tbody>
-          {teams.map((team, i) => {
-            const pc = PROJECT_COLORS[team.project] || "#6b7280";
-            const activePanes = team.panes.filter(p => p.status === "active").length;
+          {sessions.map((session, index) => {
+            const pc = PROJECT_COLORS[session.project] || "#6b7280";
+            const activePanes = session.panes.filter((pane) => pane.status === "active").length;
             return (
-              <tr key={i} onClick={() => onJump(team)} style={{ borderBottom: "1px solid #0a0e14", cursor: "pointer", opacity: team.sessionStatus === "stopped" ? 0.5 : 1, transition: "background 0.1s" }}
-                onMouseEnter={e => e.currentTarget.style.background = "#0f1117"}
-                onMouseLeave={e => e.currentTarget.style.background = "transparent"}
+              <tr
+                key={`${session.name}-${index}`}
+                onClick={() => onJump(session)}
+                style={{
+                  borderBottom: "1px solid #0a0e14",
+                  cursor: "pointer",
+                  transition: "background 0.1s",
+                  ...sessionStyle(session),
+                }}
+                onMouseEnter={(event) => {
+                  event.currentTarget.style.background = "#0f1117";
+                }}
+                onMouseLeave={(event) => {
+                  event.currentTarget.style.background = "transparent";
+                }}
               >
-                <td style={{ padding: "7px 12px" }}><div style={{ width: 3, height: 18, borderRadius: 2, background: pc }} /></td>
-                <td style={{ padding: "7px 12px", color: "#cbd5e1", fontWeight: 500 }}>{team.name}</td>
-                <td style={{ padding: "7px 12px", color: pc, fontSize: 11 }}>{team.project}</td>
-                <td style={{ padding: "7px 12px" }}><div style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot status={team.sessionStatus} size={6} /><span style={{ color: "#334155", fontSize: 11 }}>{team.sessionStatus}</span></div></td>
-                <td style={{ padding: "7px 12px", color: "#334155" }}>{team.panes.length}</td>
-                <td style={{ padding: "7px 12px", color: activePanes > 0 ? "#10b981" : "#1e2535" }}>{activePanes}</td>
                 <td style={{ padding: "7px 12px" }}>
-                  <div style={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
-                    {team.prs.length === 0
-                      ? <span style={{ color: "#1e2535" }}>—</span>
-                      : team.prs.map((pr, j) => <span key={j} style={{ fontSize: 9, color: pc, background: `${pc}18`, borderRadius: 3, padding: "1px 5px" }}>#{pr.num}</span>)
-                    }
+                  <div style={{ width: 3, height: 18, borderRadius: 2, background: pc }} />
+                </td>
+                <td style={{ padding: "7px 12px", color: "#cbd5e1", fontWeight: 500 }}>{session.name}</td>
+                <td style={{ padding: "7px 12px", color: pc, fontSize: 11 }}>{session.project || "unassigned"}</td>
+                <td style={{ padding: "7px 12px", color: "#94a3b8", fontSize: 11 }}>{hostLabel(session.host)}</td>
+                <td style={{ padding: "7px 12px" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <Dot status={session.status} size={6} />
+                    <span style={{ color: "#64748b", fontSize: 11 }}>{session.status}</span>
                   </div>
                 </td>
-                <td style={{ padding: "7px 12px", color: "#1e2535", fontSize: 11 }}>{team.panes[0]?.lastActivity || "—"}</td>
+                <td style={{ padding: "7px 12px", color: "#334155" }}>{session.panes.length}</td>
+                <td style={{ padding: "7px 12px", color: activePanes > 0 ? "#10b981" : "#1e2535" }}>{activePanes}</td>
+                <td style={{ padding: "7px 12px", color: "#60a5fa" }}>{session.openPrCount || "-"}</td>
+                <td style={{ padding: "7px 12px", color: "#475569", fontSize: 11 }}>
+                  {session.panes[0]?.lastActivity || relativeTime(session.polled_at)}
+                </td>
               </tr>
             );
           })}
@@ -198,25 +663,91 @@ function ListView({ teams, onJump }) {
   );
 }
 
-function GroupedView({ teams, onJump }) {
-  const byProject = {};
-  teams.forEach(t => { if (!byProject[t.project]) byProject[t.project] = []; byProject[t.project].push(t); });
+function GroupedView({ sessions, onJump }) {
+  const byProject = useMemo(() => {
+    const grouped = new Map();
+    sessions.forEach((session) => {
+      const project = session.project || "unassigned";
+      if (!grouped.has(project)) {
+        grouped.set(project, []);
+      }
+      grouped.get(project).push(session);
+    });
+    return grouped;
+  }, [sessions]);
+
   return (
     <div style={{ padding: "0 24px 24px", display: "flex", flexDirection: "column", gap: 28 }}>
-      {Object.entries(byProject).map(([project, projectTeams]) => {
+      {Array.from(byProject.entries()).map(([project, projectSessions]) => {
         const pc = PROJECT_COLORS[project] || "#6b7280";
-        const running = projectTeams.filter(t => t.sessionStatus === "running").length;
-        const totalPRs = projectTeams.reduce((n, t) => n + t.prs.length, 0);
+        const running = projectSessions.filter((session) => session.status === "running").length;
+        const totalPrs = projectSessions.reduce((sum, session) => sum + session.openPrCount, 0);
+
+        const byHost = new Map();
+        projectSessions.forEach((session) => {
+          const key = session.host?.id || `unknown-${session.host_id}`;
+          if (!byHost.has(key)) {
+            byHost.set(key, { host: session.host, sessions: [] });
+          }
+          byHost.get(key).sessions.push(session);
+        });
+
         return (
           <div key={project}>
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12, paddingBottom: 8, borderBottom: `1px solid ${pc}25` }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                marginBottom: 12,
+                paddingBottom: 8,
+                borderBottom: `1px solid ${pc}25`,
+              }}
+            >
               <div style={{ width: 4, height: 16, borderRadius: 2, background: pc }} />
               <span style={{ fontSize: 12, fontWeight: 700, color: pc, letterSpacing: "0.06em" }}>{project}</span>
-              <span style={{ fontSize: 10, color: "#1e2535" }}>{running}/{projectTeams.length} running</span>
-              {totalPRs > 0 && <span style={{ fontSize: 10, color: pc, background: `${pc}18`, borderRadius: 3, padding: "1px 7px" }}>{totalPRs} PR{totalPRs !== 1 ? "s" : ""}</span>}
+              <span style={{ fontSize: 10, color: "#334155" }}>
+                {running}/{projectSessions.length} running
+              </span>
+              {totalPrs > 0 && (
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: pc,
+                    background: `${pc}18`,
+                    borderRadius: 3,
+                    padding: "1px 7px",
+                  }}
+                >
+                  {totalPrs} PR{totalPrs !== 1 ? "s" : ""}
+                </span>
+              )}
             </div>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 8 }}>
-              {projectTeams.map((team, i) => <GridCard key={i} team={team} onJump={onJump} />)}
+
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              {Array.from(byHost.values()).map(({ host, sessions: hostSessions }) => (
+                <div key={host?.id || `unknown-${hostSessions[0]?.host_id || "na"}`}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                    <span style={{ fontSize: 10, color: "#64748b", letterSpacing: "0.08em" }}>
+                      HOST {hostLabel(host).toUpperCase()}
+                    </span>
+                    <span style={{ fontSize: 10, color: host?.reachable ? "#10b981" : "#94a3b8" }}>
+                      {host?.reachable ? "reachable" : `last seen ${relativeTime(host?.last_seen)}`}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+                      gap: 8,
+                    }}
+                  >
+                    {hostSessions.map((session, index) => (
+                      <GridCard key={`${session.name}-${index}`} session={session} onJump={onJump} />
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         );
@@ -226,106 +757,376 @@ function GroupedView({ teams, onJump }) {
 }
 
 export default function Dashboard() {
+  const baseUrl = useMemo(() => daemonBaseUrl(), []);
   const [view, setView] = useState("grouped");
   const [statusFilter, setStatusFilter] = useState("all");
   const [projectFilter, setProjectFilter] = useState("all");
   const [search, setSearch] = useState("");
   const [jumpTarget, setJumpTarget] = useState(null);
+  const [hosts, setHosts] = useState([]);
+  const [sessions, setSessions] = useState([]);
+  const [defaultTerminal, setDefaultTerminal] = useState("iterm2");
+  const [pollIntervalMs, setPollIntervalMs] = useState(DEFAULT_POLL_MS);
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
 
-  const projects = [...new Set(TEAMS.map(t => t.project))];
+  useEffect(() => {
+    let cancelled = false;
 
-  const filtered = TEAMS.filter(t => {
-    if (statusFilter === "running" && t.sessionStatus !== "running") return false;
-    if (statusFilter === "idle" && t.sessionStatus !== "idle") return false;
-    if (statusFilter === "stopped" && t.sessionStatus !== "stopped") return false;
-    if (projectFilter !== "all" && t.project !== projectFilter) return false;
-    if (search && !t.name.includes(search.toLowerCase())) return false;
-    return true;
-  });
+    async function loadConfig() {
+      try {
+        const response = await fetch(`${baseUrl}/dashboard-config.json`);
+        if (!response.ok) {
+          throw new Error(`dashboard-config HTTP ${response.status}`);
+        }
+        const config = await response.json();
+        if (cancelled) {
+          return;
+        }
+        if (Array.isArray(config.hosts)) {
+          setHosts(config.hosts);
+        }
+        if (typeof config.default_terminal === "string" && config.default_terminal.length > 0) {
+          setDefaultTerminal(config.default_terminal);
+        }
+        if (Number.isFinite(config.poll_interval_ms) && config.poll_interval_ms > 0) {
+          setPollIntervalMs(config.poll_interval_ms);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(`Failed to load dashboard config: ${String(error)}`);
+        }
+      }
+    }
 
-  const runningCount = TEAMS.filter(t => t.sessionStatus === "running").length;
-  const idleCount = TEAMS.filter(t => t.sessionStatus === "idle").length;
-  const stoppedCount = TEAMS.filter(t => t.sessionStatus === "stopped").length;
-  const activeAgents = TEAMS.flatMap(t => t.panes).filter(p => p.status === "active").length;
-  const openPRs = TEAMS.reduce((n, t) => n + t.prs.length, 0);
+    loadConfig();
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refresh() {
+      try {
+        const [sessionsResponse, hostsResponse] = await Promise.all([
+          fetch(`${baseUrl}/sessions`),
+          fetch(`${baseUrl}/hosts`),
+        ]);
+        if (!sessionsResponse.ok) {
+          throw new Error(`/sessions HTTP ${sessionsResponse.status}`);
+        }
+        if (!hostsResponse.ok) {
+          throw new Error(`/hosts HTTP ${hostsResponse.status}`);
+        }
+
+        const [sessionsBody, hostsBody] = await Promise.all([
+          sessionsResponse.json(),
+          hostsResponse.json(),
+        ]);
+        if (cancelled) {
+          return;
+        }
+
+        const hostRows = Array.isArray(hostsBody) ? hostsBody : [];
+        const hostMap = new Map(hostRows.map((host) => [host.id, host]));
+
+        const normalizedSessions = (Array.isArray(sessionsBody) ? sessionsBody : []).map((row) => {
+          const ciEntries = normalizeCi(row);
+          const prs = extractPrs(row, ciEntries);
+          return {
+            ...row,
+            status: row.status || "stopped",
+            project: row.project || "unassigned",
+            panes: normalizePanes(row),
+            ciEntries,
+            prs,
+            openPrCount: extractOpenPrCount(row, ciEntries),
+            host: hostMap.get(row.host_id) || null,
+          };
+        });
+
+        setHosts(hostRows);
+        setSessions(normalizedSessions);
+        setErrorMessage(null);
+        setLastUpdated(new Date());
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(`Refresh failed: ${String(error)}`);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    refresh();
+    const timer = window.setInterval(refresh, pollIntervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [baseUrl, pollIntervalMs]);
+
+  const projects = useMemo(
+    () => [...new Set(sessions.map((session) => session.project).filter(Boolean))],
+    [sessions],
+  );
+
+  const filtered = useMemo(() => {
+    const searchText = search.trim().toLowerCase();
+    return sessions.filter((session) => {
+      if (statusFilter !== "all" && session.status !== statusFilter) {
+        return false;
+      }
+      if (projectFilter !== "all" && session.project !== projectFilter) {
+        return false;
+      }
+      if (searchText && !session.name.toLowerCase().includes(searchText)) {
+        return false;
+      }
+      return true;
+    });
+  }, [sessions, statusFilter, projectFilter, search]);
+
+  const runningCount = sessions.filter((session) => session.status === "running").length;
+  const idleCount = sessions.filter((session) => session.status === "idle").length;
+  const stoppedCount = sessions.filter((session) => session.status === "stopped").length;
+  const activeAgents = sessions
+    .flatMap((session) => session.panes)
+    .filter((pane) => pane.status === "active").length;
+  const openPrs = sessions.reduce((sum, session) => sum + session.openPrCount, 0);
 
   return (
-    <div style={{ background: "#060810", minHeight: "100vh", color: "#e2e8f0", fontFamily: "'Berkeley Mono', 'Fira Code', 'JetBrains Mono', monospace" }}>
+    <div
+      style={{
+        background: "#060810",
+        minHeight: "100vh",
+        color: "#e2e8f0",
+        fontFamily: "'Berkeley Mono', 'Fira Code', 'JetBrains Mono', monospace",
+      }}
+    >
       <style>{`
         @keyframes ping { 75%, 100% { transform: scale(2.2); opacity: 0; } }
         * { box-sizing: border-box; margin: 0; padding: 0; }
         input::placeholder { color: #1a2030; }
+        button { font-family: inherit; }
       `}</style>
 
-      {/* Top bar */}
-      <div style={{ borderBottom: "1px solid #0a0e14", padding: "12px 24px", display: "flex", alignItems: "center", gap: 20, position: "sticky", top: 0, background: "#060810", zIndex: 10 }}>
-        <div style={{ fontSize: 11, fontWeight: 800, color: "#475569", letterSpacing: "0.16em" }}>TEAM CONTROL</div>
-        <div style={{ width: 1, height: 14, background: "#131820" }} />
-        <div style={{ display: "flex", gap: 14, fontSize: 11 }}>
-          <span><span style={{ color: "#10b981" }}>{runningCount}</span><span style={{ color: "#1e2535" }}> run</span></span>
-          <span><span style={{ color: "#f59e0b" }}>{idleCount}</span><span style={{ color: "#1e2535" }}> idle</span></span>
-          <span><span style={{ color: "#1e2535" }}>{stoppedCount}</span><span style={{ color: "#131820" }}> off</span></span>
-          <span style={{ color: "#131820" }}>·</span>
-          <span><span style={{ color: "#10b981" }}>{activeAgents}</span><span style={{ color: "#1e2535" }}> agents</span></span>
-          <span style={{ color: "#131820" }}>·</span>
-          <span><span style={{ color: "#3b82f6" }}>{openPRs}</span><span style={{ color: "#1e2535" }}> PRs</span></span>
+      <div
+        style={{
+          borderBottom: "1px solid #0a0e14",
+          padding: "12px 24px",
+          display: "flex",
+          alignItems: "center",
+          gap: 20,
+          position: "sticky",
+          top: 0,
+          background: "#060810",
+          zIndex: 10,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 800, color: "#475569", letterSpacing: "0.16em" }}>
+          TEAM CONTROL
         </div>
-        <div style={{ flex: 1 }} />
-        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="search sessions…"
-          style={{ background: "#0a0e14", border: "1px solid #131820", borderRadius: 5, padding: "5px 10px", fontSize: 11, color: "#94a3b8", outline: "none", width: 150 }} />
-        <div style={{ display: "flex", background: "#0a0e14", borderRadius: 5, border: "1px solid #131820", overflow: "hidden" }}>
-          {[["grid", "⊞ Grid"], ["list", "≡ List"], ["grouped", "❏ Project"]].map(([v, label]) => (
-            <button key={v} onClick={() => setView(v)} style={{
-              padding: "5px 12px", background: view === v ? "#1e2535" : "transparent",
-              border: "none", color: view === v ? "#cbd5e1" : "#334155", cursor: "pointer",
-              fontSize: 10, fontFamily: "inherit", letterSpacing: "0.04em", transition: "background 0.1s"
-            }}>{label}</button>
-          ))}
+        <div style={{ width: 1, height: 14, background: "#131820" }} />
+        <div style={{ display: "flex", gap: 14, fontSize: 11, flexWrap: "wrap" }}>
+          <span>
+            <span style={{ color: "#10b981" }}>{runningCount}</span>
+            <span style={{ color: "#1e2535" }}> run</span>
+          </span>
+          <span>
+            <span style={{ color: "#f59e0b" }}>{idleCount}</span>
+            <span style={{ color: "#1e2535" }}> idle</span>
+          </span>
+          <span>
+            <span style={{ color: "#94a3b8" }}>{stoppedCount}</span>
+            <span style={{ color: "#1e2535" }}> off</span>
+          </span>
+          <span style={{ color: "#131820" }}>.</span>
+          <span>
+            <span style={{ color: "#10b981" }}>{activeAgents}</span>
+            <span style={{ color: "#1e2535" }}> agents</span>
+          </span>
+          <span style={{ color: "#131820" }}>.</span>
+          <span>
+            <span style={{ color: "#3b82f6" }}>{openPrs}</span>
+            <span style={{ color: "#1e2535" }}> PRs</span>
+          </span>
+        </div>
+
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 10, color: "#475569" }}>poll {pollIntervalMs}ms</span>
+          {lastUpdated && (
+            <span style={{ fontSize: 10, color: "#475569" }}>updated {relativeTime(lastUpdated.toISOString())}</span>
+          )}
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="search sessions..."
+            style={{
+              background: "#0a0e14",
+              border: "1px solid #131820",
+              borderRadius: 5,
+              padding: "5px 10px",
+              fontSize: 11,
+              color: "#94a3b8",
+              outline: "none",
+              width: 180,
+            }}
+          />
+          <div
+            style={{
+              display: "flex",
+              background: "#0a0e14",
+              borderRadius: 5,
+              border: "1px solid #131820",
+              overflow: "hidden",
+            }}
+          >
+            {[
+              ["grid", "Grid"],
+              ["list", "List"],
+              ["grouped", "Project"],
+            ].map(([value, label]) => (
+              <button
+                key={value}
+                onClick={() => setView(value)}
+                style={{
+                  padding: "5px 12px",
+                  background: view === value ? "#1e2535" : "transparent",
+                  border: "none",
+                  color: view === value ? "#cbd5e1" : "#334155",
+                  cursor: "pointer",
+                  fontSize: 10,
+                  letterSpacing: "0.04em",
+                  transition: "background 0.1s",
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 
-      {/* Filter bar */}
-      <div style={{ padding: "8px 24px", borderBottom: "1px solid #0a0e14", display: "flex", gap: 5, flexWrap: "wrap", alignItems: "center" }}>
-        {["all", "running", "idle", "stopped"].map(f => (
-          <button key={f} onClick={() => setStatusFilter(f)} style={{
-            padding: "3px 8px", borderRadius: 4, fontSize: 10, cursor: "pointer", fontFamily: "inherit",
-            background: statusFilter === f ? "#131820" : "transparent",
-            border: statusFilter === f ? "1px solid #1e2535" : "1px solid transparent",
-            color: statusFilter === f ? "#94a3b8" : "#1e2535", letterSpacing: "0.04em"
-          }}>{f}</button>
+      <div
+        style={{
+          padding: "8px 24px",
+          borderBottom: "1px solid #0a0e14",
+          display: "flex",
+          gap: 5,
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
+        {["all", "running", "idle", "stopped"].map((filterValue) => (
+          <button
+            key={filterValue}
+            onClick={() => setStatusFilter(filterValue)}
+            style={{
+              padding: "3px 8px",
+              borderRadius: 4,
+              fontSize: 10,
+              cursor: "pointer",
+              background: statusFilter === filterValue ? "#131820" : "transparent",
+              border:
+                statusFilter === filterValue
+                  ? "1px solid #1e2535"
+                  : "1px solid transparent",
+              color: statusFilter === filterValue ? "#94a3b8" : "#1e2535",
+              letterSpacing: "0.04em",
+            }}
+          >
+            {filterValue}
+          </button>
         ))}
         <div style={{ width: 1, height: 12, background: "#131820", margin: "0 4px" }} />
-        <button onClick={() => setProjectFilter("all")} style={{
-          padding: "3px 8px", borderRadius: 4, fontSize: 10, cursor: "pointer", fontFamily: "inherit",
-          background: projectFilter === "all" ? "#131820" : "transparent",
-          border: projectFilter === "all" ? "1px solid #1e2535" : "1px solid transparent",
-          color: projectFilter === "all" ? "#94a3b8" : "#1e2535"
-        }}>all projects</button>
-        {projects.map(p => {
-          const pc = PROJECT_COLORS[p] || "#6b7280";
+        <button
+          onClick={() => setProjectFilter("all")}
+          style={{
+            padding: "3px 8px",
+            borderRadius: 4,
+            fontSize: 10,
+            cursor: "pointer",
+            background: projectFilter === "all" ? "#131820" : "transparent",
+            border:
+              projectFilter === "all"
+                ? "1px solid #1e2535"
+                : "1px solid transparent",
+            color: projectFilter === "all" ? "#94a3b8" : "#1e2535",
+          }}
+        >
+          all projects
+        </button>
+        {projects.map((project) => {
+          const pc = PROJECT_COLORS[project] || "#6b7280";
           return (
-            <button key={p} onClick={() => setProjectFilter(p)} style={{
-              padding: "3px 8px", borderRadius: 4, fontSize: 10, cursor: "pointer", fontFamily: "inherit",
-              background: projectFilter === p ? `${pc}15` : "transparent",
-              border: projectFilter === p ? `1px solid ${pc}40` : "1px solid transparent",
-              color: projectFilter === p ? pc : "#1e2535"
-            }}>{p}</button>
+            <button
+              key={project}
+              onClick={() => setProjectFilter(project)}
+              style={{
+                padding: "3px 8px",
+                borderRadius: 4,
+                fontSize: 10,
+                cursor: "pointer",
+                background: projectFilter === project ? `${pc}15` : "transparent",
+                border:
+                  projectFilter === project
+                    ? `1px solid ${pc}40`
+                    : "1px solid transparent",
+                color: projectFilter === project ? pc : "#1e2535",
+              }}
+            >
+              {project}
+            </button>
           );
         })}
       </div>
 
-      {/* Content */}
-      <div style={{ paddingTop: 20 }}>
-        {view === "grid" && (
-          <div style={{ padding: "0 24px 24px", display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 10 }}>
-            {filtered.map((team, i) => <GridCard key={i} team={team} onJump={setJumpTarget} />)}
-          </div>
-        )}
-        {view === "list" && <ListView teams={filtered} onJump={setJumpTarget} />}
-        {view === "grouped" && <GroupedView teams={filtered} onJump={setJumpTarget} />}
-      </div>
+      {errorMessage && (
+        <div style={{ padding: "10px 24px", color: "#f87171", fontSize: 12 }}>{errorMessage}</div>
+      )}
 
-      <JumpModal team={jumpTarget} onClose={() => setJumpTarget(null)} />
+      {loading ? (
+        <div style={{ padding: "30px 24px", color: "#64748b", fontSize: 12 }}>Loading dashboard data...</div>
+      ) : (
+        <div style={{ paddingTop: 20 }}>
+          {view === "grid" && (
+            <div
+              style={{
+                padding: "0 24px 24px",
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+                gap: 10,
+              }}
+            >
+              {filtered.map((session, index) => (
+                <GridCard key={`${session.name}-${index}`} session={session} onJump={setJumpTarget} />
+              ))}
+            </div>
+          )}
+          {view === "list" && <ListView sessions={filtered} onJump={setJumpTarget} />}
+          {view === "grouped" && <GroupedView sessions={filtered} onJump={setJumpTarget} />}
+        </div>
+      )}
+
+      <JumpModal
+        baseUrl={baseUrl}
+        defaultTerminal={defaultTerminal}
+        session={jumpTarget}
+        onClose={() => setJumpTarget(null)}
+      />
+
+      {hosts.length === 0 && !loading && (
+        <div style={{ padding: "0 24px 24px", color: "#475569", fontSize: 11 }}>
+          No hosts reported by daemon.
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/sprint-specs/p2-s2-dashboard-test-checklist.md
+++ b/docs/sprint-specs/p2-s2-dashboard-test-checklist.md
@@ -1,0 +1,88 @@
+# Sprint 2.2 Dashboard Manual Test Checklist
+
+This checklist maps `T-UI-01..T-UI-17` to explicit manual verification steps.
+
+## T-UI-01 Grid view renders all sessions
+- Precondition: daemon running with at least 3 sessions.
+- Action: open dashboard, click `Grid` view.
+- Expected: one card per session currently returned by `GET /sessions`.
+
+## T-UI-02 List view renders all sessions in table
+- Precondition: daemon running with at least 3 sessions.
+- Action: click `List` view.
+- Expected: table rows match session count from `GET /sessions`.
+
+## T-UI-03 Grouped view groups by project
+- Precondition: sessions exist across at least 2 projects.
+- Action: click `Project` view.
+- Expected: sessions are grouped under project headers with per-project summary counts.
+
+## T-UI-04 Status filters work correctly
+- Precondition: dataset includes `running`, `idle`, and `stopped` sessions.
+- Action: click each status filter (`running`, `idle`, `stopped`).
+- Expected: only sessions with selected status remain visible.
+
+## T-UI-05 Project filter shows only correct sessions
+- Precondition: sessions exist in at least 2 projects.
+- Action: select one project filter chip.
+- Expected: only sessions for that project are shown.
+
+## T-UI-06 Search filters by name substring
+- Precondition: at least one session has a distinct name substring.
+- Action: type substring in search input.
+- Expected: visible sessions are limited to names containing substring (case-insensitive).
+
+## T-UI-07 Clicking session opens jump modal
+- Precondition: at least one session is visible.
+- Action: click any session card/row.
+- Expected: jump modal opens for that session.
+
+## T-UI-08 Modal shows correct pane list
+- Precondition: target session has pane data in `panes` array.
+- Action: open jump modal for target session.
+- Expected: pane names and statuses match current session pane payload.
+
+## T-UI-09 Modal shows correct PR badges with links
+- Precondition: target session has GitHub PR metadata in session CI payload.
+- Action: open jump modal.
+- Expected: PR badges/list show expected PR numbers/titles and links open in new tab.
+
+## T-UI-10 Modal "Open in iTerm2" sends POST /jump and shows feedback
+- Precondition: daemon reachable; target session exists.
+- Action: click `Open in iTerm2 ->` in modal.
+- Expected: `POST /sessions/:name/jump` is sent to daemon, and modal displays daemon `message` response.
+
+## T-UI-11 Stopped sessions are visually de-emphasized
+- Precondition: at least one session status is `stopped`.
+- Action: observe stopped session in any view.
+- Expected: stopped session has reduced visual emphasis (lower opacity).
+
+## T-UI-12 Unreachable host sessions render in monochrome
+- Precondition: at least one host is reported `reachable=false` by `GET /hosts`.
+- Action: observe sessions mapped to that host.
+- Expected: those sessions render with grayscale/monochrome styling.
+
+## T-UI-13 "Last seen N ago" shows for unreachable hosts
+- Precondition: unreachable host has non-null `last_seen`.
+- Action: inspect grouped host header and/or session host status labels.
+- Expected: text shows `last seen <relative time>`.
+
+## T-UI-14 Full color resumes when host returns
+- Precondition: host transitions from unreachable to reachable in `/hosts`.
+- Action: wait for next poll interval or trigger refresh.
+- Expected: sessions for that host return to full color rendering.
+
+## T-UI-15 Tool-unavailable CI badges show install tooltip
+- Precondition: session CI entry has `status="tool_unavailable"` and message.
+- Action: hover tool-unavailable badge.
+- Expected: tooltip displays install/help message from daemon payload.
+
+## T-UI-16 Escape key closes modal
+- Precondition: jump modal is open.
+- Action: press `Escape`.
+- Expected: modal closes.
+
+## T-UI-17 Header counts match data
+- Precondition: sessions include mixed statuses and pane activity.
+- Action: compare header counters with computed values from current sessions payload.
+- Expected: running/idle/stopped/active-agents/open-PR counts are correct.


### PR DESCRIPTION
## Summary
- replace static mock sessions in `dashboard/team-dashboard.jsx` with live polling of daemon APIs
- fetch config from `/dashboard-config.json` with file/null-origin fallback to `http://localhost:7878`
- poll `/sessions` and `/hosts` each interval and cross-reference by `host_id`
- preserve Grid/List/Project views and combinable status/project/search filters
- implement host-aware rendering:
  - unreachable host sessions render monochrome (grayscale + reduced opacity)
  - host headers show `last seen N ago` when unreachable
- wire jump modal to `POST /sessions/:name/jump`, show exact shell command, and show daemon response feedback
- add CI badge rendering behavior for provider payloads and `tool_unavailable` tooltip messaging
- update dashboard docs and add explicit `T-UI-01..T-UI-17` manual checklist

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
