### PR TITLE
Sprint 3.1: CI polling + session CI API summary

### DIFF
--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -8,6 +8,7 @@ use axum::{
 };
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 
@@ -57,6 +58,17 @@ struct SessionSummary {
     auto_start: bool,
     panes: serde_json::Value,
     polled_at: Option<String>,
+    session_ci: Vec<SessionCiSummary>,
+}
+
+#[derive(Serialize, Clone)]
+struct SessionCiSummary {
+    provider: String,
+    status: String,
+    data_json: Option<serde_json::Value>,
+    tool_message: Option<String>,
+    polled_at: Option<String>,
+    next_poll_at: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -168,6 +180,7 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
 async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionSummary>> {
     let sessions = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<SessionSummary>> {
         let db = state.db.lock().unwrap();
+        let ci_by_session = load_ci_by_session(&db)?;
         let mut stmt = db.prepare(
             "SELECT s.id, s.name, s.project, s.host_id, s.cron_schedule, s.auto_start,
                     COALESCE(ss.status, 'stopped') as status,
@@ -181,8 +194,9 @@ async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionSu
 
         let rows = stmt.query_map([], |r| {
             let panes_str: String = r.get(7)?;
+            let id: i64 = r.get(0)?;
             Ok(SessionSummary {
-                id: r.get(0)?,
+                id,
                 name: r.get(1)?,
                 project: r.get(2)?,
                 host_id: r.get(3)?,
@@ -191,6 +205,7 @@ async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionSu
                 status: r.get(6)?,
                 panes: serde_json::from_str(&panes_str).unwrap_or(serde_json::json!([])),
                 polled_at: r.get(8)?,
+                session_ci: ci_by_session.get(&id).cloned().unwrap_or_default(),
             })
         })?;
 
@@ -253,6 +268,8 @@ async fn get_session(
             panes_str,
             polled_at,
         ) = row;
+        let session_ci =
+            load_ci_for_session(&db, id).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
         let mut estmt = db
             .prepare(
@@ -287,6 +304,7 @@ async fn get_session(
                 status,
                 panes: serde_json::from_str(&panes_str).unwrap_or(serde_json::json!([])),
                 polled_at,
+                session_ci,
             },
             config_json: serde_json::from_str(&config_str).unwrap_or(serde_json::json!({})),
             recent_events: events,
@@ -612,6 +630,64 @@ async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
     })
     .await??;
     Ok(hosts)
+}
+
+fn load_ci_by_session(
+    db: &rusqlite::Connection,
+) -> anyhow::Result<HashMap<i64, Vec<SessionCiSummary>>> {
+    let mut stmt = db.prepare(
+        "SELECT session_id, provider, status, data_json, tool_message, polled_at, next_poll_at
+         FROM session_ci
+         ORDER BY session_id, provider",
+    )?;
+    let mut map: HashMap<i64, Vec<SessionCiSummary>> = HashMap::new();
+    let rows = stmt.query_map([], |r| {
+        let data_json: Option<String> = r.get(3)?;
+        Ok((
+            r.get::<_, i64>(0)?,
+            SessionCiSummary {
+                provider: r.get(1)?,
+                status: r.get(2)?,
+                data_json: data_json.and_then(|raw| serde_json::from_str(&raw).ok()),
+                tool_message: r.get(4)?,
+                polled_at: r.get(5)?,
+                next_poll_at: r.get(6)?,
+            },
+        ))
+    })?;
+
+    for row in rows {
+        let (session_id, entry) = row?;
+        map.entry(session_id).or_default().push(entry);
+    }
+    Ok(map)
+}
+
+fn load_ci_for_session(
+    db: &rusqlite::Connection,
+    session_id: i64,
+) -> anyhow::Result<Vec<SessionCiSummary>> {
+    let mut stmt = db.prepare(
+        "SELECT provider, status, data_json, tool_message, polled_at, next_poll_at
+         FROM session_ci
+         WHERE session_id = ?1
+         ORDER BY provider",
+    )?;
+    let rows = stmt
+        .query_map(params![session_id], |r| {
+            let data_json: Option<String> = r.get(2)?;
+            Ok(SessionCiSummary {
+                provider: r.get(0)?,
+                status: r.get(1)?,
+                data_json: data_json.and_then(|raw| serde_json::from_str(&raw).ok()),
+                tool_message: r.get(3)?,
+                polled_at: r.get(4)?,
+                next_poll_at: r.get(5)?,
+            })
+        })?
+        .filter_map(|row| row.ok())
+        .collect::<Vec<_>>();
+    Ok(rows)
 }
 
 async fn log_action_result(

--- a/crates/scmux-daemon/src/ci.rs
+++ b/crates/scmux-daemon/src/ci.rs
@@ -1,0 +1,319 @@
+use crate::{db, AppState};
+use chrono::Utc;
+use serde::Serialize;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::process::Command;
+use tracing::warn;
+
+const GH_INSTALL_HINT: &str = "Install gh CLI: brew install gh";
+const AZ_INSTALL_HINT: &str = "Install az CLI: brew install azure-cli";
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToolAvailability {
+    pub gh_available: bool,
+    pub az_available: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderResult {
+    pub status: String,
+    pub data: Option<serde_json::Value>,
+    pub tool_message: Option<String>,
+}
+
+pub fn detect_tools() -> ToolAvailability {
+    ToolAvailability {
+        gh_available: detect_tool(&gh_bin()),
+        az_available: detect_tool(&az_bin()),
+    }
+}
+
+pub fn next_interval(has_active_pane: bool) -> Duration {
+    if has_active_pane {
+        Duration::from_secs(60)
+    } else {
+        Duration::from_secs(300)
+    }
+}
+
+pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
+    let sessions = {
+        let state = Arc::clone(state);
+        tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<db::CiSession>> {
+            let db_conn = state.db.lock().expect("db lock");
+            db::list_ci_sessions(&db_conn)
+        })
+        .await??
+    };
+
+    for session in sessions {
+        if let Some(repo) = session.github_repo.as_deref() {
+            poll_provider(
+                Arc::clone(state),
+                &session,
+                "github",
+                state.ci_tools.gh_available,
+                GH_INSTALL_HINT,
+                poll_github(repo),
+            )
+            .await;
+        }
+        if let Some(project) = session.azure_project.as_deref() {
+            poll_provider(
+                Arc::clone(state),
+                &session,
+                "azure",
+                state.ci_tools.az_available,
+                AZ_INSTALL_HINT,
+                poll_azure(project),
+            )
+            .await;
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn poll_github(repo: &str) -> ProviderResult {
+    let prs = run_json_command(
+        &gh_bin(),
+        &[
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--json",
+            "number,title,url,author,isDraft",
+        ],
+    )
+    .await;
+    let runs = run_json_command(
+        &gh_bin(),
+        &[
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--json",
+            "status,conclusion,headBranch,createdAt,displayTitle",
+            "--limit",
+            "10",
+        ],
+    )
+    .await;
+
+    match (prs, runs) {
+        (Ok(prs_json), Ok(runs_json)) => ProviderResult {
+            status: "ok".to_string(),
+            data: Some(serde_json::json!({
+                "prs": prs_json,
+                "runs": runs_json,
+            })),
+            tool_message: None,
+        },
+        (Err(err), _) | (_, Err(err)) => classify_cli_error(err),
+    }
+}
+
+pub async fn poll_azure(project: &str) -> ProviderResult {
+    let prs = run_json_command(
+        &az_bin(),
+        &[
+            "repos",
+            "pr",
+            "list",
+            "--project",
+            project,
+            "--status",
+            "active",
+            "--output",
+            "json",
+        ],
+    )
+    .await;
+    let runs = run_json_command(
+        &az_bin(),
+        &[
+            "pipelines",
+            "runs",
+            "list",
+            "--project",
+            project,
+            "--top",
+            "10",
+            "--output",
+            "json",
+        ],
+    )
+    .await;
+
+    match (prs, runs) {
+        (Ok(prs_json), Ok(runs_json)) => ProviderResult {
+            status: "ok".to_string(),
+            data: Some(serde_json::json!({
+                "prs": prs_json,
+                "runs": runs_json,
+            })),
+            tool_message: None,
+        },
+        (Err(err), _) | (_, Err(err)) => classify_cli_error(err),
+    }
+}
+
+async fn poll_provider(
+    state: Arc<AppState>,
+    session: &db::CiSession,
+    provider: &str,
+    tool_available: bool,
+    tool_hint: &str,
+    poll_result: impl std::future::Future<Output = ProviderResult>,
+) {
+    let now = Utc::now();
+    let polled_at = now.to_rfc3339();
+    let next_poll_at = (now
+        + chrono::Duration::from_std(next_interval(session.has_active_pane))
+            .unwrap_or_else(|_| chrono::Duration::minutes(5)))
+    .to_rfc3339();
+
+    let due = {
+        let provider_for_db = provider.to_string();
+        let state = Arc::clone(&state);
+        let session_id = session.id;
+        let now_iso = polled_at.clone();
+        match tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
+            let db_conn = state.db.lock().expect("db lock");
+            db::ci_provider_due(&db_conn, session_id, &provider_for_db, &now_iso)
+        })
+        .await
+        {
+            Ok(Ok(due)) => due,
+            Ok(Err(err)) => {
+                warn!(
+                    "ci provider due-check error session={} provider={provider}: {err}",
+                    session.name
+                );
+                false
+            }
+            Err(err) => {
+                warn!(
+                    "ci provider due-check task failed session={} provider={provider}: {err}",
+                    session.name
+                );
+                false
+            }
+        }
+    };
+
+    if !due {
+        return;
+    }
+
+    let result = if !tool_available {
+        ProviderResult {
+            status: "tool_unavailable".to_string(),
+            data: None,
+            tool_message: Some(tool_hint.to_string()),
+        }
+    } else {
+        poll_result.await
+    };
+
+    let update = db::SessionCiUpdate {
+        session_id: session.id,
+        provider: provider.to_string(),
+        status: result.status,
+        data_json: result
+            .data
+            .and_then(|value| serde_json::to_string(&value).ok()),
+        tool_message: result.tool_message,
+        polled_at,
+        next_poll_at,
+    };
+
+    let state = Arc::clone(&state);
+    match tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let db_conn = state.db.lock().expect("db lock");
+        db::upsert_session_ci(&db_conn, &update)
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            warn!(
+                "ci upsert error session={} provider={provider}: {err}",
+                session.name
+            );
+        }
+        Err(err) => {
+            warn!(
+                "ci upsert task failed session={} provider={provider}: {err}",
+                session.name
+            );
+        }
+    }
+}
+
+async fn run_json_command(bin: &str, args: &[&str]) -> anyhow::Result<serde_json::Value> {
+    let output = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!(if stderr.is_empty() {
+            format!("{bin} command failed with status {}", output.status)
+        } else {
+            stderr
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(serde_json::from_str(stdout.trim())?)
+}
+
+fn detect_tool(bin: &str) -> bool {
+    std::process::Command::new(bin)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn classify_cli_error(err: anyhow::Error) -> ProviderResult {
+    let message = err.to_string();
+    let lower = message.to_lowercase();
+    let status = if lower.contains("rate limit") {
+        "rate_limited"
+    } else if lower.contains("auth")
+        || lower.contains("authentication")
+        || lower.contains("unauthorized")
+        || lower.contains("forbidden")
+        || lower.contains("login")
+    {
+        "auth_error"
+    } else {
+        "error"
+    };
+    ProviderResult {
+        status: status.to_string(),
+        data: None,
+        tool_message: Some(message),
+    }
+}
+
+fn gh_bin() -> String {
+    std::env::var("SCMUX_GH_BIN").unwrap_or_else(|_| "gh".to_string())
+}
+
+fn az_bin() -> String {
+    std::env::var("SCMUX_AZ_BIN").unwrap_or_else(|_| "az".to_string())
+}

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -43,6 +43,26 @@ pub struct RemoteSessionUpsert {
     pub polled_at: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct CiSession {
+    pub id: i64,
+    pub name: String,
+    pub github_repo: Option<String>,
+    pub azure_project: Option<String>,
+    pub has_active_pane: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionCiUpdate {
+    pub session_id: i64,
+    pub provider: String,
+    pub status: String,
+    pub data_json: Option<String>,
+    pub tool_message: Option<String>,
+    pub polled_at: String,
+    pub next_poll_at: String,
+}
+
 pub fn open(path: &str) -> Result<Connection> {
     let conn = Connection::open(path)?;
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
@@ -280,6 +300,74 @@ pub fn upsert_remote_session(
     Ok(())
 }
 
+pub fn list_ci_sessions(conn: &Connection) -> anyhow::Result<Vec<CiSession>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.id, s.name, s.github_repo, s.azure_project, COALESCE(ss.panes_json, '[]')
+         FROM sessions s
+         LEFT JOIN session_status ss ON ss.session_id = s.id
+         WHERE s.enabled = 1
+           AND (s.github_repo IS NOT NULL OR s.azure_project IS NOT NULL)
+         ORDER BY s.id",
+    )?;
+    let rows = stmt
+        .query_map([], |r| {
+            let panes_json: String = r.get(4)?;
+            Ok(CiSession {
+                id: r.get(0)?,
+                name: r.get(1)?,
+                github_repo: r.get(2)?,
+                azure_project: r.get(3)?,
+                has_active_pane: panes_json_has_active(&panes_json),
+            })
+        })?
+        .filter_map(|row| row.ok())
+        .collect::<Vec<_>>();
+    Ok(rows)
+}
+
+pub fn ci_provider_due(
+    conn: &Connection,
+    session_id: i64,
+    provider: &str,
+    now_iso: &str,
+) -> anyhow::Result<bool> {
+    let due = conn
+        .query_row(
+            "SELECT next_poll_at <= ?3
+             FROM session_ci
+             WHERE session_id = ?1 AND provider = ?2",
+            params![session_id, provider, now_iso],
+            |r| r.get::<_, bool>(0),
+        )
+        .optional()?
+        .unwrap_or(true);
+    Ok(due)
+}
+
+pub fn upsert_session_ci(conn: &Connection, update: &SessionCiUpdate) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO session_ci (
+            session_id, provider, status, data_json, tool_message, polled_at, next_poll_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(session_id, provider) DO UPDATE SET
+            status = excluded.status,
+            data_json = excluded.data_json,
+            tool_message = excluded.tool_message,
+            polled_at = excluded.polled_at,
+            next_poll_at = excluded.next_poll_at",
+        params![
+            update.session_id,
+            update.provider,
+            update.status,
+            update.data_json,
+            update.tool_message,
+            update.polled_at,
+            update.next_poll_at
+        ],
+    )?;
+    Ok(())
+}
+
 pub fn log_session_event(
     conn: &Connection,
     session_id: i64,
@@ -442,6 +530,20 @@ fn validate_cron(expr: &str) -> anyhow::Result<()> {
     let normalized = normalize_cron_expr(expr);
     Schedule::from_str(&normalized).map_err(|e| anyhow!("invalid cron_schedule: {e}"))?;
     Ok(())
+}
+
+fn panes_json_has_active(panes_json: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(panes_json) else {
+        return false;
+    };
+    let Some(items) = value.as_array() else {
+        return false;
+    };
+    items.iter().any(|item| {
+        item.get("status")
+            .and_then(|status| status.as_str())
+            .is_some_and(|status| status.eq_ignore_ascii_case("active"))
+    })
 }
 
 fn normalize_cron_expr(expr: &str) -> String {

--- a/crates/scmux-daemon/src/lib.rs
+++ b/crates/scmux-daemon/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod ci;
 pub mod config;
 pub mod db;
 pub mod hosts;
@@ -12,6 +13,7 @@ pub struct AppState {
     pub host_id: i64,
     pub config: config::Config,
     pub reachability: std::sync::Mutex<std::collections::HashMap<i64, hosts::HostReachability>>,
+    pub ci_tools: ci::ToolAvailability,
     pub last_api_access: std::sync::atomic::AtomicU64,
     pub started_at: std::time::Instant,
 }

--- a/crates/scmux-daemon/src/main.rs
+++ b/crates/scmux-daemon/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use scmux_daemon::config::Config;
-use scmux_daemon::{api, db, hosts, logging, scheduler, AppState};
+use scmux_daemon::{api, ci, db, hosts, logging, scheduler, AppState};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
             .collect::<Vec<_>>(),
     )?;
     let host_id = db::ensure_local_host(&conn)?;
+    let ci_tools = ci::detect_tools();
 
     info!("scmux-daemon starting — db={db_path} host_id={host_id}");
 
@@ -94,6 +95,7 @@ async fn main() -> anyhow::Result<()> {
         host_id,
         config,
         reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        ci_tools,
         last_api_access: std::sync::atomic::AtomicU64::new(0),
         started_at: std::time::Instant::now(),
     });
@@ -142,6 +144,18 @@ async fn main() -> anyhow::Result<()> {
             }
             .max(1);
             tokio::time::sleep(tokio::time::Duration::from_secs(sleep_secs)).await;
+        }
+    });
+
+    // CI loop — provider polling with per-session adaptive cadence via next_poll_at
+    let ci_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(15));
+        loop {
+            interval.tick().await;
+            if let Err(e) = ci::poll_once(&ci_state).await {
+                tracing::warn!("ci poll loop error: {e}");
+            }
         }
     });
 

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -1,4 +1,5 @@
 use scmux_daemon::api;
