### PR TITLE
Sprint 2.2 QA fix: SCMUX-QA-010/011 blocking + non-blocking items

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -35,7 +35,7 @@ scmux-daemon
 2. Open in browser:
 
 ```text
-http://localhost:7700/
+http://localhost:7878/
 ```
 
 ## Local Development

--- a/dashboard/team-dashboard.jsx
+++ b/dashboard/team-dashboard.jsx
@@ -155,6 +155,34 @@ function extractOpenPrCount(session, ciEntries) {
   return Number.isFinite(numeric) ? Number(numeric) : 0;
 }
 
+function extractRuns(ciEntries) {
+  const rows = [];
+
+  ciEntries.forEach((entry) => {
+    if (!entry.payload || !Array.isArray(entry.payload.runs)) {
+      return;
+    }
+    entry.payload.runs.forEach((run, index) => {
+      rows.push({
+        provider: entry.provider,
+        title:
+          run.displayTitle ||
+          run.name ||
+          run.pipeline?.name ||
+          run.definition?.name ||
+          `run-${index + 1}`,
+        status: run.status || run.state || run.result || run.conclusion || "unknown",
+        conclusion: run.conclusion || run.result || null,
+        branch: run.headBranch || run.sourceBranch || run.branch || null,
+        createdAt: run.createdAt || run.creationDate || run.queueTime || run.finishTime || null,
+        url: run.url || run.webUrl || run._links?.web?.href || null,
+      });
+    });
+  });
+
+  return rows;
+}
+
 function relativeTime(iso) {
   if (!iso) {
     return "unknown";
@@ -214,67 +242,143 @@ function hostBadge(host) {
 }
 
 function CiBadges({ session }) {
+  const [showGithubPrs, setShowGithubPrs] = useState(false);
+
   if (!session.ciEntries.length) {
     return null;
   }
 
   return (
-    <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
-      {session.ciEntries.map((entry, index) => {
-        if (entry.status === "tool_unavailable") {
-          return (
-            <span
-              key={`${entry.provider}-${index}`}
-              title={entry.toolMessage || "Install required CLI tool"}
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+        {session.ciEntries.map((entry, index) => {
+          if (entry.status === "tool_unavailable") {
+            const installHint =
+              entry.provider === "github"
+                ? "Install gh CLI: brew install gh"
+                : entry.provider === "azure"
+                  ? "Install az CLI: brew install azure-cli"
+                  : "Install required CLI tool";
+            return (
+              <span
+                key={`${entry.provider}-${index}`}
+                title={entry.toolMessage || installHint}
+                style={{
+                  fontSize: 9,
+                  color: "#94a3b8",
+                  background: "#1e293b",
+                  borderRadius: 3,
+                  padding: "1px 6px",
+                }}
+              >
+                {entry.provider}: unavailable
+              </span>
+            );
+          }
+
+          if (entry.provider === "github") {
+            return (
+              <button
+                key={`${entry.provider}-${index}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setShowGithubPrs((prev) => !prev);
+                }}
+                title={`GitHub Actions: ${session.ciRuns.filter((run) => run.provider === "github").length} runs`}
+                style={{
+                  fontSize: 9,
+                  color: "#60a5fa",
+                  background: "#172554",
+                  borderRadius: 3,
+                  padding: "1px 6px",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                GH PRs: {session.openPrCount}
+              </button>
+            );
+          }
+
+          if (entry.provider === "azure") {
+            return (
+              <span
+                key={`${entry.provider}-${index}`}
+                title={`Azure Pipelines: ${session.ciRuns.filter((run) => run.provider === "azure").length} runs`}
+                style={{
+                  fontSize: 9,
+                  color: "#38bdf8",
+                  background: "#082f49",
+                  borderRadius: 3,
+                  padding: "1px 6px",
+                }}
+              >
+                Azure: {entry.status}
+              </span>
+            );
+          }
+
+          return null;
+        })}
+      </div>
+
+      {showGithubPrs && (
+        <div
+          onClick={(event) => event.stopPropagation()}
+          style={{
+            background: "#0a0e14",
+            border: "1px solid #131820",
+            borderRadius: 4,
+            padding: "6px 8px",
+            minWidth: 180,
+          }}
+        >
+          {session.prs.length === 0 && (
+            <div style={{ fontSize: 10, color: "#64748b" }}>No open PRs.</div>
+          )}
+          {session.prs.map((pr, index) => (
+            <a
+              key={`${pr.url || "pr"}-${index}`}
+              href={pr.url || "#"}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => event.stopPropagation()}
               style={{
-                fontSize: 9,
-                color: "#94a3b8",
-                background: "#1e293b",
-                borderRadius: 3,
-                padding: "1px 6px",
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                textDecoration: "none",
+                padding: "3px 0",
               }}
             >
-              {entry.provider}: unavailable
-            </span>
-          );
-        }
-
-        if (entry.provider === "github") {
-          return (
-            <span
-              key={`${entry.provider}-${index}`}
-              style={{
-                fontSize: 9,
-                color: "#60a5fa",
-                background: "#172554",
-                borderRadius: 3,
-                padding: "1px 6px",
-              }}
-            >
-              GH PRs: {session.openPrCount}
-            </span>
-          );
-        }
-
-        if (entry.provider === "azure") {
-          return (
-            <span
-              key={`${entry.provider}-${index}`}
-              style={{
-                fontSize: 9,
-                color: "#38bdf8",
-                background: "#082f49",
-                borderRadius: 3,
-                padding: "1px 6px",
-              }}
-            >
-              Azure: {entry.status}
-            </span>
-          );
-        }
-
-        return null;
-      })}
+              <span
+                style={{
+                  fontSize: 9,
+                  color: "#60a5fa",
+                  background: "#172554",
+                  borderRadius: 3,
+                  padding: "1px 5px",
+                  flexShrink: 0,
+                }}
+              >
+                #{pr.num || "?"}
+              </span>
+              <span
+                style={{
+                  fontSize: 10,
+                  color: "#94a3b8",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {pr.title || "Untitled PR"}
+              </span>
+            </a>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -309,6 +413,8 @@ function JumpModal({ baseUrl, defaultTerminal, session, onClose }) {
 
   const pc = PROJECT_COLORS[session.project] || "#3b82f6";
   const cmd = buildJumpCommand(session, session.host);
+  const ciEntries = Array.isArray(session.ciEntries) ? session.ciEntries : [];
+  const ciRuns = Array.isArray(session.ciRuns) ? session.ciRuns : [];
 
   const handleJump = async () => {
     setSubmitting(true);
@@ -455,6 +561,71 @@ function JumpModal({ baseUrl, defaultTerminal, session, onClose }) {
                 </span>
                 <span style={{ fontSize: 11, color: "#334155" }}>↗</span>
               </a>
+            ))}
+          </div>
+        )}
+
+        {ciEntries.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.1em", marginBottom: 8 }}>
+              CI RUN STATUS
+            </div>
+            {ciRuns.length === 0 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                {ciEntries.map((entry, index) => (
+                  <div
+                    key={`${entry.provider}-${index}`}
+                    style={{ display: "flex", alignItems: "center", gap: 8, padding: "3px 0" }}
+                  >
+                    <span
+                      style={{
+                        fontSize: 9,
+                        color: entry.provider === "github" ? "#60a5fa" : "#38bdf8",
+                        background: entry.provider === "github" ? "#172554" : "#082f49",
+                        borderRadius: 3,
+                        padding: "1px 5px",
+                        flexShrink: 0,
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      {entry.provider}
+                    </span>
+                    <span style={{ fontSize: 10, color: "#64748b" }}>{entry.status}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {ciRuns.slice(0, 8).map((run, index) => (
+              <div
+                key={`${run.provider}-${run.title}-${index}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "5px 0",
+                  borderBottom: index < Math.min(ciRuns.length, 8) - 1 ? "1px solid #0f172a" : "none",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 9,
+                    color: run.provider === "github" ? "#60a5fa" : "#38bdf8",
+                    background: run.provider === "github" ? "#172554" : "#082f49",
+                    borderRadius: 3,
+                    padding: "1px 5px",
+                    flexShrink: 0,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {run.provider}
+                </span>
+                <span style={{ fontSize: 11, color: "#94a3b8", flex: 1 }}>
+                  {run.title}
+                </span>
+                <span style={{ fontSize: 10, color: "#64748b" }}>
+                  {run.conclusion || run.status}
+                </span>
+              </div>
             ))}
           </div>
         )}
@@ -836,12 +1007,14 @@ export default function Dashboard() {
         const normalizedSessions = (Array.isArray(sessionsBody) ? sessionsBody : []).map((row) => {
           const ciEntries = normalizeCi(row);
           const prs = extractPrs(row, ciEntries);
+          const ciRuns = extractRuns(ciEntries);
           return {
             ...row,
             status: row.status || "stopped",
             project: row.project || "unassigned",
             panes: normalizePanes(row),
             ciEntries,
+            ciRuns,
             prs,
             openPrCount: extractOpenPrCount(row, ciEntries),
             host: hostMap.get(row.host_id) || null,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,38 +25,26 @@ scmux provides:
 ```
 ┌─ Mac Studio ────────────────────────────────────────────┐
 │                                                         │
-│  scmux-daemon  (HTTP :7700)                               │
-│  ├── SQLite  ~/.config/scmux/scmux.db  (SSOT)              │
+│  Browser Dashboard + scmux CLI                          │
+│          │                                              │
+│          └───────────── HTTP :7878 ───────────────┐     │
+│                                                    ▼     │
+│  local scmux-daemon (aggregation + SSOT)                │
+│  ├── SQLite  ~/.config/scmux/scmux.db                   │
 │  ├── poll_loop        every 15s  → tmux ls              │
 │  ├── ci_loop          adaptive   → gh / az cli          │
 │  ├── health_loop      every 60s  → heartbeat            │
-│  └── axum HTTP server            → web + CLI clients    │
-│                                                         │
-│  Clients:                                               │
-│  ├── Browser  →  dashboard (static files from daemon)   │
-│  └── scmux CLI  →  same HTTP API                          │
+│  ├── host_loop        polls remote daemons              │
+│  └── axum HTTP server                                    │
 │                                                         │
 └──────────────────────────┬──────────────────────────────┘
-                           │ HTTP :7700
-┌─ DGX Spark ──────────────┼──────────────────────────────┐
-│  scmux-daemon  (HTTP :7700)│                               │
-│  SQLite  ~/.config/scmux/scmux.db                           │
+                           │ daemon-to-daemon polling
+                           │
+┌─ DGX Spark ──────────────▼──────────────────────────────┐
+│  remote scmux-daemon (HTTP :7878)                       │
+│  SQLite  ~/.config/scmux/scmux.db                       │
 │  ... (same structure)                                   │
-└──────────────────────────┼──────────────────────────────┘
-                           │
-                  ┌────────┴────────┐
-                  │  Browser        │
-                  │  Dashboard      │
-                  │  (polls all     │
-                  │   known hosts)  │
-                  └────────┬────────┘
-                           │ POST /sessions/:name/jump
-                           │
-                  ┌────────▼────────┐
-                  │  scmux-daemon     │
-                  │  spawns iTerm2  │
-                  │  returns status │
-                  └─────────────────┘
+└─────────────────────────────────────────────────────────┘
 ```
 
 ## 4. Components
@@ -214,7 +202,7 @@ Hosts are defined in `scmux.toml` (version-controlled, seeded into SQLite on fir
 
 ```toml
 [daemon]
-port = 7700
+port = 7878
 default_terminal = "iterm2"
 
 [[hosts]]
@@ -226,7 +214,7 @@ is_local = true
 name = "dgx-spark"
 address = "192.168.1.50"
 ssh_user = "randlee"
-api_port = 7700
+api_port = 7878
 ```
 
 #### VPN-gated hosts
@@ -287,7 +275,7 @@ scmux daemon status
 scmux daemon restart
 ```
 
-CLI connects to daemon at `http://localhost:7700` by default. Override with `SCMUX_HOST` env var or `--host` flag for managing remote hosts directly.
+CLI connects to daemon at `http://localhost:7878` by default. Override with `SCMUX_HOST` env var or `--host` flag for managing remote hosts directly.
 
 ### 4.6 Dashboard
 
@@ -299,15 +287,15 @@ The dashboard is configuration-aware via `GET /dashboard-config.json`:
 ```json
 {
   "hosts": [
-    { "name": "mac-studio", "url": "http://localhost:7700",     "is_local": true },
-    { "name": "dgx-spark",  "url": "http://192.168.1.50:7700", "is_local": false }
+    { "name": "mac-studio", "url": "http://localhost:7878",     "is_local": true },
+    { "name": "dgx-spark",  "url": "http://192.168.1.50:7878", "is_local": false }
   ],
   "default_terminal": "iterm2",
   "poll_interval_ms": 15000
 }
 ```
 
-Dashboard polls each host's `/sessions` endpoint independently. Unreachable hosts render in monochrome with last-known data and a "last seen N ago" indicator.
+Dashboard polls the local daemon only. The local daemon polls remote hosts, merges their latest cached session snapshots, and serves unified `/sessions` and `/hosts` responses. Unreachable hosts render in monochrome with last-known data and a "last seen N ago" indicator.
 
 ## 5. SQLite Schema Summary
 
@@ -330,7 +318,7 @@ One database per machine at `~/.config/scmux/scmux.db`. Schema applied via migra
 
 ```toml
 [daemon]
-port = 7700
+port = 7878
 db_path = "~/.config/scmux/scmux.db"
 default_terminal = "iterm2"
 log_level = "info"
@@ -350,7 +338,7 @@ is_local = true
 name     = "dgx-spark"
 address  = "192.168.1.50"
 ssh_user = "randlee"
-api_port = 7700
+api_port = 7878
 ```
 
 ## 7. Process Supervision

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -117,7 +117,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| API-01 | The daemon shall expose HTTP on a configurable port (default 7700) | 1.2 |
+| API-01 | The daemon shall expose HTTP on a configurable port (default 7878) | 1.2 |
 | API-02 | All responses shall be JSON | 1.2 |
 | API-03 | CORS shall be permissive | 1.2 |
 | API-04 | `GET /health` — daemon status, host_id, running count, timestamp | 1.2 |
@@ -192,7 +192,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 |----|-------------|--------|
 | CLI-01 | `scmux` shall be a separate binary from `scmux-daemon` | 3.2 |
 | CLI-02 | `scmux` shall communicate exclusively via the daemon HTTP API | 3.2 |
-| CLI-03 | Default daemon URL: `http://localhost:7700`; override with `SCMUX_HOST` env var or `--host` flag | 3.2 |
+| CLI-03 | Default daemon URL: `http://localhost:7878`; override with `SCMUX_HOST` env var or `--host` flag | 3.2 |
 | CLI-04 | `scmux list` — list sessions with status | 3.2 |
 | CLI-05 | `scmux show <name>` — full session detail | 3.2 |
 | CLI-06 | `scmux start <name>` — start session | 3.2 |


### PR DESCRIPTION
## Summary

Fix pass addressing all QA findings from Sprint 2.2 review.

**Blocking (gate items — required for merge):**
- SCMUX-QA-010: Updated architecture.md §3 system diagram and §4.6 multi-host section — browser now shown polling local daemon only (not individual remote hosts)
- SCMUX-QA-011: DC-02 GitHub CI badge is now clickable, expands inline PR list with title + URL links

**Non-blocking (included in same commit):**
- SCMUX-QA-012: CI badge tooltip is now provider-specific (GitHub Actions vs Azure Pipelines)
- SCMUX-QA-013: Jump modal includes CI status context when available (DJ-05)
- SCMUX-QA-014: Default daemon port canonicalized to 7878 (was 7700 in two places)

## Validation

- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --workspace` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)