+use scmux_daemon::ci;
 use scmux_daemon::config::{Config, DaemonConfig, PollingConfig};
 use scmux_daemon::db;
 use scmux_daemon::AppState;
@@ -55,6 +56,7 @@ impl ApiHarness {
                 hosts: Vec::new(),
             },
             reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+            ci_tools: ci::ToolAvailability::default(),
             last_api_access: std::sync::atomic::AtomicU64::new(0),
             started_at: std::time::Instant::now(),
         });
@@ -464,6 +466,82 @@ async fn t_a_14_get_hosts_returns_all_hosts_with_reachability_flag() {
     let body: Vec<Value> = response.json().await.expect("json");
     assert!(body.len() >= 2);
     assert!(body.iter().all(|row| row["reachable"].is_boolean()));
+}
+
+#[tokio::test]
+async fn t_a_15_get_sessions_includes_ci_summary_payload() {
+    let h = ApiHarness::new().await;
+    h.create_session("alpha").await;
+    {
+        let db = h.state.db.lock().expect("db lock");
+        let session_id: i64 = db
+            .query_row("SELECT id FROM sessions WHERE name = 'alpha'", [], |r| {
+                r.get(0)
+            })
+            .expect("session id");
+        db.execute(
+            "INSERT INTO session_ci (session_id, provider, status, data_json, tool_message, polled_at, next_poll_at)
+             VALUES (?1, 'github', 'ok', ?2, NULL, datetime('now'), datetime('now', '+1 minute'))",
+            rusqlite::params![
+                session_id,
+                r#"{"prs":[{"number":123,"title":"feat: test"}],"runs":[{"status":"completed"}]}"#
+            ],
+        )
+        .expect("insert session ci");
+    }
+
+    let response = h
+        .client
+        .get(format!("{}/sessions", h.base_url))
+        .send()
+        .await
+        .expect("sessions request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Vec<Value> = response.json().await.expect("json");
+    assert_eq!(body.len(), 1);
+    assert!(body[0]["session_ci"].is_array());
+    assert_eq!(body[0]["session_ci"][0]["provider"], "github");
+    assert_eq!(body[0]["session_ci"][0]["status"], "ok");
+    assert_eq!(
+        body[0]["session_ci"][0]["data_json"]["prs"][0]["number"],
+        123
+    );
+}
+
+#[tokio::test]
+async fn t_a_16_get_session_detail_includes_ci_summary_payload() {
+    let h = ApiHarness::new().await;
+    h.create_session("alpha").await;
+    {
+        let db = h.state.db.lock().expect("db lock");
+        let session_id: i64 = db
+            .query_row("SELECT id FROM sessions WHERE name = 'alpha'", [], |r| {
+                r.get(0)
+            })
+            .expect("session id");
+        db.execute(
+            "INSERT INTO session_ci (session_id, provider, status, data_json, tool_message, polled_at, next_poll_at)
+             VALUES (?1, 'github', 'tool_unavailable', NULL, 'Install gh CLI: brew install gh', datetime('now'), datetime('now', '+5 minute'))",
+            rusqlite::params![session_id],
+        )
+        .expect("insert session ci");
+    }
+
+    let response = h
+        .client
+        .get(format!("{}/sessions/alpha", h.base_url))
+        .send()
+        .await
+        .expect("detail request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("json");
+    assert!(body["session_ci"].is_array());
+    assert_eq!(body["session_ci"][0]["provider"], "github");
+    assert_eq!(body["session_ci"][0]["status"], "tool_unavailable");
+    assert!(body["session_ci"][0]["tool_message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("brew install gh"));
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/ci_tests.rs
+++ b/crates/scmux-daemon/tests/ci_tests.rs
@@ -1,0 +1,308 @@
+use chrono::DateTime;
+use scmux_daemon::ci::{self, ToolAvailability};
+use scmux_daemon::config::{Config, DaemonConfig, PollingConfig};
+use scmux_daemon::{db, AppState};
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> &'static Mutex<()> {
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn test_config() -> Config {
+    Config {
+        daemon: DaemonConfig {
+            port: None,
+            db_path: None,
+            default_terminal: Some("iterm2".to_string()),
+            log_level: None,
+        },
+        polling: PollingConfig {
+            tmux_interval_secs: Some(15),
+            health_interval_secs: Some(60),
+            ci_active_interval_secs: None,
+            ci_idle_interval_secs: None,
+        },
+        hosts: Vec::new(),
+    }
+}
+
+fn build_state(ci_tools: ToolAvailability) -> (Arc<AppState>, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("ci-tests.db");
+    let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
+    let host_id = db::ensure_local_host(&conn).expect("local host");
+    let state = Arc::new(AppState {
+        db: std::sync::Mutex::new(conn),
+        host_id,
+        config: test_config(),
+        reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        ci_tools,
+        last_api_access: std::sync::atomic::AtomicU64::new(0),
+        started_at: std::time::Instant::now(),
+    });
+    (state, tmp)
+}
+
+fn insert_ci_session(
+    state: &Arc<AppState>,
+    name: &str,
+    github_repo: Option<&str>,
+    azure_project: Option<&str>,
+    panes_json: &str,
+) -> i64 {
+    let db_conn = state.db.lock().expect("db lock");
+    let session_id = db::create_session(
+        &db_conn,
+        &db::NewSession {
+            name: name.to_string(),
+            project: Some("ci".to_string()),
+            host_id: state.host_id,
+            config_json: format!(r#"{{"session_name":"{name}"}}"#),
+            cron_schedule: None,
+            auto_start: false,
+            github_repo: github_repo.map(ToString::to_string),
+            azure_project: azure_project.map(ToString::to_string),
+        },
+    )
+    .expect("create session");
+
+    db_conn
+        .execute(
+            "INSERT INTO session_status (session_id, status, panes_json, polled_at)
+             VALUES (?1, 'running', ?2, datetime('now'))
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = excluded.status,
+                panes_json = excluded.panes_json,
+                polled_at = excluded.polled_at",
+            rusqlite::params![session_id, panes_json],
+        )
+        .expect("insert session status");
+
+    session_id
+}
+
+fn ci_row(
+    state: &Arc<AppState>,
+    session_id: i64,
+    provider: &str,
+) -> (String, Option<String>, String, String) {
+    let db_conn = state.db.lock().expect("db lock");
+    db_conn
+        .query_row(
+            "SELECT status, tool_message, polled_at, next_poll_at
+             FROM session_ci
+             WHERE session_id = ?1 AND provider = ?2",
+            rusqlite::params![session_id, provider],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .expect("ci row")
+}
+
+fn write_script(contents: &str) -> tempfile::TempPath {
+    let mut file = tempfile::NamedTempFile::new().expect("temp script");
+    file.write_all(contents.as_bytes()).expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = file.as_file().metadata().expect("metadata").permissions();
+        perms.set_mode(0o755);
+        file.as_file().set_permissions(perms).expect("chmod");
+    }
+    file.into_temp_path()
+}
+
+fn set_env_var(key: &str, value: &str) -> Option<String> {
+    let prev = std::env::var(key).ok();
+    // SAFETY: test-only env mutation guarded by async mutex.
+    unsafe { std::env::set_var(key, value) };
+    prev
+}
+
+fn restore_env_var(key: &str, prev: Option<String>) {
+    match prev {
+        Some(value) => {
+            // SAFETY: test-only env restoration guarded by async mutex.
+            unsafe { std::env::set_var(key, value) };
+        }
+        None => {
+            // SAFETY: test-only env restoration guarded by async mutex.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+}
+
+#[test]
+fn td_10_ci_interval_is_1_minute_when_any_pane_is_active() {
+    assert_eq!(ci::next_interval(true).as_secs(), 60);
+}
+
+#[test]
+fn td_11_ci_interval_is_5_minutes_when_all_panes_are_idle() {
+    assert_eq!(ci::next_interval(false).as_secs(), 300);
+}
+
+#[tokio::test]
+async fn td_12_tool_unavailable_recorded_when_gh_missing() {
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: false,
+        az_available: true,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td12-gh-missing",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"agent","status":"active"}]"#,
+    );
+
+    ci::poll_once(&state).await.expect("poll once");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "github");
+    assert_eq!(status, "tool_unavailable");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.contains("brew install gh")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_13_tool_unavailable_recorded_when_az_missing() {
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: true,
+        az_available: false,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td13-az-missing",
+        None,
+        Some("devops-project"),
+        r#"[{"name":"agent","status":"idle"}]"#,
+    );
+
+    ci::poll_once(&state).await.expect("poll once");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "azure");
+    assert_eq!(status, "tool_unavailable");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.contains("brew install azure-cli")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_17_network_failure_records_error_without_crash() {
+    let _guard = env_lock().lock().await;
+    let script = write_script(
+        r#"#!/bin/sh
+echo "network unreachable" >&2
+exit 1
+"#,
+    );
+    let prev = set_env_var("SCMUX_GH_BIN", script.to_string_lossy().as_ref());
+
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: true,
+        az_available: true,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td17-network-fail",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"agent","status":"active"}]"#,
+    );
+
+    let result = ci::poll_once(&state).await;
+    restore_env_var("SCMUX_GH_BIN", prev);
+    result.expect("poll once should not crash");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "github");
+    assert_eq!(status, "error");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.contains("network unreachable")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_18_auth_or_rate_limit_error_is_handled_gracefully() {
+    let _guard = env_lock().lock().await;
+    let script = write_script(
+        r#"#!/bin/sh
+echo "authentication failed for github.com" >&2
+exit 1
+"#,
+    );
+    let prev = set_env_var("SCMUX_GH_BIN", script.to_string_lossy().as_ref());
+
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: true,
+        az_available: true,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td18-auth-fail",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"agent","status":"idle"}]"#,
+    );
+
+    let result = ci::poll_once(&state).await;
+    restore_env_var("SCMUX_GH_BIN", prev);
+    result.expect("poll once should not crash");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "github");
+    assert_eq!(status, "auth_error");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.to_ascii_lowercase().contains("authentication")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_10_td_11_poll_once_uses_active_and_idle_cadence() {
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: false,
+        az_available: true,
+    });
+    let active_id = insert_ci_session(
+        &state,
+        "td10-active",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"active-pane","status":"active"}]"#,
+    );
+    let idle_id = insert_ci_session(
+        &state,
+        "td11-idle",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"idle-pane","status":"idle"}]"#,
+    );
+
+    ci::poll_once(&state).await.expect("poll once");
+
+    let (_, _, active_polled, active_next) = ci_row(&state, active_id, "github");
+    let active_polled = DateTime::parse_from_rfc3339(&active_polled).expect("active polled");
+    let active_next = DateTime::parse_from_rfc3339(&active_next).expect("active next");
+    let active_delta = active_next
+        .signed_duration_since(active_polled)
+        .num_seconds();
+    assert!((55..=65).contains(&active_delta));
+
+    let (_, _, idle_polled, idle_next) = ci_row(&state, idle_id, "github");
+    let idle_polled = DateTime::parse_from_rfc3339(&idle_polled).expect("idle polled");
+    let idle_next = DateTime::parse_from_rfc3339(&idle_next).expect("idle next");
+    let idle_delta = idle_next.signed_duration_since(idle_polled).num_seconds();
+    assert!((295..=305).contains(&idle_delta));
+}

--- a/crates/scmux-daemon/tests/integration_tests.rs
+++ b/crates/scmux-daemon/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Duration, Timelike, Utc};
 use scmux_daemon::config::{Config, DaemonConfig, PollingConfig};
-use scmux_daemon::{db, hosts, scheduler, AppState};
+use scmux_daemon::{ci, db, hosts, scheduler, AppState};
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -41,6 +41,7 @@ fn build_state() -> (Arc<AppState>, TempDir) {
         host_id,
         config: test_config(),
         reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        ci_tools: ci::ToolAvailability::default(),
         last_api_access: std::sync::atomic::AtomicU64::new(0),
         started_at: std::time::Instant::now(),
     });


### PR DESCRIPTION
## Summary\n- add CI provider polling module () with startup tool detection and per-session adaptive cadence\n- wire CI loop into daemon main state and runtime\n- add DB helpers for listing CI-eligible sessions, due checks, and  upserts\n- extend  and  responses with  summary payload\n- add CI test suite for T-D-10/11/12/13/17/18 and API coverage for CI summary payload\n\n## Validation\n- \n- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test logging::tests::td_16_parse_level_returns_debug ... ok
test logging::tests::td_15_parse_level_returns_warn ... ok
test logging::tests::td_14_ensure_log_dir_creates_parent_directory ... ok
test tmux::tests::td_09_live_sessions_parses_session_names_correctly ... ok
test tmux::tests::td_08_live_sessions_returns_empty_when_tmux_not_running ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 17 tests
test route_not_found_returns_404 ... ok
test t_a_02_get_sessions_returns_empty_array_when_no_sessions ... ok
test t_a_01_get_health_returns_200_with_correct_fields ... ok
test t_a_05_get_sessions_name_returns_404_for_unknown_session ... ok
test t_a_14_get_hosts_returns_all_hosts_with_reachability_flag ... ok
test t_a_11_post_sessions_add_creates_session_in_sqlite ... ok
test t_a_13_delete_sessions_name_disables_session ... ok
test t_a_03_get_sessions_returns_sessions_with_correct_status_and_panes ... ok
test t_a_12_patch_sessions_name_updates_cron_schedule ... ok
test t_a_10_post_sessions_name_jump_returns_ok_false_when_terminal_unavailable ... ok
test t_a_15_get_sessions_includes_ci_summary_payload ... ok
test t_a_04_get_sessions_name_returns_200_with_config_and_events ... ok
test t_a_16_get_session_detail_includes_ci_summary_payload ... ok
test t_a_06_post_sessions_name_start_returns_ok_true_and_logs_event ... ok
test t_a_08_post_sessions_name_stop_returns_ok_true_and_logs_event ... ok
test t_a_07_post_sessions_name_start_returns_ok_false_on_tmuxp_failure ... ok
test t_a_09_post_sessions_name_jump_returns_ok_true_when_iterm2_launched ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s


running 7 tests
test td_10_ci_interval_is_1_minute_when_any_pane_is_active ... ok
test td_11_ci_interval_is_5_minutes_when_all_panes_are_idle ... ok
test td_13_tool_unavailable_recorded_when_az_missing ... ok
test td_12_tool_unavailable_recorded_when_gh_missing ... ok
test td_10_td_11_poll_once_uses_active_and_idle_cadence ... ok
test td_17_network_failure_records_error_without_crash ... ok
test td_18_auth_or_rate_limit_error_is_handled_gracefully ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.25s


running 4 tests
test td_01_open_creates_schema_on_fresh_db ... ok
test td_02_open_is_idempotent_on_existing_db ... ok
test td_04_ensure_local_host_returns_same_id_on_repeated_calls ... ok
test td_03_ensure_local_host_uses_system_hostname ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 13 tests
test t_i_08_write_health_inserts_row ... ok
test t_i_09_write_health_prunes_older_than_seven_days ... ok
test t_i_02_poll_cycle_marks_session_running_when_found_in_tmux ... ok
test t_i_04_auto_start_attempt_logs_event ... ok
test t_i_04_running_to_missing_transition_logs_stopped_event ... ok
test t_i_01_poll_cycle_writes_session_status_rows ... ok
test t_i_05_due_cron_attempt_logs_event ... ok
test t_i_06_invalid_cron_does_not_attempt_start ... ok
test t_i_03_poll_cycle_marks_stopped_for_missing_session ... ok
test t_i_07_single_cycle_does_not_retry_failed_start ... ok
test t_i_11_three_failures_mark_host_unreachable ... ok
test t_i_12_success_after_failures_marks_host_reachable ... ok
test t_i_10_poll_hosts_unreachable_test_net_returns_ok ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.62s


running 3 tests
test td_07_should_run_now_invalid_cron_returns_false ... ok
test td_06_should_run_now_false_when_cron_does_not_fire_in_window ... ok
test td_05_should_run_now_true_when_cron_fires_in_window ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n