### PR TITLE
Release v0.2.0 — Phase 2+3 (multi-host, dashboard, CI, CLI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,16 +1282,19 @@ dependencies = [
 
 [[package]]
 name = "scmux"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
+ "clap",
+ "reqwest",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
 name = "scmux-daemon"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1460,12 +1463,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2146,16 +2149,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2173,31 +2167,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2207,22 +2184,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2231,22 +2196,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2255,22 +2208,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2279,22 +2220,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+
+version = "0.2.0"
 edition = "2021"
 authors = ["scmux contributors"]
 license = "MIT"

--- a/crates/scmux-daemon/Cargo.toml
+++ b/crates/scmux-daemon/Cargo.toml
@@ -28,7 +28,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true
 anyhow.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-reqwest.workspace = true

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -1,12 +1,14 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Request, State},
     http::StatusCode,
-    response::{Html, Json},
+    middleware::{from_fn_with_state, Next},
+    response::{Html, Json, Response},
     routing::{get, post},
     Router,
 };
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 
@@ -15,6 +17,7 @@ use crate::tmux::{self, HostTarget};
 use crate::AppState;
 
 pub fn router(state: Arc<AppState>) -> Router {
+    let middleware_state = Arc::clone(&state);
     Router::new()
         .route("/", get(dashboard_index))
         .route("/health", get(health))
@@ -29,6 +32,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/sessions/:name/stop", post(stop_session))
         .route("/sessions/:name/jump", post(jump_session))
         .layer(CorsLayer::permissive())
+        .layer(from_fn_with_state(middleware_state, touch_last_api_access))
         .with_state(state)
 }
 
@@ -48,11 +52,23 @@ struct SessionSummary {
     id: i64,
     name: String,
     project: Option<String>,
+    host_id: i64,
     status: String,
     cron_schedule: Option<String>,
     auto_start: bool,
     panes: serde_json::Value,
     polled_at: Option<String>,
+    session_ci: Vec<SessionCiSummary>,
+}
+
+#[derive(Serialize, Clone)]
+struct SessionCiSummary {
+    provider: String,
+    status: String,
+    data_json: Option<serde_json::Value>,
+    tool_message: Option<String>,
+    polled_at: Option<String>,
+    next_poll_at: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -130,6 +146,15 @@ async fn dashboard_index() -> Html<&'static str> {
     Html(DASHBOARD_HTML)
 }
 
+async fn touch_last_api_access(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    state.mark_api_access();
+    next.run(request).await
+}
+
 async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
     let host_id = state.host_id;
     let running: i64 = tokio::task::spawn_blocking(move || {
@@ -155,28 +180,32 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
 async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionSummary>> {
     let sessions = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<SessionSummary>> {
         let db = state.db.lock().unwrap();
+        let ci_by_session = load_ci_by_session(&db)?;
         let mut stmt = db.prepare(
-            "SELECT s.id, s.name, s.project, s.cron_schedule, s.auto_start,
+            "SELECT s.id, s.name, s.project, s.host_id, s.cron_schedule, s.auto_start,
                     COALESCE(ss.status, 'stopped') as status,
                     COALESCE(ss.panes_json, '[]') as panes_json,
                     ss.polled_at
                  FROM sessions s
                  LEFT JOIN session_status ss ON ss.session_id = s.id
-                 WHERE s.host_id = ?1 AND s.enabled = 1
-                 ORDER BY s.project, s.name",
+                 WHERE s.enabled = 1
+                 ORDER BY s.host_id, s.project, s.name",
         )?;
 
-        let rows = stmt.query_map(params![state.host_id], |r| {
-            let panes_str: String = r.get(6)?;
+        let rows = stmt.query_map([], |r| {
+            let panes_str: String = r.get(7)?;
+            let id: i64 = r.get(0)?;
             Ok(SessionSummary {
-                id: r.get(0)?,
+                id,
                 name: r.get(1)?,
                 project: r.get(2)?,
-                cron_schedule: r.get(3)?,
-                auto_start: r.get(4)?,
-                status: r.get(5)?,
+                host_id: r.get(3)?,
+                cron_schedule: r.get(4)?,
+                auto_start: r.get(5)?,
+                status: r.get(6)?,
                 panes: serde_json::from_str(&panes_str).unwrap_or(serde_json::json!([])),
-                polled_at: r.get(7)?,
+                polled_at: r.get(8)?,
+                session_ci: ci_by_session.get(&id).cloned().unwrap_or_default(),
             })
         })?;
 
@@ -199,7 +228,7 @@ async fn get_session(
 
         let row = db
             .query_row(
-                "SELECT s.id, s.name, s.project, s.cron_schedule, s.auto_start,
+                "SELECT s.id, s.host_id, s.name, s.project, s.cron_schedule, s.auto_start,
                     s.config_json,
                     COALESCE(ss.status, 'stopped'),
                     COALESCE(ss.panes_json, '[]'),
@@ -209,18 +238,19 @@ async fn get_session(
              WHERE s.name = ?1 AND s.host_id = ?2 AND s.enabled = 1",
                 params![name, state.host_id],
                 |r| {
-                    let panes_str: String = r.get(7)?;
-                    let config_str: String = r.get(5)?;
+                    let panes_str: String = r.get(8)?;
+                    let config_str: String = r.get(6)?;
                     Ok((
                         r.get::<_, i64>(0)?,
-                        r.get::<_, String>(1)?,
-                        r.get::<_, Option<String>>(2)?,
+                        r.get::<_, i64>(1)?,
+                        r.get::<_, String>(2)?,
                         r.get::<_, Option<String>>(3)?,
-                        r.get::<_, bool>(4)?,
+                        r.get::<_, Option<String>>(4)?,
+                        r.get::<_, bool>(5)?,
                         config_str,
-                        r.get::<_, String>(6)?,
+                        r.get::<_, String>(7)?,
                         panes_str,
-                        r.get::<_, Option<String>>(8)?,
+                        r.get::<_, Option<String>>(9)?,
                     ))
                 },
             )
@@ -228,6 +258,7 @@ async fn get_session(
 
         let (
             id,
+            host_id,
             name,
             project,
             cron_schedule,
@@ -237,6 +268,8 @@ async fn get_session(
             panes_str,
             polled_at,
         ) = row;
+        let session_ci =
+            load_ci_for_session(&db, id).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
         let mut estmt = db
             .prepare(
@@ -265,11 +298,13 @@ async fn get_session(
                 id,
                 name,
                 project,
+                host_id,
                 cron_schedule,
                 auto_start,
                 status,
                 panes: serde_json::from_str(&panes_str).unwrap_or(serde_json::json!([])),
                 polled_at,
+                session_ci,
             },
             config_json: serde_json::from_str(&config_str).unwrap_or(serde_json::json!({})),
             recent_events: events,
@@ -551,6 +586,10 @@ async fn get_dashboard_config(
 }
 
 async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
+    let reachability = {
+        let map = state.reachability.lock().expect("reachability lock");
+        map.clone()
+    };
     let hosts = tokio::task::spawn_blocking(move || {
         let db_conn = state.db.lock().unwrap();
         let mut stmt = db_conn.prepare(
@@ -559,19 +598,29 @@ async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
         )?;
         let rows = stmt
             .query_map([], |r| {
+                let id: i64 = r.get(0)?;
                 let is_local: bool = r.get(5)?;
                 let address: String = r.get(2)?;
                 let api_port: u16 = r.get(4)?;
-                let last_seen: Option<String> = r.get(6)?;
+                let db_last_seen: Option<String> = r.get(6)?;
+                let reach = reachability.get(&id);
+                let reachable = if is_local {
+                    true
+                } else {
+                    reach.map(|entry| entry.reachable).unwrap_or(false)
+                };
+                let last_seen = reach
+                    .and_then(|entry| entry.last_seen.clone())
+                    .or(db_last_seen);
                 Ok(HostSummary {
-                    id: r.get(0)?,
+                    id,
                     name: r.get(1)?,
                     address: address.clone(),
                     ssh_user: r.get(3)?,
                     api_port,
                     is_local,
-                    last_seen: last_seen.clone(),
-                    reachable: is_local || last_seen.is_some(),
+                    last_seen,
+                    reachable,
                     url: format!("http://{address}:{api_port}"),
                 })
             })?
@@ -581,6 +630,64 @@ async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
     })
     .await??;
     Ok(hosts)
+}
+
+fn load_ci_by_session(
+    db: &rusqlite::Connection,
+) -> anyhow::Result<HashMap<i64, Vec<SessionCiSummary>>> {
+    let mut stmt = db.prepare(
+        "SELECT session_id, provider, status, data_json, tool_message, polled_at, next_poll_at
+         FROM session_ci
+         ORDER BY session_id, provider",
+    )?;
+    let mut map: HashMap<i64, Vec<SessionCiSummary>> = HashMap::new();
+    let rows = stmt.query_map([], |r| {
+        let data_json: Option<String> = r.get(3)?;
+        Ok((
+            r.get::<_, i64>(0)?,
+            SessionCiSummary {
+                provider: r.get(1)?,
+                status: r.get(2)?,
+                data_json: data_json.and_then(|raw| serde_json::from_str(&raw).ok()),
+                tool_message: r.get(4)?,
+                polled_at: r.get(5)?,
+                next_poll_at: r.get(6)?,
+            },
+        ))
+    })?;
+
+    for row in rows {
+        let (session_id, entry) = row?;
+        map.entry(session_id).or_default().push(entry);
+    }
+    Ok(map)
+}
+
+fn load_ci_for_session(
+    db: &rusqlite::Connection,
+    session_id: i64,
+) -> anyhow::Result<Vec<SessionCiSummary>> {
+    let mut stmt = db.prepare(
+        "SELECT provider, status, data_json, tool_message, polled_at, next_poll_at
+         FROM session_ci
+         WHERE session_id = ?1
+         ORDER BY provider",
+    )?;
+    let rows = stmt
+        .query_map(params![session_id], |r| {
+            let data_json: Option<String> = r.get(2)?;
+            Ok(SessionCiSummary {
+                provider: r.get(0)?,
+                status: r.get(1)?,
+                data_json: data_json.and_then(|raw| serde_json::from_str(&raw).ok()),
+                tool_message: r.get(3)?,
+                polled_at: r.get(4)?,
+                next_poll_at: r.get(5)?,
+            })
+        })?
+        .filter_map(|row| row.ok())
+        .collect::<Vec<_>>();
+    Ok(rows)
 }
 
 async fn log_action_result(

--- a/crates/scmux-daemon/src/ci.rs
+++ b/crates/scmux-daemon/src/ci.rs
@@ -1,0 +1,319 @@
+use crate::{db, AppState};
+use chrono::Utc;
+use serde::Serialize;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::process::Command;
+use tracing::warn;
+
+const GH_INSTALL_HINT: &str = "Install gh CLI: brew install gh";
+const AZ_INSTALL_HINT: &str = "Install az CLI: brew install azure-cli";
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ToolAvailability {
+    pub gh_available: bool,
+    pub az_available: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderResult {
+    pub status: String,
+    pub data: Option<serde_json::Value>,
+    pub tool_message: Option<String>,
+}
+
+pub fn detect_tools() -> ToolAvailability {
+    ToolAvailability {
+        gh_available: detect_tool(&gh_bin()),
+        az_available: detect_tool(&az_bin()),
+    }
+}
+
+pub fn next_interval(has_active_pane: bool) -> Duration {
+    if has_active_pane {
+        Duration::from_secs(60)
+    } else {
+        Duration::from_secs(300)
+    }
+}
+
+pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
+    let sessions = {
+        let state = Arc::clone(state);
+        tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<db::CiSession>> {
+            let db_conn = state.db.lock().expect("db lock");
+            db::list_ci_sessions(&db_conn)
+        })
+        .await??
+    };
+
+    for session in sessions {
+        if let Some(repo) = session.github_repo.as_deref() {
+            poll_provider(
+                Arc::clone(state),
+                &session,
+                "github",
+                state.ci_tools.gh_available,
+                GH_INSTALL_HINT,
+                poll_github(repo),
+            )
+            .await;
+        }
+        if let Some(project) = session.azure_project.as_deref() {
+            poll_provider(
+                Arc::clone(state),
+                &session,
+                "azure",
+                state.ci_tools.az_available,
+                AZ_INSTALL_HINT,
+                poll_azure(project),
+            )
+            .await;
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn poll_github(repo: &str) -> ProviderResult {
+    let prs = run_json_command(
+        &gh_bin(),
+        &[
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--json",
+            "number,title,url,author,isDraft",
+        ],
+    )
+    .await;
+    let runs = run_json_command(
+        &gh_bin(),
+        &[
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--json",
+            "status,conclusion,headBranch,createdAt,displayTitle",
+            "--limit",
+            "10",
+        ],
+    )
+    .await;
+
+    match (prs, runs) {
+        (Ok(prs_json), Ok(runs_json)) => ProviderResult {
+            status: "ok".to_string(),
+            data: Some(serde_json::json!({
+                "prs": prs_json,
+                "runs": runs_json,
+            })),
+            tool_message: None,
+        },
+        (Err(err), _) | (_, Err(err)) => classify_cli_error(err),
+    }
+}
+
+pub async fn poll_azure(project: &str) -> ProviderResult {
+    let prs = run_json_command(
+        &az_bin(),
+        &[
+            "repos",
+            "pr",
+            "list",
+            "--project",
+            project,
+            "--status",
+            "active",
+            "--output",
+            "json",
+        ],
+    )
+    .await;
+    let runs = run_json_command(
+        &az_bin(),
+        &[
+            "pipelines",
+            "runs",
+            "list",
+            "--project",
+            project,
+            "--top",
+            "10",
+            "--output",
+            "json",
+        ],
+    )
+    .await;
+
+    match (prs, runs) {
+        (Ok(prs_json), Ok(runs_json)) => ProviderResult {
+            status: "ok".to_string(),
+            data: Some(serde_json::json!({
+                "prs": prs_json,
+                "runs": runs_json,
+            })),
+            tool_message: None,
+        },
+        (Err(err), _) | (_, Err(err)) => classify_cli_error(err),
+    }
+}
+
+async fn poll_provider(
+    state: Arc<AppState>,
+    session: &db::CiSession,
+    provider: &str,
+    tool_available: bool,
+    tool_hint: &str,
+    poll_result: impl std::future::Future<Output = ProviderResult>,
+) {
+    let now = Utc::now();
+    let polled_at = now.to_rfc3339();
+    let next_poll_at = (now
+        + chrono::Duration::from_std(next_interval(session.has_active_pane))
+            .unwrap_or_else(|_| chrono::Duration::minutes(5)))
+    .to_rfc3339();
+
+    let due = {
+        let provider_for_db = provider.to_string();
+        let state = Arc::clone(&state);
+        let session_id = session.id;
+        let now_iso = polled_at.clone();
+        match tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
+            let db_conn = state.db.lock().expect("db lock");
+            db::ci_provider_due(&db_conn, session_id, &provider_for_db, &now_iso)
+        })
+        .await
+        {
+            Ok(Ok(due)) => due,
+            Ok(Err(err)) => {
+                warn!(
+                    "ci provider due-check error session={} provider={provider}: {err}",
+                    session.name
+                );
+                false
+            }
+            Err(err) => {
+                warn!(
+                    "ci provider due-check task failed session={} provider={provider}: {err}",
+                    session.name
+                );
+                false
+            }
+        }
+    };
+
+    if !due {
+        return;
+    }
+
+    let result = if !tool_available {
+        ProviderResult {
+            status: "tool_unavailable".to_string(),
+            data: None,
+            tool_message: Some(tool_hint.to_string()),
+        }
+    } else {
+        poll_result.await
+    };
+
+    let update = db::SessionCiUpdate {
+        session_id: session.id,
+        provider: provider.to_string(),
+        status: result.status,
+        data_json: result
+            .data
+            .and_then(|value| serde_json::to_string(&value).ok()),
+        tool_message: result.tool_message,
+        polled_at,
+        next_poll_at,
+    };
+
+    let state = Arc::clone(&state);
+    match tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let db_conn = state.db.lock().expect("db lock");
+        db::upsert_session_ci(&db_conn, &update)
+    })
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            warn!(
+                "ci upsert error session={} provider={provider}: {err}",
+                session.name
+            );
+        }
+        Err(err) => {
+            warn!(
+                "ci upsert task failed session={} provider={provider}: {err}",
+                session.name
+            );
+        }
+    }
+}
+
+async fn run_json_command(bin: &str, args: &[&str]) -> anyhow::Result<serde_json::Value> {
+    let output = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!(if stderr.is_empty() {
+            format!("{bin} command failed with status {}", output.status)
+        } else {
+            stderr
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(serde_json::from_str(stdout.trim())?)
+}
+
+fn detect_tool(bin: &str) -> bool {
+    std::process::Command::new(bin)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn classify_cli_error(err: anyhow::Error) -> ProviderResult {
+    let message = err.to_string();
+    let lower = message.to_lowercase();
+    let status = if lower.contains("rate limit") {
+        "rate_limited"
+    } else if lower.contains("auth")
+        || lower.contains("authentication")
+        || lower.contains("unauthorized")
+        || lower.contains("forbidden")
+        || lower.contains("login")
+    {
+        "auth_error"
+    } else {
+        "error"
+    };
+    ProviderResult {
+        status: status.to_string(),
+        data: None,
+        tool_message: Some(message),
+    }
+}
+
+fn gh_bin() -> String {
+    std::env::var("SCMUX_GH_BIN").unwrap_or_else(|_| "gh".to_string())
+}
+
+fn az_bin() -> String {
+    std::env::var("SCMUX_AZ_BIN").unwrap_or_else(|_| "az".to_string())
+}

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -32,6 +32,37 @@ pub struct SessionPatch {
     pub azure_project: Option<Option<String>>,
 }
 
+#[derive(Debug, Clone)]
+pub struct RemoteSessionUpsert {
+    pub name: String,
+    pub project: Option<String>,
+    pub cron_schedule: Option<String>,
+    pub auto_start: bool,
+    pub status: String,
+    pub panes_json: String,
+    pub polled_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CiSession {
+    pub id: i64,
+    pub name: String,
+    pub github_repo: Option<String>,
+    pub azure_project: Option<String>,
+    pub has_active_pane: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionCiUpdate {
+    pub session_id: i64,
+    pub provider: String,
+    pub status: String,
+    pub data_json: Option<String>,
+    pub tool_message: Option<String>,
+    pub polled_at: String,
+    pub next_poll_at: String,
+}
+
 pub fn open(path: &str) -> Result<Connection> {
     let conn = Connection::open(path)?;
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
@@ -70,6 +101,18 @@ pub fn seed_hosts_from_config(conn: &Connection, hosts: &[HostConfig]) -> anyhow
             ],
         )?;
     }
+    Ok(())
+}
+
+pub fn update_host_last_seen(
+    conn: &Connection,
+    host_id: i64,
+    last_seen: &str,
+) -> anyhow::Result<()> {
+    conn.execute(
+        "UPDATE hosts SET last_seen = ?1 WHERE id = ?2",
+        params![last_seen, host_id],
+    )?;
     Ok(())
 }
 
@@ -203,6 +246,128 @@ pub fn session_id(conn: &Connection, host_id: i64, name: &str) -> anyhow::Result
     Ok(value)
 }
 
+pub fn upsert_remote_session(
+    conn: &Connection,
+    host_id: i64,
+    session: &RemoteSessionUpsert,
+) -> anyhow::Result<()> {
+    let config_json = serde_json::json!({ "session_name": session.name }).to_string();
+    conn.execute(
+        "INSERT INTO sessions (
+            name, project, host_id, config_json, cron_schedule, auto_start, enabled
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)
+         ON CONFLICT(name, host_id) DO UPDATE SET
+            project = excluded.project,
+            cron_schedule = excluded.cron_schedule,
+            auto_start = excluded.auto_start,
+            enabled = 1",
+        params![
+            session.name,
+            session.project,
+            host_id,
+            config_json,
+            session.cron_schedule,
+            session.auto_start
+        ],
+    )?;
+
+    let session_id: i64 = conn.query_row(
+        "SELECT id FROM sessions WHERE name = ?1 AND host_id = ?2",
+        params![session.name, host_id],
+        |r| r.get(0),
+    )?;
+
+    conn.execute(
+        "INSERT INTO session_status (session_id, status, panes_json, polled_at)
+         VALUES (
+            ?1,
+            ?2,
+            ?3,
+            COALESCE(?4, datetime('now'))
+         )
+         ON CONFLICT(session_id) DO UPDATE SET
+            status = excluded.status,
+            panes_json = excluded.panes_json,
+            polled_at = excluded.polled_at",
+        params![
+            session_id,
+            session.status,
+            session.panes_json,
+            session.polled_at
+        ],
+    )?;
+
+    Ok(())
+}
+
+pub fn list_ci_sessions(conn: &Connection) -> anyhow::Result<Vec<CiSession>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.id, s.name, s.github_repo, s.azure_project, COALESCE(ss.panes_json, '[]')
+         FROM sessions s
+         LEFT JOIN session_status ss ON ss.session_id = s.id
+         WHERE s.enabled = 1
+           AND (s.github_repo IS NOT NULL OR s.azure_project IS NOT NULL)
+         ORDER BY s.id",
+    )?;
+    let rows = stmt
+        .query_map([], |r| {
+            let panes_json: String = r.get(4)?;
+            Ok(CiSession {
+                id: r.get(0)?,
+                name: r.get(1)?,
+                github_repo: r.get(2)?,
+                azure_project: r.get(3)?,
+                has_active_pane: panes_json_has_active(&panes_json),
+            })
+        })?
+        .filter_map(|row| row.ok())
+        .collect::<Vec<_>>();
+    Ok(rows)
+}
+
+pub fn ci_provider_due(
+    conn: &Connection,
+    session_id: i64,
+    provider: &str,
+    now_iso: &str,
+) -> anyhow::Result<bool> {
+    let due = conn
+        .query_row(
+            "SELECT next_poll_at <= ?3
+             FROM session_ci
+             WHERE session_id = ?1 AND provider = ?2",
+            params![session_id, provider, now_iso],
+            |r| r.get::<_, bool>(0),
+        )
+        .optional()?
+        .unwrap_or(true);
+    Ok(due)
+}
+
+pub fn upsert_session_ci(conn: &Connection, update: &SessionCiUpdate) -> anyhow::Result<()> {
+    conn.execute(
+        "INSERT INTO session_ci (
+            session_id, provider, status, data_json, tool_message, polled_at, next_poll_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(session_id, provider) DO UPDATE SET
+            status = excluded.status,
+            data_json = excluded.data_json,
+            tool_message = excluded.tool_message,
+            polled_at = excluded.polled_at,
+            next_poll_at = excluded.next_poll_at",
+        params![
+            update.session_id,
+            update.provider,
+            update.status,
+            update.data_json,
+            update.tool_message,
+            update.polled_at,
+            update.next_poll_at
+        ],
+    )?;
+    Ok(())
+}
+
 pub fn log_session_event(
     conn: &Connection,
     session_id: i64,
@@ -260,7 +425,7 @@ fn migrate(conn: &Connection) -> Result<()> {
             api_port   INTEGER NOT NULL DEFAULT 7700,
             is_local   BOOLEAN NOT NULL DEFAULT 0,
             created_at DATETIME NOT NULL DEFAULT (datetime('now')),
-            last_seen  DATETIME
+            last_seen  TEXT
         );
 
         CREATE TABLE IF NOT EXISTS sessions (
@@ -330,7 +495,22 @@ fn migrate(conn: &Connection) -> Result<()> {
           BEGIN
             UPDATE sessions SET updated_at = datetime('now') WHERE id = OLD.id;
           END;
-    "#)
+    "#)?;
+    ensure_hosts_last_seen_column(conn)?;
+    Ok(())
+}
+
+fn ensure_hosts_last_seen_column(conn: &Connection) -> Result<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(hosts)")?;
+    let has_last_seen = stmt
+        .query_map([], |r| r.get::<_, String>(1))?
+        .filter_map(Result::ok)
+        .any(|name| name == "last_seen");
+
+    if !has_last_seen {
+        conn.execute("ALTER TABLE hosts ADD COLUMN last_seen TEXT", [])?;
+    }
+    Ok(())
 }
 
 fn validate_config_session_name(name: &str, config_json: &str) -> anyhow::Result<()> {
@@ -350,6 +530,20 @@ fn validate_cron(expr: &str) -> anyhow::Result<()> {
     let normalized = normalize_cron_expr(expr);
     Schedule::from_str(&normalized).map_err(|e| anyhow!("invalid cron_schedule: {e}"))?;
     Ok(())
+}
+
+fn panes_json_has_active(panes_json: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(panes_json) else {
+        return false;
+    };
+    let Some(items) = value.as_array() else {
+        return false;
+    };
+    items.iter().any(|item| {
+        item.get("status")
+            .and_then(|status| status.as_str())
+            .is_some_and(|status| status.eq_ignore_ascii_case("active"))
+    })
 }
 
 fn normalize_cron_expr(expr: &str) -> String {

--- a/crates/scmux-daemon/src/hosts.rs
+++ b/crates/scmux-daemon/src/hosts.rs
@@ -1,0 +1,244 @@
+use crate::{db, AppState};
+use anyhow::Context;
+use chrono::Utc;
+use serde::Deserialize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::process::Command;
+use tracing::{debug, warn};
+
+const ACTIVE_API_WINDOW_MS: u64 = 60_000;
+const REMOTE_FETCH_TIMEOUT_SECS: u64 = 5;
+
+#[derive(Debug, Clone, Default)]
+pub struct HostReachability {
+    pub host_id: i64,
+    pub reachable: bool,
+    pub last_seen: Option<String>,
+    pub consecutive_failures: u32,
+}
+
+#[derive(Debug, Clone)]
+struct HostRow {
+    id: i64,
+    name: String,
+    address: String,
+    api_port: u16,
+    is_local: bool,
+    last_seen: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteSessionResponse {
+    name: String,
+    project: Option<String>,
+    #[serde(default)]
+    cron_schedule: Option<String>,
+    #[serde(default)]
+    auto_start: bool,
+    #[serde(default = "default_status")]
+    status: String,
+    #[serde(default = "default_panes")]
+    panes: serde_json::Value,
+    #[serde(default)]
+    polled_at: Option<String>,
+}
+
+fn default_status() -> String {
+    "stopped".to_string()
+}
+
+fn default_panes() -> serde_json::Value {
+    serde_json::json!([])
+}
+
+pub async fn probe_host(address: &str) -> bool {
+    let mut command = Command::new(ping_bin());
+    if cfg!(target_os = "macos") {
+        command.args(["-c", "1", "-t", "10", address]);
+    } else {
+        command.args(["-c", "1", "-W", "10", address]);
+    }
+    command
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+pub async fn fetch_remote_sessions(
+    address: &str,
+    port: u16,
+) -> anyhow::Result<Vec<db::RemoteSessionUpsert>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(REMOTE_FETCH_TIMEOUT_SECS))
+        .build()
+        .context("build reqwest client")?;
+    let url = format!("http://{address}:{port}/sessions");
+    let rows = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("non-success status from {url}"))?
+        .json::<Vec<RemoteSessionResponse>>()
+        .await
+        .with_context(|| format!("decode JSON from {url}"))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| db::RemoteSessionUpsert {
+            name: row.name,
+            project: row.project,
+            cron_schedule: row.cron_schedule,
+            auto_start: row.auto_start,
+            status: row.status,
+            panes_json: serde_json::to_string(&row.panes).unwrap_or_else(|_| "[]".to_string()),
+            polled_at: row.polled_at,
+        })
+        .collect())
+}
+
+pub fn apply_probe_result(mut previous: HostReachability, probe_ok: bool) -> HostReachability {
+    if probe_ok {
+        previous.reachable = true;
+        previous.consecutive_failures = 0;
+        previous.last_seen = Some(Utc::now().to_rfc3339());
+        return previous;
+    }
+
+    previous.consecutive_failures = previous.consecutive_failures.saturating_add(1);
+    if previous.reachable && previous.consecutive_failures >= 3 {
+        previous.reachable = false;
+    }
+    previous
+}
+
+pub async fn poll_hosts(state: Arc<AppState>) -> anyhow::Result<()> {
+    let hosts = load_hosts(Arc::clone(&state)).await?;
+    let mut next = {
+        let map = state.reachability.lock().expect("reachability lock");
+        map.clone()
+    };
+
+    for host in hosts {
+        let previous = next.get(&host.id).cloned().unwrap_or(HostReachability {
+            host_id: host.id,
+            reachable: host.is_local,
+            last_seen: host.last_seen.clone(),
+            consecutive_failures: 0,
+        });
+
+        let updated = if host.is_local {
+            HostReachability {
+                host_id: host.id,
+                reachable: true,
+                last_seen: previous.last_seen,
+                consecutive_failures: 0,
+            }
+        } else {
+            let probe_ok = probe_host(&host.address).await;
+            let updated = apply_probe_result(previous, probe_ok);
+
+            if probe_ok {
+                if let Some(last_seen) = updated.last_seen.clone() {
+                    let state2 = Arc::clone(&state);
+                    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+                        let db_conn = state2.db.lock().expect("db lock");
+                        db::update_host_last_seen(&db_conn, host.id, &last_seen)?;
+                        Ok(())
+                    })
+                    .await??;
+                }
+
+                match fetch_remote_sessions(&host.address, host.api_port).await {
+                    Ok(remote_sessions) => {
+                        let state2 = Arc::clone(&state);
+                        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+                            let db_conn = state2.db.lock().expect("db lock");
+                            for session in &remote_sessions {
+                                db::upsert_remote_session(&db_conn, host.id, session)?;
+                            }
+                            Ok(())
+                        })
+                        .await??;
+                    }
+                    Err(err) => {
+                        warn!(
+                            "remote session fetch failed host={} address={}: {}",
+                            host.name, host.address, err
+                        );
+                    }
+                }
+            }
+            updated
+        };
+
+        debug!(
+            "host poll id={} name={} reachable={} failures={}",
+            updated.host_id, host.name, updated.reachable, updated.consecutive_failures
+        );
+        next.insert(host.id, updated);
+    }
+
+    let mut map = state.reachability.lock().expect("reachability lock");
+    *map = next;
+    Ok(())
+}
+
+pub async fn should_use_active_interval(state: &Arc<AppState>) -> anyhow::Result<bool> {
+    let now_ms = state.monotonic_millis();
+    let last_access = state
+        .last_api_access
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let api_recent = last_access > 0 && now_ms.saturating_sub(last_access) <= ACTIVE_API_WINDOW_MS;
+    if !api_recent {
+        return Ok(false);
+    }
+
+    let state2 = Arc::clone(state);
+    let running: i64 = tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
+        let db_conn = state2.db.lock().expect("db lock");
+        let value = db_conn.query_row(
+            "SELECT COUNT(*) FROM session_status WHERE status = 'running'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(value)
+    })
+    .await??;
+    Ok(running > 0)
+}
+
+async fn load_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostRow>> {
+    tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<HostRow>> {
+        let db_conn = state.db.lock().expect("db lock");
+        let mut stmt = db_conn.prepare(
+            "SELECT id, name, address, api_port, is_local, last_seen
+             FROM hosts
+             ORDER BY is_local DESC, name",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(HostRow {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    address: r.get(2)?,
+                    api_port: r.get(3)?,
+                    is_local: r.get(4)?,
+                    last_seen: r.get(5)?,
+                })
+            })?
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>();
+        Ok(rows)
+    })
+    .await?
+}
+
+fn ping_bin() -> String {
+    std::env::var("SCMUX_PING_BIN").unwrap_or_else(|_| "ping".to_string())
+}

--- a/crates/scmux-daemon/src/lib.rs
+++ b/crates/scmux-daemon/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod api;
+pub mod ci;
 pub mod config;
 pub mod db;
+pub mod hosts;
 pub mod logging;
 pub mod scheduler;
 pub mod tmux;
@@ -10,4 +12,21 @@ pub struct AppState {
     pub db: std::sync::Mutex<rusqlite::Connection>,
     pub host_id: i64,
     pub config: config::Config,
+    pub reachability: std::sync::Mutex<std::collections::HashMap<i64, hosts::HostReachability>>,
+    pub ci_tools: ci::ToolAvailability,
+    pub last_api_access: std::sync::atomic::AtomicU64,
+    pub started_at: std::time::Instant,
+}
+
+impl AppState {
+    pub fn monotonic_millis(&self) -> u64 {
+        self.started_at.elapsed().as_millis() as u64
+    }
+
+    pub fn mark_api_access(&self) {
+        self.last_api_access.store(
+            self.monotonic_millis(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
 }

--- a/crates/scmux-daemon/src/main.rs
+++ b/crates/scmux-daemon/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use scmux_daemon::config::Config;
-use scmux_daemon::{api, db, logging, scheduler, AppState};
+use scmux_daemon::{api, ci, db, hosts, logging, scheduler, AppState};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
@@ -68,6 +68,7 @@ async fn main() -> anyhow::Result<()> {
             .collect::<Vec<_>>(),
     )?;
     let host_id = db::ensure_local_host(&conn)?;
+    let ci_tools = ci::detect_tools();
 
     info!("scmux-daemon starting — db={db_path} host_id={host_id}");
 
@@ -93,6 +94,10 @@ async fn main() -> anyhow::Result<()> {
         db: std::sync::Mutex::new(conn),
         host_id,
         config,
+        reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        ci_tools,
+        last_api_access: std::sync::atomic::AtomicU64::new(0),
+        started_at: std::time::Instant::now(),
     });
 
     // Poll loop — every 15 seconds
@@ -117,6 +122,39 @@ async fn main() -> anyhow::Result<()> {
             interval.tick().await;
             if let Err(e) = db::write_health(&health_state).await {
                 tracing::error!("health write error: {e}");
+            }
+        }
+    });
+
+    // Host reachability loop — adaptive interval based on API activity and live sessions
+    let host_poll_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = hosts::poll_hosts(Arc::clone(&host_poll_state)).await {
+                tracing::warn!("host poll error: {e}");
+            }
+
+            let active = hosts::should_use_active_interval(&host_poll_state)
+                .await
+                .unwrap_or(false);
+            let sleep_secs = if active {
+                health_interval_secs
+            } else {
+                health_interval_secs.saturating_mul(10)
+            }
+            .max(1);
+            tokio::time::sleep(tokio::time::Duration::from_secs(sleep_secs)).await;
+        }
+    });
+
+    // CI loop — provider polling with per-session adaptive cadence via next_poll_at
+    let ci_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(15));
+        loop {
+            interval.tick().await;
+            if let Err(e) = ci::poll_once(&ci_state).await {
+                tracing::warn!("ci poll loop error: {e}");
             }
         }
     });

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -1,4 +1,5 @@
 use scmux_daemon::api;
+use scmux_daemon::ci;
 use scmux_daemon::config::{Config, DaemonConfig, PollingConfig};
 use scmux_daemon::db;
 use scmux_daemon::AppState;
@@ -54,6 +55,10 @@ impl ApiHarness {
                 },
                 hosts: Vec::new(),
             },
+            reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+            ci_tools: ci::ToolAvailability::default(),
+            last_api_access: std::sync::atomic::AtomicU64::new(0),
+            started_at: std::time::Instant::now(),
         });
 
         let router = api::router(Arc::clone(&state));
@@ -213,6 +218,7 @@ async fn t_a_03_get_sessions_returns_sessions_with_correct_status_and_panes() {
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Vec<Value> = response.json().await.expect("json");
     assert_eq!(body.len(), 1);
+    assert!(body[0]["host_id"].as_i64().is_some());
     assert_eq!(body[0]["status"], "running");
     assert!(body[0]["panes"].is_array());
     assert!(!body[0]["panes"].as_array().expect("panes").is_empty());
@@ -460,6 +466,82 @@ async fn t_a_14_get_hosts_returns_all_hosts_with_reachability_flag() {
     let body: Vec<Value> = response.json().await.expect("json");
     assert!(body.len() >= 2);
     assert!(body.iter().all(|row| row["reachable"].is_boolean()));
+}
+
+#[tokio::test]
+async fn t_a_15_get_sessions_includes_ci_summary_payload() {
+    let h = ApiHarness::new().await;
+    h.create_session("alpha").await;
+    {
+        let db = h.state.db.lock().expect("db lock");
+        let session_id: i64 = db
+            .query_row("SELECT id FROM sessions WHERE name = 'alpha'", [], |r| {
+                r.get(0)
+            })
+            .expect("session id");
+        db.execute(
+            "INSERT INTO session_ci (session_id, provider, status, data_json, tool_message, polled_at, next_poll_at)
+             VALUES (?1, 'github', 'ok', ?2, NULL, datetime('now'), datetime('now', '+1 minute'))",
+            rusqlite::params![
+                session_id,
+                r#"{"prs":[{"number":123,"title":"feat: test"}],"runs":[{"status":"completed"}]}"#
+            ],
+        )
+        .expect("insert session ci");
+    }
+
+    let response = h
+        .client
+        .get(format!("{}/sessions", h.base_url))
+        .send()
+        .await
+        .expect("sessions request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Vec<Value> = response.json().await.expect("json");
+    assert_eq!(body.len(), 1);
+    assert!(body[0]["session_ci"].is_array());
+    assert_eq!(body[0]["session_ci"][0]["provider"], "github");
+    assert_eq!(body[0]["session_ci"][0]["status"], "ok");
+    assert_eq!(
+        body[0]["session_ci"][0]["data_json"]["prs"][0]["number"],
+        123
+    );
+}
+
+#[tokio::test]
+async fn t_a_16_get_session_detail_includes_ci_summary_payload() {
+    let h = ApiHarness::new().await;
+    h.create_session("alpha").await;
+    {
+        let db = h.state.db.lock().expect("db lock");
+        let session_id: i64 = db
+            .query_row("SELECT id FROM sessions WHERE name = 'alpha'", [], |r| {
+                r.get(0)
+            })
+            .expect("session id");
+        db.execute(
+            "INSERT INTO session_ci (session_id, provider, status, data_json, tool_message, polled_at, next_poll_at)
+             VALUES (?1, 'github', 'tool_unavailable', NULL, 'Install gh CLI: brew install gh', datetime('now'), datetime('now', '+5 minute'))",
+            rusqlite::params![session_id],
+        )
+        .expect("insert session ci");
+    }
+
+    let response = h
+        .client
+        .get(format!("{}/sessions/alpha", h.base_url))
+        .send()
+        .await
+        .expect("detail request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("json");
+    assert!(body["session_ci"].is_array());
+    assert_eq!(body["session_ci"][0]["provider"], "github");
+    assert_eq!(body["session_ci"][0]["status"], "tool_unavailable");
+    assert!(body["session_ci"][0]["tool_message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("brew install gh"));
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/ci_tests.rs
+++ b/crates/scmux-daemon/tests/ci_tests.rs
@@ -1,0 +1,308 @@
+use chrono::DateTime;
+use scmux_daemon::ci::{self, ToolAvailability};
+use scmux_daemon::config::{Config, DaemonConfig, PollingConfig};
+use scmux_daemon::{db, AppState};
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> &'static Mutex<()> {
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn test_config() -> Config {
+    Config {
+        daemon: DaemonConfig {
+            port: None,
+            db_path: None,
+            default_terminal: Some("iterm2".to_string()),
+            log_level: None,
+        },
+        polling: PollingConfig {
+            tmux_interval_secs: Some(15),
+            health_interval_secs: Some(60),
+            ci_active_interval_secs: None,
+            ci_idle_interval_secs: None,
+        },
+        hosts: Vec::new(),
+    }
+}
+
+fn build_state(ci_tools: ToolAvailability) -> (Arc<AppState>, TempDir) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("ci-tests.db");
+    let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
+    let host_id = db::ensure_local_host(&conn).expect("local host");
+    let state = Arc::new(AppState {
+        db: std::sync::Mutex::new(conn),
+        host_id,
+        config: test_config(),
+        reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        ci_tools,
+        last_api_access: std::sync::atomic::AtomicU64::new(0),
+        started_at: std::time::Instant::now(),
+    });
+    (state, tmp)
+}
+
+fn insert_ci_session(
+    state: &Arc<AppState>,
+    name: &str,
+    github_repo: Option<&str>,
+    azure_project: Option<&str>,
+    panes_json: &str,
+) -> i64 {
+    let db_conn = state.db.lock().expect("db lock");
+    let session_id = db::create_session(
+        &db_conn,
+        &db::NewSession {
+            name: name.to_string(),
+            project: Some("ci".to_string()),
+            host_id: state.host_id,
+            config_json: format!(r#"{{"session_name":"{name}"}}"#),
+            cron_schedule: None,
+            auto_start: false,
+            github_repo: github_repo.map(ToString::to_string),
+            azure_project: azure_project.map(ToString::to_string),
+        },
+    )
+    .expect("create session");
+
+    db_conn
+        .execute(
+            "INSERT INTO session_status (session_id, status, panes_json, polled_at)
+             VALUES (?1, 'running', ?2, datetime('now'))
+             ON CONFLICT(session_id) DO UPDATE SET
+                status = excluded.status,
+                panes_json = excluded.panes_json,
+                polled_at = excluded.polled_at",
+            rusqlite::params![session_id, panes_json],
+        )
+        .expect("insert session status");
+
+    session_id
+}
+
+fn ci_row(
+    state: &Arc<AppState>,
+    session_id: i64,
+    provider: &str,
+) -> (String, Option<String>, String, String) {
+    let db_conn = state.db.lock().expect("db lock");
+    db_conn
+        .query_row(
+            "SELECT status, tool_message, polled_at, next_poll_at
+             FROM session_ci
+             WHERE session_id = ?1 AND provider = ?2",
+            rusqlite::params![session_id, provider],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )
+        .expect("ci row")
+}
+
+fn write_script(contents: &str) -> tempfile::TempPath {
+    let mut file = tempfile::NamedTempFile::new().expect("temp script");
+    file.write_all(contents.as_bytes()).expect("write script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = file.as_file().metadata().expect("metadata").permissions();
+        perms.set_mode(0o755);
+        file.as_file().set_permissions(perms).expect("chmod");
+    }
+    file.into_temp_path()
+}
+
+fn set_env_var(key: &str, value: &str) -> Option<String> {
+    let prev = std::env::var(key).ok();
+    // SAFETY: test-only env mutation guarded by async mutex.
+    unsafe { std::env::set_var(key, value) };
+    prev
+}
+
+fn restore_env_var(key: &str, prev: Option<String>) {
+    match prev {
+        Some(value) => {
+            // SAFETY: test-only env restoration guarded by async mutex.
+            unsafe { std::env::set_var(key, value) };
+        }
+        None => {
+            // SAFETY: test-only env restoration guarded by async mutex.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+}
+
+#[test]
+fn td_10_ci_interval_is_1_minute_when_any_pane_is_active() {
+    assert_eq!(ci::next_interval(true).as_secs(), 60);
+}
+
+#[test]
+fn td_11_ci_interval_is_5_minutes_when_all_panes_are_idle() {
+    assert_eq!(ci::next_interval(false).as_secs(), 300);
+}
+
+#[tokio::test]
+async fn td_12_tool_unavailable_recorded_when_gh_missing() {
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: false,
+        az_available: true,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td12-gh-missing",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"agent","status":"active"}]"#,
+    );
+
+    ci::poll_once(&state).await.expect("poll once");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "github");
+    assert_eq!(status, "tool_unavailable");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.contains("brew install gh")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_13_tool_unavailable_recorded_when_az_missing() {
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: true,
+        az_available: false,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td13-az-missing",
+        None,
+        Some("devops-project"),
+        r#"[{"name":"agent","status":"idle"}]"#,
+    );
+
+    ci::poll_once(&state).await.expect("poll once");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "azure");
+    assert_eq!(status, "tool_unavailable");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.contains("brew install azure-cli")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_17_network_failure_records_error_without_crash() {
+    let _guard = env_lock().lock().await;
+    let script = write_script(
+        r#"#!/bin/sh
+echo "network unreachable" >&2
+exit 1
+"#,
+    );
+    let prev = set_env_var("SCMUX_GH_BIN", script.to_string_lossy().as_ref());
+
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: true,
+        az_available: true,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td17-network-fail",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"agent","status":"active"}]"#,
+    );
+
+    let result = ci::poll_once(&state).await;
+    restore_env_var("SCMUX_GH_BIN", prev);
+    result.expect("poll once should not crash");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "github");
+    assert_eq!(status, "error");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.contains("network unreachable")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_18_auth_or_rate_limit_error_is_handled_gracefully() {
+    let _guard = env_lock().lock().await;
+    let script = write_script(
+        r#"#!/bin/sh
+echo "authentication failed for github.com" >&2
+exit 1
+"#,
+    );
+    let prev = set_env_var("SCMUX_GH_BIN", script.to_string_lossy().as_ref());
+
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: true,
+        az_available: true,
+    });
+    let session_id = insert_ci_session(
+        &state,
+        "td18-auth-fail",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"agent","status":"idle"}]"#,
+    );
+
+    let result = ci::poll_once(&state).await;
+    restore_env_var("SCMUX_GH_BIN", prev);
+    result.expect("poll once should not crash");
+
+    let (status, tool_message, polled_at, next_poll_at) = ci_row(&state, session_id, "github");
+    assert_eq!(status, "auth_error");
+    assert!(tool_message
+        .as_deref()
+        .is_some_and(|msg| msg.to_ascii_lowercase().contains("authentication")));
+    assert!(DateTime::parse_from_rfc3339(&polled_at).is_ok());
+    assert!(DateTime::parse_from_rfc3339(&next_poll_at).is_ok());
+}
+
+#[tokio::test]
+async fn td_10_td_11_poll_once_uses_active_and_idle_cadence() {
+    let (state, _tmp) = build_state(ToolAvailability {
+        gh_available: false,
+        az_available: true,
+    });
+    let active_id = insert_ci_session(
+        &state,
+        "td10-active",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"active-pane","status":"active"}]"#,
+    );
+    let idle_id = insert_ci_session(
+        &state,
+        "td11-idle",
+        Some("acme/repo"),
+        None,
+        r#"[{"name":"idle-pane","status":"idle"}]"#,
+    );
+
+    ci::poll_once(&state).await.expect("poll once");
+
+    let (_, _, active_polled, active_next) = ci_row(&state, active_id, "github");
+    let active_polled = DateTime::parse_from_rfc3339(&active_polled).expect("active polled");
+    let active_next = DateTime::parse_from_rfc3339(&active_next).expect("active next");
+    let active_delta = active_next
+        .signed_duration_since(active_polled)
+        .num_seconds();
+    assert!((55..=65).contains(&active_delta));
+
+    let (_, _, idle_polled, idle_next) = ci_row(&state, idle_id, "github");
+    let idle_polled = DateTime::parse_from_rfc3339(&idle_polled).expect("idle polled");
+    let idle_next = DateTime::parse_from_rfc3339(&idle_next).expect("idle next");
+    let idle_delta = idle_next.signed_duration_since(idle_polled).num_seconds();
+    assert!((295..=305).contains(&idle_delta));
+}

--- a/crates/scmux-daemon/tests/integration_tests.rs
+++ b/crates/scmux-daemon/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Duration, Timelike, Utc};
 use scmux_daemon::config::{Config, DaemonConfig, PollingConfig};
-use scmux_daemon::{db, scheduler, AppState};
+use scmux_daemon::{ci, db, hosts, scheduler, AppState};
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -40,6 +40,10 @@ fn build_state() -> (Arc<AppState>, TempDir) {
         db: std::sync::Mutex::new(conn),
         host_id,
         config: test_config(),
+        reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        ci_tools: ci::ToolAvailability::default(),
+        last_api_access: std::sync::atomic::AtomicU64::new(0),
+        started_at: std::time::Instant::now(),
     });
     (state, tmp)
 }
@@ -117,6 +121,18 @@ fn event_count(state: &Arc<AppState>, session_id: i64, event: &str, trigger: &st
             |r| r.get(0),
         )
         .expect("event count")
+}
+
+fn insert_remote_host(state: &Arc<AppState>, name: &str, address: &str, api_port: u16) -> i64 {
+    let db_conn = state.db.lock().expect("db lock");
+    db_conn
+        .execute(
+            "INSERT INTO hosts (name, address, ssh_user, api_port, is_local)
+             VALUES (?1, ?2, 'tester', ?3, 0)",
+            rusqlite::params![name, address, api_port],
+        )
+        .expect("insert remote host");
+    db_conn.last_insert_rowid()
 }
 
 #[tokio::test]
@@ -339,4 +355,75 @@ async fn t_i_09_write_health_prunes_older_than_seven_days() {
         )
         .expect("old row count");
     assert_eq!(old_count, 0);
+}
+
+#[tokio::test]
+async fn t_i_10_poll_hosts_unreachable_test_net_returns_ok() {
+    let (state, _tmp) = build_state();
+    insert_remote_host(&state, "ti10-remote", "192.0.2.1", 7700);
+
+    let _guard = env_lock().lock().await;
+    let script = write_script("#!/bin/sh\nexit 1\n");
+    let prev = set_env_var("SCMUX_PING_BIN", script.to_string_lossy().as_ref());
+
+    let result = hosts::poll_hosts(Arc::clone(&state)).await;
+    restore_env_var("SCMUX_PING_BIN", prev);
+    result.expect("poll hosts");
+}
+
+#[tokio::test]
+async fn t_i_11_three_failures_mark_host_unreachable() {
+    let (state, _tmp) = build_state();
+    let remote_id = insert_remote_host(&state, "ti11-remote", "192.0.2.1", 7700);
+
+    let _guard = env_lock().lock().await;
+    let script = write_script("#!/bin/sh\nexit 1\n");
+    let prev = set_env_var("SCMUX_PING_BIN", script.to_string_lossy().as_ref());
+
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts #1");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts #2");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts #3");
+    restore_env_var("SCMUX_PING_BIN", prev);
+
+    let map = state.reachability.lock().expect("reachability lock");
+    let entry = map.get(&remote_id).expect("remote host entry");
+    assert!(!entry.reachable);
+    assert!(entry.consecutive_failures >= 3);
+}
+
+#[tokio::test]
+async fn t_i_12_success_after_failures_marks_host_reachable() {
+    let (state, _tmp) = build_state();
+    let remote_id = insert_remote_host(&state, "ti12-remote", "127.0.0.1", 1);
+
+    let _guard = env_lock().lock().await;
+    let fail_script = write_script("#!/bin/sh\nexit 1\n");
+    let success_script = write_script("#!/bin/sh\nexit 0\n");
+    let prev = set_env_var("SCMUX_PING_BIN", fail_script.to_string_lossy().as_ref());
+
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts fail #1");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts fail #2");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts fail #3");
+    let _ = set_env_var("SCMUX_PING_BIN", success_script.to_string_lossy().as_ref());
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("poll hosts success");
+    restore_env_var("SCMUX_PING_BIN", prev);
+
+    let map = state.reachability.lock().expect("reachability lock");
+    let entry = map.get(&remote_id).expect("remote host entry");
+    assert!(entry.reachable);
+    assert_eq!(entry.consecutive_failures, 0);
 }

--- a/crates/scmux/Cargo.toml
+++ b/crates/scmux/Cargo.toml
@@ -15,5 +15,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+clap.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true

--- a/crates/scmux/src/client.rs
+++ b/crates/scmux/src/client.rs
@@ -1,0 +1,344 @@
+//! Typed HTTP client for `scmux-daemon`.
+
+use reqwest::{Method, StatusCode};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+/// Default daemon endpoint for CLI requests (canonical daemon port 7878).
+pub const DEFAULT_DAEMON_URL: &str = "http://localhost:7878";
+
+#[derive(Debug, Clone)]
+pub struct ApiClient {
+    base_url: String,
+    http: reqwest::Client,
+}
+
+#[derive(Debug)]
+pub enum ClientError {
+    ConnectionRefused,
+    NotFound,
+    HttpStatus(u16, String),
+    Transport(String),
+    Decode(String),
+}
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionRefused => {
+                write!(f, "scmux: daemon not running (start with scmux-daemon)")
+            }
+            Self::NotFound => write!(f, "scmux: resource not found"),
+            Self::HttpStatus(code, body) => {
+                if body.trim().is_empty() {
+                    write!(f, "scmux: daemon request failed ({code})")
+                } else {
+                    write!(f, "scmux: daemon request failed ({code}): {body}")
+                }
+            }
+            Self::Transport(message) => write!(f, "scmux: request failed: {message}"),
+            Self::Decode(message) => write!(f, "scmux: invalid daemon response: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for ClientError {}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PaneSummary {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub last_activity: Option<String>,
+    #[serde(default)]
+    pub current_command: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SessionCiSummary {
+    pub provider: String,
+    pub status: String,
+    #[serde(default)]
+    pub data_json: Option<serde_json::Value>,
+    #[serde(default)]
+    pub tool_message: Option<String>,
+    #[serde(default)]
+    pub polled_at: Option<String>,
+    #[serde(default)]
+    pub next_poll_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SessionSummary {
+    pub id: i64,
+    pub name: String,
+    #[serde(default)]
+    pub project: Option<String>,
+    pub host_id: i64,
+    pub status: String,
+    #[serde(default)]
+    pub cron_schedule: Option<String>,
+    pub auto_start: bool,
+    #[serde(default)]
+    pub panes: Vec<PaneSummary>,
+    #[serde(default)]
+    pub polled_at: Option<String>,
+    #[serde(default)]
+    pub session_ci: Vec<SessionCiSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct EventRow {
+    pub event: String,
+    pub trigger: String,
+    #[serde(default)]
+    pub note: Option<String>,
+    pub occurred_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SessionDetail {
+    pub id: i64,
+    pub name: String,
+    #[serde(default)]
+    pub project: Option<String>,
+    pub host_id: i64,
+    pub status: String,
+    #[serde(default)]
+    pub cron_schedule: Option<String>,
+    pub auto_start: bool,
+    pub panes: serde_json::Value,
+    #[serde(default)]
+    pub polled_at: Option<String>,
+    #[serde(default)]
+    pub session_ci: Vec<SessionCiSummary>,
+    pub config_json: serde_json::Value,
+    #[serde(default)]
+    pub recent_events: Vec<EventRow>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ActionResponse {
+    pub ok: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HostSummary {
+    pub id: i64,
+    pub name: String,
+    pub address: String,
+    #[serde(default)]
+    pub ssh_user: Option<String>,
+    pub api_port: u16,
+    pub is_local: bool,
+    #[serde(default)]
+    pub last_seen: Option<String>,
+    pub reachable: bool,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HealthResponse {
+    pub status: String,
+    pub host_id: i64,
+    pub sessions_running: i64,
+    pub polled_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreateSessionRequest {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
+    pub config_json: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cron_schedule: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_start: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub azure_project: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct PatchSessionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_json: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cron_schedule: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_start: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_repo: Option<Option<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub azure_project: Option<Option<String>>,
+}
+
+impl PatchSessionRequest {
+    pub fn is_empty(&self) -> bool {
+        self.project.is_none()
+            && self.config_json.is_none()
+            && self.cron_schedule.is_none()
+            && self.auto_start.is_none()
+            && self.enabled.is_none()
+            && self.github_repo.is_none()
+            && self.azure_project.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JumpRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_id: Option<i64>,
+}
+
+impl ApiClient {
+    pub fn new(base_url: String) -> Self {
+        Self {
+            base_url: normalize_host(&base_url),
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub async fn list_sessions(&self) -> Result<Vec<SessionSummary>, ClientError> {
+        self.request_json(Method::GET, "/sessions", None::<&()>)
+            .await
+    }
+
+    pub async fn get_session(&self, name: &str) -> Result<SessionDetail, ClientError> {
+        self.request_json(Method::GET, &format!("/sessions/{name}"), None::<&()>)
+            .await
+    }
+
+    pub async fn start_session(&self, name: &str) -> Result<ActionResponse, ClientError> {
+        self.request_json(
+            Method::POST,
+            &format!("/sessions/{name}/start"),
+            None::<&()>,
+        )
+        .await
+    }
+
+    pub async fn stop_session(&self, name: &str) -> Result<ActionResponse, ClientError> {
+        self.request_json(Method::POST, &format!("/sessions/{name}/stop"), None::<&()>)
+            .await
+    }
+
+    pub async fn jump_session(
+        &self,
+        name: &str,
+        req: &JumpRequest,
+    ) -> Result<ActionResponse, ClientError> {
+        self.request_json(Method::POST, &format!("/sessions/{name}/jump"), Some(req))
+            .await
+    }
+
+    pub async fn create_session(
+        &self,
+        req: &CreateSessionRequest,
+    ) -> Result<ActionResponse, ClientError> {
+        self.request_json(Method::POST, "/sessions", Some(req))
+            .await
+    }
+
+    pub async fn patch_session(
+        &self,
+        name: &str,
+        req: &PatchSessionRequest,
+    ) -> Result<ActionResponse, ClientError> {
+        self.request_json(Method::PATCH, &format!("/sessions/{name}"), Some(req))
+            .await
+    }
+
+    pub async fn delete_session(&self, name: &str) -> Result<ActionResponse, ClientError> {
+        self.request_json(Method::DELETE, &format!("/sessions/{name}"), None::<&()>)
+            .await
+    }
+
+    pub async fn list_hosts(&self) -> Result<Vec<HostSummary>, ClientError> {
+        self.request_json(Method::GET, "/hosts", None::<&()>).await
+    }
+
+    pub async fn health(&self) -> Result<HealthResponse, ClientError> {
+        self.request_json(Method::GET, "/health", None::<&()>).await
+    }
+
+    async fn request_json<T, B>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&B>,
+    ) -> Result<T, ClientError>
+    where
+        T: DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
+        let mut req = self.http.request(method, url);
+        if let Some(payload) = body {
+            req = req.json(payload);
+        }
+
+        let response = req.send().await.map_err(map_send_error)?;
+        let status = response.status();
+
+        if status == StatusCode::NOT_FOUND {
+            return Err(ClientError::NotFound);
+        }
+
+        if !status.is_success() {
+            let body_text = response.text().await.unwrap_or_default();
+            return Err(ClientError::HttpStatus(status.as_u16(), body_text));
+        }
+
+        response
+            .json::<T>()
+            .await
+            .map_err(|err| ClientError::Decode(err.to_string()))
+    }
+}
+
+pub fn resolve_base_url(host_flag: Option<&str>) -> String {
+    if let Some(flag_host) = host_flag {
+        if !flag_host.trim().is_empty() {
+            return normalize_host(flag_host);
+        }
+    }
+
+    if let Ok(env_host) = std::env::var("SCMUX_HOST") {
+        if !env_host.trim().is_empty() {
+            return normalize_host(&env_host);
+        }
+    }
+
+    DEFAULT_DAEMON_URL.to_string()
+}
+
+fn normalize_host(raw: &str) -> String {
+    let value = raw.trim().trim_end_matches('/');
+    if value.starts_with("http://") || value.starts_with("https://") {
+        value.to_string()
+    } else {
+        format!("http://{value}")
+    }
+}
+
+fn map_send_error(err: reqwest::Error) -> ClientError {
+    if err.is_connect() {
+        ClientError::ConnectionRefused
+    } else {
+        ClientError::Transport(err.to_string())
+    }
+}

--- a/crates/scmux/src/lib.rs
+++ b/crates/scmux/src/lib.rs
@@ -1,0 +1,100 @@
+//! scmux CLI crate.
+//!
+//! This crate contains the command-line surface, daemon HTTP client, and
+//! terminal output helpers for the `scmux` binary.
+
+pub mod client;
+pub mod output;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(name = "scmux")]
+#[command(about = "CLI client for scmux-daemon")]
+pub struct Cli {
+    /// Daemon base URL (e.g. http://localhost:7878)
+    #[arg(long, global = true)]
+    pub host: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// List sessions
+    List {
+        /// Optional project filter
+        #[arg(long)]
+        project: Option<String>,
+    },
+    /// Show full session detail
+    Show { name: String },
+    /// Start a session
+    Start { name: String },
+    /// Stop a session
+    Stop { name: String },
+    /// Jump to a session via daemon terminal launch
+    Jump {
+        name: String,
+        #[arg(long)]
+        terminal: Option<String>,
+        #[arg(long)]
+        host_id: Option<i64>,
+    },
+    /// Register a new session
+    Add {
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
+        config: String,
+        #[arg(long)]
+        cron: Option<String>,
+        #[arg(long)]
+        auto_start: bool,
+        #[arg(long)]
+        host_id: Option<i64>,
+        #[arg(long)]
+        github_repo: Option<String>,
+        #[arg(long)]
+        azure_project: Option<String>,
+    },
+    /// Edit a session
+    Edit {
+        name: String,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
+        config: Option<String>,
+        #[arg(long)]
+        cron: Option<String>,
+        /// Set auto-start behavior. Supports `--auto-start` and `--auto-start=false`.
+        #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+        auto_start: Option<bool>,
+        #[arg(long)]
+        github_repo: Option<String>,
+        #[arg(long)]
+        azure_project: Option<String>,
+    },
+    /// Disable a session
+    Disable { name: String },
+    /// Enable a session
+    Enable { name: String },
+    /// Remove a session
+    Remove { name: String },
+    /// List hosts
+    Hosts,
+    /// Daemon subcommands
+    Daemon {
+        #[command(subcommand)]
+        command: DaemonCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum DaemonCommand {
+    /// Show daemon health status
+    Status,
+}

--- a/crates/scmux/src/main.rs
+++ b/crates/scmux/src/main.rs
@@ -1,3 +1,203 @@
-fn main() {
-    println!("scmux CLI — not yet implemented");
+use anyhow::anyhow;
+use clap::Parser;
+use scmux::client::{
+    resolve_base_url, ActionResponse, ApiClient, ClientError, CreateSessionRequest, JumpRequest,
+    PatchSessionRequest,
+};
+use scmux::output;
+use scmux::{Cli, Command, DaemonCommand};
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    if let Err(err) = run(cli).await {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run(cli: Cli) -> anyhow::Result<()> {
+    let client = ApiClient::new(resolve_base_url(cli.host.as_deref()));
+
+    match cli.command {
+        Command::List { project } => {
+            let mut sessions = client.list_sessions().await.map_err(map_client_error)?;
+            if let Some(project_filter) = project {
+                sessions
+                    .retain(|session| session.project.as_deref() == Some(project_filter.as_str()));
+            }
+
+            let hosts = client.list_hosts().await.map_err(map_client_error)?;
+            output::print_session_list(&sessions, &hosts);
+        }
+        Command::Show { name } => {
+            let session = client
+                .get_session(&name)
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            output::print_json_pretty(&session)?;
+        }
+        Command::Start { name } => {
+            let action = client
+                .start_session(&name)
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            ensure_action_ok(action)?;
+        }
+        Command::Stop { name } => {
+            let action = client
+                .stop_session(&name)
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            ensure_action_ok(action)?;
+        }
+        Command::Jump {
+            name,
+            terminal,
+            host_id,
+        } => {
+            let action = client
+                .jump_session(&name, &JumpRequest { terminal, host_id })
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            ensure_action_ok(action)?;
+        }
+        Command::Add {
+            name,
+            project,
+            config,
+            cron,
+            auto_start,
+            host_id,
+            github_repo,
+            azure_project,
+        } => {
+            let config_json = read_json_file(&config)?;
+            let action = client
+                .create_session(&CreateSessionRequest {
+                    name,
+                    project,
+                    config_json,
+                    cron_schedule: cron,
+                    auto_start: Some(auto_start),
+                    host_id,
+                    github_repo,
+                    azure_project,
+                })
+                .await
+                .map_err(map_client_error)?;
+            ensure_action_ok(action)?;
+        }
+        Command::Edit {
+            name,
+            project,
+            config,
+            cron,
+            auto_start,
+            github_repo,
+            azure_project,
+        } => {
+            let mut patch = PatchSessionRequest::default();
+            if let Some(project) = project {
+                patch.project = Some(Some(project));
+            }
+            if let Some(config_path) = config {
+                patch.config_json = Some(read_json_file(&config_path)?);
+            }
+            if let Some(cron_expr) = cron {
+                patch.cron_schedule = Some(Some(cron_expr));
+            }
+            if let Some(auto_start) = auto_start {
+                patch.auto_start = Some(auto_start);
+            }
+            if let Some(github_repo) = github_repo {
+                patch.github_repo = Some(Some(github_repo));
+            }
+            if let Some(azure_project) = azure_project {
+                patch.azure_project = Some(Some(azure_project));
+            }
+
+            if patch.is_empty() {
+                return Err(anyhow!("scmux: no changes requested"));
+            }
+
+            let action = client
+                .patch_session(&name, &patch)
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            ensure_action_ok(action)?;
+        }
+        Command::Disable { name } => {
+            let action = client
+                .patch_session(
+                    &name,
+                    &PatchSessionRequest {
+                        enabled: Some(false),
+                        ..PatchSessionRequest::default()
+                    },
+                )
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            ensure_action_ok(action)?;
+        }
+        Command::Enable { name } => {
+            let action = client
+                .patch_session(
+                    &name,
+                    &PatchSessionRequest {
+                        enabled: Some(true),
+                        ..PatchSessionRequest::default()
+                    },
+                )
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            ensure_action_ok(action)?;
+        }
+        Command::Remove { name } => {
+            let action = client
+                .delete_session(&name)
+                .await
+                .map_err(|err| map_session_error(err, &name))?;
+            ensure_action_ok(action)?;
+        }
+        Command::Hosts => {
+            let hosts = client.list_hosts().await.map_err(map_client_error)?;
+            output::print_hosts(&hosts);
+        }
+        Command::Daemon { command } => match command {
+            DaemonCommand::Status => {
+                let health = client.health().await.map_err(map_client_error)?;
+                output::print_health(&health);
+            }
+        },
+    }
+
+    Ok(())
+}
+
+fn ensure_action_ok(action: ActionResponse) -> anyhow::Result<()> {
+    if action.ok {
+        output::print_action(&action);
+        Ok(())
+    } else {
+        Err(anyhow!("scmux: {}", action.message))
+    }
+}
+
+fn read_json_file(path: &str) -> anyhow::Result<serde_json::Value> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|err| anyhow!("scmux: failed to read config file '{path}': {err}"))?;
+    serde_json::from_str(&contents)
+        .map_err(|err| anyhow!("scmux: invalid JSON in config file '{path}': {err}"))
+}
+
+fn map_session_error(err: ClientError, name: &str) -> anyhow::Error {
+    match err {
+        ClientError::NotFound => anyhow!("scmux: session {name} not found"),
+        other => map_client_error(other),
+    }
+}
+
+fn map_client_error(err: ClientError) -> anyhow::Error {
+    anyhow::Error::new(err)
 }

--- a/crates/scmux/src/output.rs
+++ b/crates/scmux/src/output.rs
@@ -1,0 +1,100 @@
+//! Terminal output formatting helpers for `scmux` commands.
+
+use crate::client::{ActionResponse, HealthResponse, HostSummary, SessionSummary};
+use std::collections::HashMap;
+
+pub fn print_session_list(sessions: &[SessionSummary], hosts: &[HostSummary]) {
+    let host_names: HashMap<i64, String> = hosts
+        .iter()
+        .map(|host| (host.id, host.name.clone()))
+        .collect();
+
+    println!(
+        "{:<15} {:<9} {:<10} {:<11} WINDOW",
+        "NAME", "STATUS", "HOST", "CRON/AUTO"
+    );
+
+    for session in sessions {
+        let host = host_names
+            .get(&session.host_id)
+            .map(|s| s.as_str())
+            .unwrap_or("—");
+        let cron_auto = session
+            .cron_schedule
+            .as_deref()
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| {
+                // If both cron_schedule and auto_start exist, cron takes precedence in display.
+                if session.auto_start {
+                    "auto".to_string()
+                } else {
+                    "—".to_string()
+                }
+            });
+        let window = window_name(session);
+
+        println!(
+            "{:<15} {:<9} {:<10} {:<11} {}",
+            session.name, session.status, host, cron_auto, window
+        );
+    }
+}
+
+pub fn print_hosts(hosts: &[HostSummary]) {
+    println!(
+        "{:<15} {:<24} {:<10} LAST_SEEN",
+        "NAME", "ADDRESS", "REACHABLE"
+    );
+
+    for host in hosts {
+        let address = format!("{}:{}", host.address, host.api_port);
+        let reachable = if host.reachable { "yes" } else { "no" };
+        let last_seen = host.last_seen.as_deref().unwrap_or("—");
+        println!(
+            "{:<15} {:<24} {:<10} {}",
+            host.name, address, reachable, last_seen
+        );
+    }
+}
+
+pub fn print_health(status: &HealthResponse) {
+    println!("status: {}", status.status);
+    println!("host_id: {}", status.host_id);
+    println!("sessions_running: {}", status.sessions_running);
+    println!("polled_at: {}", status.polled_at);
+}
+
+pub fn print_action(result: &ActionResponse) {
+    println!("{}", result.message);
+}
+
+pub fn print_json_pretty<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
+    let output = serde_json::to_string_pretty(value)?;
+    println!("{output}");
+    Ok(())
+}
+
+fn window_name(session: &SessionSummary) -> String {
+    if session.status.eq_ignore_ascii_case("stopped") {
+        return "—".to_string();
+    }
+
+    // Daemon API does not currently expose a dedicated tmux window name, so this
+    // uses the active (or first available) pane name as the best proxy.
+    let mut first_name: Option<&str> = None;
+    for pane in &session.panes {
+        if !pane.name.is_empty() && first_name.is_none() {
+            first_name = Some(&pane.name);
+        }
+
+        if pane.status.eq_ignore_ascii_case("active") {
+            return if pane.name.is_empty() {
+                "—".to_string()
+            } else {
+                pane.name.clone()
+            };
+        }
+    }
+
+    first_name.unwrap_or("—").to_string()
+}

--- a/crates/scmux/tests/cli_tests.rs
+++ b/crates/scmux/tests/cli_tests.rs
@@ -1,0 +1,140 @@
+use clap::Parser;
+use scmux::client::resolve_base_url;
+use scmux::{Cli, Command, DaemonCommand};
+use std::sync::{Mutex, OnceLock};
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn env_lock() -> &'static Mutex<()> {
+    ENV_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn set_env_var(key: &str, value: &str) -> Option<String> {
+    let prev = std::env::var(key).ok();
+    // SAFETY: test-only env mutation under global test mutex.
+    unsafe { std::env::set_var(key, value) };
+    prev
+}
+
+fn restore_env_var(key: &str, prev: Option<String>) {
+    match prev {
+        Some(value) => {
+            // SAFETY: test-only env restoration under global test mutex.
+            unsafe { std::env::set_var(key, value) };
+        }
+        None => {
+            // SAFETY: test-only env restoration under global test mutex.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+}
+
+#[test]
+fn td_c_01_parse_list_command() {
+    let cli =
+        Cli::try_parse_from(["scmux", "list", "--project", "demo"]).expect("parse list command");
+    match cli.command {
+        Command::List { project } => assert_eq!(project.as_deref(), Some("demo")),
+        other => panic!("expected list command, got {other:?}"),
+    }
+}
+
+#[test]
+fn td_c_02_parse_daemon_status_command() {
+    let cli = Cli::try_parse_from(["scmux", "daemon", "status"]).expect("parse daemon status");
+    match cli.command {
+        Command::Daemon { command } => assert!(matches!(command, DaemonCommand::Status)),
+        other => panic!("expected daemon command, got {other:?}"),
+    }
+}
+
+#[test]
+fn td_c_03_parse_add_command() {
+    let cli = Cli::try_parse_from([
+        "scmux",
+        "add",
+        "--name",
+        "alpha",
+        "--project",
+        "demo",
+        "--config",
+        "alpha.json",
+        "--auto-start",
+    ])
+    .expect("parse add command");
+
+    match cli.command {
+        Command::Add {
+            name,
+            project,
+            config,
+            auto_start,
+            ..
+        } => {
+            assert_eq!(name, "alpha");
+            assert_eq!(project.as_deref(), Some("demo"));
+            assert_eq!(config, "alpha.json");
+            assert!(auto_start);
+        }
+        other => panic!("expected add command, got {other:?}"),
+    }
+}
+
+#[test]
+fn td_c_04_host_resolution_uses_default_when_no_env_or_flag() {
+    let _guard = env_lock().lock().expect("env lock");
+    let prev = std::env::var("SCMUX_HOST").ok();
+    // SAFETY: test-only env mutation under global test mutex.
+    unsafe { std::env::remove_var("SCMUX_HOST") };
+
+    let resolved = resolve_base_url(None);
+
+    restore_env_var("SCMUX_HOST", prev);
+    assert_eq!(resolved, "http://localhost:7878");
+}
+
+#[test]
+fn td_c_05_host_resolution_uses_flag_when_env_missing() {
+    let _guard = env_lock().lock().expect("env lock");
+    let prev = std::env::var("SCMUX_HOST").ok();
+    // SAFETY: test-only env mutation under global test mutex.
+    unsafe { std::env::remove_var("SCMUX_HOST") };
+
+    let resolved = resolve_base_url(Some("127.0.0.1:8800"));
+
+    restore_env_var("SCMUX_HOST", prev);
+    assert_eq!(resolved, "http://127.0.0.1:8800");
+}
+
+#[test]
+fn td_c_06_host_resolution_flag_overrides_env() {
+    let _guard = env_lock().lock().expect("env lock");
+    let prev = set_env_var("SCMUX_HOST", "https://example.internal:9999");
+
+    let resolved = resolve_base_url(Some("127.0.0.1:8800"));
+
+    restore_env_var("SCMUX_HOST", prev);
+    assert_eq!(resolved, "http://127.0.0.1:8800");
+}
+
+#[test]
+fn td_c_07_parse_edit_auto_start_false() {
+    let cli = Cli::try_parse_from(["scmux", "edit", "alpha", "--auto-start=false"])
+        .expect("parse edit auto-start false");
+
+    match cli.command {
+        Command::Edit { auto_start, .. } => assert_eq!(auto_start, Some(false)),
+        other => panic!("expected edit command, got {other:?}"),
+    }
+}
+
+#[test]
+fn td_c_08_parse_edit_auto_start_true_without_value() {
+    let cli = Cli::try_parse_from(["scmux", "edit", "alpha", "--auto-start"])
+        .expect("parse edit auto-start true");
+
+    match cli.command {
+        Command::Edit { auto_start, .. } => assert_eq!(auto_start, Some(true)),
+        other => panic!("expected edit command, got {other:?}"),
+    }
+}

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,47 +1,50 @@
 # scmux Dashboard
 
-React single-file dashboard for monitoring and jumping to tmux agent teams.
+`dashboard/team-dashboard.jsx` is the live dashboard UI for `scmux-daemon`.
 
-## Features
+## Daemon URL Discovery
 
-- **Grid / List / Grouped** views
-- Per-session pane status (active / idle / stopped)
-- Open PRs with links
-- Jump modal — fires WezTerm SSH command to attach to session
-- Filter by status (running / idle / stopped) and project
-- Search sessions by name
+The dashboard resolves the daemon base URL from `window.location.origin`.
 
-## Running
+- Normal daemon-served mode: uses the page origin directly.
+- Local file/dev fallback: if origin is `null` or protocol is `file:`, uses `http://localhost:7878`.
 
-The dashboard is a single React JSX file (`team-dashboard.jsx`). To run:
+## Multi-Host Polling Model
+
+The browser only calls the local daemon.
+
+- `GET /dashboard-config.json` on initial load
+  - reads `default_terminal`
+  - reads `poll_interval_ms`
+  - seeds host metadata
+- `GET /sessions` and `GET /hosts` every `poll_interval_ms`
+  - sessions are cross-referenced by `host_id`
+  - host reachability and `last_seen` are taken from `/hosts`
+  - unreachable host sessions render monochrome in the UI
+
+## Opening the Dashboard
+
+Recommended path:
+
+1. Start daemon:
 
 ```bash
-# Option 1: Vite
-npm create vite@latest dashboard -- --template react
-cp team-dashboard.jsx src/App.jsx
-npm run dev
-
-# Option 2: Serve as artifact in Claude.ai
-# Paste team-dashboard.jsx contents into a Claude artifact
+scmux-daemon
 ```
 
-## Connecting to scmux-daemon
+2. Open in browser:
 
-Replace the static `TEAMS` array with a `useEffect` fetch from your daemon:
-
-```js
-useEffect(() => {
-  fetch('http://localhost:7700/sessions')
-    .then(r => r.json())
-    .then(setTeams);
-}, []);
+```text
+http://localhost:7878/
 ```
 
-For multiple hosts, fetch from each and merge with a `host` field added to each session.
+## Local Development
 
-## Jump Command
+You can iterate on the JSX file with a static server while keeping daemon APIs running:
 
-The jump modal shows the WezTerm command for the selected session:
+```bash
+cd dashboard
+python3 -m http.server 8080
+```
 
-- **Local:** `wezterm start -- tmux attach -t <session-name>`
-- **Remote:** `wezterm ssh user@host -- tmux attach -t <session-name>`
+Then open `http://localhost:8080/` and ensure a daemon is running on `http://localhost:7878` (fallback URL), or serve from daemon origin directly.

--- a/dashboard/team-dashboard.jsx
+++ b/dashboard/team-dashboard.jsx
@@ -1,10 +1,10 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const PROJECT_COLORS = {
   "radiant-p3": "#3b82f6",
-  "atm": "#10b981",
-  "beads": "#f59e0b",
-  "provenance": "#8b5cf6",
+  atm: "#10b981",
+  beads: "#f59e0b",
+  provenance: "#8b5cf6",
   "synaptic-canvas": "#ec4899",
   "claude-history": "#06b6d4",
   "ui-platform": "#f97316",
@@ -19,93 +19,663 @@ const STATUS_DOT = {
   running: { color: "#10b981", pulse: true },
 };
 
-const TEAMS = [
-  { name: "ui-template", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 42, title: "Add template renderer", url: "#" }, { num: 43, title: "Fix layout props", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "2m ago" }, { name: "architect", status: "idle", lastActivity: "8m ago" }, { name: "implementer", status: "active", lastActivity: "1m ago" }] },
-  { name: "p3-backend", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 55, title: "Subagent session extraction", url: "#" }], panes: [{ name: "architect", status: "active", lastActivity: "30s ago" }, { name: "implementer", status: "active", lastActivity: "1m ago" }, { name: "tester", status: "idle", lastActivity: "12m ago" }] },
-  { name: "p3-calibration", project: "radiant-p3", sessionStatus: "running", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "5m ago" }, { name: "implementer", status: "idle", lastActivity: "9m ago" }, { name: "tester", status: "active", lastActivity: "2m ago" }] },
-  { name: "atm-daemon", project: "atm", sessionStatus: "running", prs: [{ num: 12, title: "Slack bridge plugin", url: "#" }], panes: [{ name: "rust-dev", status: "active", lastActivity: "4m ago" }, { name: "tui", status: "idle", lastActivity: "22m ago" }, { name: "tester", status: "idle", lastActivity: "18m ago" }] },
-  { name: "atm-tui", project: "atm", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "32m ago" }, { name: "implementer", status: "idle", lastActivity: "45m ago" }, { name: "tester", status: "stopped", lastActivity: "1h ago" }] },
-  { name: "atm-slack-bridge", project: "atm", sessionStatus: "stopped", prs: [{ num: 8, title: "Socket mode per agent", url: "#" }], panes: [{ name: "architect", status: "stopped", lastActivity: "3h ago" }, { name: "implementer", status: "stopped", lastActivity: "3h ago" }] },
-  { name: "dagu-bootstrap", project: "atm", sessionStatus: "running", prs: [], panes: [{ name: "team-lead", status: "active", lastActivity: "1m ago" }, { name: "architect", status: "active", lastActivity: "3m ago" }, { name: "implementer", status: "idle", lastActivity: "7m ago" }] },
-  { name: "codex-mcp", project: "atm", sessionStatus: "idle", prs: [{ num: 3, title: "JSON-RPC wrapper", url: "#" }], panes: [{ name: "team-lead", status: "idle", lastActivity: "1h ago" }, { name: "implementer", status: "idle", lastActivity: "1h ago" }] },
-  { name: "beads-editor", project: "beads", sessionStatus: "stopped", prs: [], panes: [{ name: "react-flow", status: "stopped", lastActivity: "1d ago" }, { name: "architect", status: "stopped", lastActivity: "1d ago" }] },
-  { name: "beads-molecules", project: "beads", sessionStatus: "stopped", prs: [{ num: 7, title: "Jinja2 conditionals", url: "#" }], panes: [{ name: "team-lead", status: "stopped", lastActivity: "2d ago" }, { name: "implementer", status: "stopped", lastActivity: "2d ago" }] },
-  { name: "kuzu-schema", project: "provenance", sessionStatus: "running", prs: [{ num: 21, title: "File provenance links", url: "#" }, { num: 22, title: "Agent ID indexing", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "3m ago" }, { name: "architect", status: "active", lastActivity: "5m ago" }, { name: "tester", status: "idle", lastActivity: "11m ago" }] },
-  { name: "neo4j-migration", project: "provenance", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "40m ago" }, { name: "implementer", status: "idle", lastActivity: "50m ago" }] },
-  { name: "genealogy-graph", project: "provenance", sessionStatus: "stopped", prs: [], panes: [{ name: "team-lead", status: "stopped", lastActivity: "5d ago" }, { name: "researcher", status: "stopped", lastActivity: "5d ago" }] },
-  { name: "sc-marketplace", project: "synaptic-canvas", sessionStatus: "running", prs: [{ num: 33, title: "Tier 2 packaging", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "1m ago" }, { name: "implementer", status: "active", lastActivity: "2m ago" }, { name: "tester", status: "active", lastActivity: "4m ago" }] },
-  { name: "sc-hooks", project: "synaptic-canvas", sessionStatus: "idle", prs: [], panes: [{ name: "architect", status: "idle", lastActivity: "25m ago" }, { name: "implementer", status: "idle", lastActivity: "30m ago" }] },
-  { name: "sc-plugin-devkit", project: "synaptic-canvas", sessionStatus: "stopped", prs: [{ num: 19, title: "Pytest fixture harness", url: "#" }], panes: [{ name: "team-lead", status: "stopped", lastActivity: "4h ago" }, { name: "tester", status: "stopped", lastActivity: "4h ago" }] },
-  { name: "claude-history-cli", project: "claude-history", sessionStatus: "running", prs: [{ num: 53, title: "Subagent extraction", url: "#" }, { num: 54, title: "PreCompact hooks", url: "#" }, { num: 55, title: "PostCompact workflow", url: "#" }], panes: [{ name: "rust-dev", status: "active", lastActivity: "2m ago" }, { name: "tester", status: "idle", lastActivity: "14m ago" }, { name: "architect", status: "idle", lastActivity: "20m ago" }] },
-  { name: "history-search", project: "claude-history", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "55m ago" }, { name: "implementer", status: "idle", lastActivity: "1h ago" }] },
-  { name: "ui-components", project: "ui-platform", sessionStatus: "running", prs: [{ num: 9, title: "Design system tokens", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "6m ago" }, { name: "implementer", status: "active", lastActivity: "8m ago" }, { name: "tester", status: "idle", lastActivity: "15m ago" }] },
-  { name: "ui-design-system", project: "ui-platform", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "6h ago" }, { name: "implementer", status: "stopped", lastActivity: "6h ago" }] },
-  { name: "dolt-agent-reg", project: "dolt-registry", sessionStatus: "running", prs: [{ num: 4, title: "CLI management interface", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "3m ago" }, { name: "architect", status: "idle", lastActivity: "9m ago" }, { name: "implementer", status: "active", lastActivity: "5m ago" }] },
-  { name: "dolt-cam-db", project: "dolt-registry", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "35m ago" }, { name: "implementer", status: "idle", lastActivity: "40m ago" }] },
-  { name: "dolt-req-db", project: "dolt-registry", sessionStatus: "stopped", prs: [{ num: 2, title: "ADR schema migration", url: "#" }], panes: [{ name: "architect", status: "stopped", lastActivity: "8h ago" }, { name: "implementer", status: "stopped", lastActivity: "8h ago" }] },
-  { name: "adr-tracker", project: "dolt-registry", sessionStatus: "idle", prs: [], panes: [{ name: "team-lead", status: "idle", lastActivity: "2h ago" }, { name: "implementer", status: "idle", lastActivity: "2h ago" }] },
-  { name: "roslyn-rdf", project: "radiant-p3", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "3d ago" }, { name: "implementer", status: "stopped", lastActivity: "3d ago" }] },
-  { name: "nurbs-sensor", project: "radiant-p3", sessionStatus: "idle", prs: [{ num: 61, title: "NURBS bias correction", url: "#" }], panes: [{ name: "team-lead", status: "idle", lastActivity: "1h ago" }, { name: "implementer", status: "idle", lastActivity: "1h ago" }] },
-  { name: "bayer-cnn", project: "radiant-p3", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "2d ago" }, { name: "implementer", status: "stopped", lastActivity: "2d ago" }] },
-  { name: "rust-imgproc", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 17, title: "UnaryMap shape impl", url: "#" }], panes: [{ name: "rust-dev", status: "active", lastActivity: "1m ago" }, { name: "architect", status: "active", lastActivity: "3m ago" }, { name: "tester", status: "idle", lastActivity: "10m ago" }] },
-  { name: "mip-schema", project: "synaptic-canvas", sessionStatus: "stopped", prs: [], panes: [{ name: "architect", status: "stopped", lastActivity: "4d ago" }, { name: "implementer", status: "stopped", lastActivity: "4d ago" }] },
-  { name: "p3-perf-bench", project: "radiant-p3", sessionStatus: "running", prs: [{ num: 71, title: "Benchmark harness", url: "#" }], panes: [{ name: "team-lead", status: "active", lastActivity: "4m ago" }, { name: "implementer", status: "active", lastActivity: "6m ago" }, { name: "tester", status: "active", lastActivity: "8m ago" }] },
-];
+const DEFAULT_BASE_URL = "http://localhost:7878";
+const DEFAULT_POLL_MS = 15_000;
+
+function daemonBaseUrl() {
+  if (typeof window === "undefined") {
+    return DEFAULT_BASE_URL;
+  }
+  const { origin, protocol } = window.location;
+  if (!origin || origin === "null" || protocol === "file:") {
+    return DEFAULT_BASE_URL;
+  }
+  return origin;
+}
 
 function Dot({ status, size = 7 }) {
   const s = STATUS_DOT[status] || STATUS_DOT.stopped;
   return (
-    <span style={{ position: "relative", display: "inline-flex", alignItems: "center", justifyContent: "center", width: size, height: size, flexShrink: 0 }}>
-      {s.pulse && <span style={{ position: "absolute", inset: 0, borderRadius: "50%", backgroundColor: s.color, opacity: 0.35, animation: "ping 1.5s cubic-bezier(0,0,0.2,1) infinite" }} />}
-      <span style={{ width: size, height: size, borderRadius: "50%", backgroundColor: s.color, display: "block" }} />
+    <span
+      style={{
+        position: "relative",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: size,
+        height: size,
+        flexShrink: 0,
+      }}
+    >
+      {s.pulse && (
+        <span
+          style={{
+            position: "absolute",
+            inset: 0,
+            borderRadius: "50%",
+            backgroundColor: s.color,
+            opacity: 0.35,
+            animation: "ping 1.5s cubic-bezier(0,0,0.2,1) infinite",
+          }}
+        />
+      )}
+      <span
+        style={{
+          width: size,
+          height: size,
+          borderRadius: "50%",
+          backgroundColor: s.color,
+          display: "block",
+        }}
+      />
     </span>
   );
 }
 
-function JumpModal({ team, onClose }) {
-  if (!team) return null;
-  const pc = PROJECT_COLORS[team.project] || "#3b82f6";
-  const cmd = `wezterm start -- tmux attach -t ${team.name}`;
-  return (
-    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.8)", display: "flex", alignItems: "center", justifyContent: "center", zIndex: 200, backdropFilter: "blur(6px)" }} onClick={onClose}>
-      <div style={{ background: "#0d1117", border: `1px solid ${pc}50`, borderRadius: 12, padding: 28, minWidth: 380, fontFamily: "inherit" }} onClick={e => e.stopPropagation()}>
-        <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.12em", marginBottom: 6 }}>JUMP TO SESSION</div>
-        <div style={{ fontSize: 20, color: "#f1f5f9", fontWeight: 700, marginBottom: 3 }}>{team.name}</div>
-        <div style={{ fontSize: 11, color: pc, marginBottom: 20 }}>{team.project}</div>
+function normalizePanes(session) {
+  const panes = Array.isArray(session.panes) ? session.panes : [];
+  return panes.map((pane, index) => ({
+    name: pane.name || `pane-${index}`,
+    status: pane.status || "idle",
+    lastActivity: pane.last_activity || pane.lastActivity || "unknown",
+    currentCommand: pane.current_command || pane.currentCommand || "",
+  }));
+}
 
-        <div style={{ background: "#060810", borderRadius: 6, padding: "10px 14px", marginBottom: 20, fontSize: 11, color: "#475569" }}>
-          <span style={{ color: "#334155" }}>$ </span>{cmd}
+function parseCiPayload(raw) {
+  if (!raw) {
+    return null;
+  }
+  if (typeof raw === "object") {
+    return raw;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeCi(session) {
+  const source = Array.isArray(session.session_ci)
+    ? session.session_ci
+    : Array.isArray(session.ci)
+      ? session.ci
+      : [];
+
+  return source
+    .map((entry) => {
+      const payload = parseCiPayload(entry.data_json || entry.data || entry.payload);
+      return {
+        provider: entry.provider || "unknown",
+        status: entry.status || "unknown",
+        payload,
+        toolMessage: entry.tool_message || entry.message || null,
+      };
+    })
+    .filter((entry) => entry.provider !== "unknown");
+}
+
+function extractPrs(session, ciEntries) {
+  if (Array.isArray(session.prs)) {
+    return session.prs;
+  }
+
+  const github = ciEntries.find((entry) => entry.provider === "github");
+  if (!github || !github.payload) {
+    return [];
+  }
+
+  if (Array.isArray(github.payload.prs)) {
+    return github.payload.prs;
+  }
+
+  return [];
+}
+
+function extractOpenPrCount(session, ciEntries) {
+  const direct = Array.isArray(session.prs) ? session.prs.length : null;
+  if (direct !== null) {
+    return direct;
+  }
+
+  const github = ciEntries.find((entry) => entry.provider === "github");
+  if (!github) {
+    return 0;
+  }
+  if (github.payload && Array.isArray(github.payload.prs)) {
+    return github.payload.prs.length;
+  }
+  const numericCandidates = [
+    github.payload?.open_pr_count,
+    github.payload?.open_prs,
+    github.payload?.pr_count,
+  ];
+  const numeric = numericCandidates.find((value) => Number.isFinite(value));
+  return Number.isFinite(numeric) ? Number(numeric) : 0;
+}
+
+function extractRuns(ciEntries) {
+  const rows = [];
+
+  ciEntries.forEach((entry) => {
+    if (!entry.payload || !Array.isArray(entry.payload.runs)) {
+      return;
+    }
+    entry.payload.runs.forEach((run, index) => {
+      rows.push({
+        provider: entry.provider,
+        title:
+          run.displayTitle ||
+          run.name ||
+          run.pipeline?.name ||
+          run.definition?.name ||
+          `run-${index + 1}`,
+        status: run.status || run.state || run.result || run.conclusion || "unknown",
+        conclusion: run.conclusion || run.result || null,
+        branch: run.headBranch || run.sourceBranch || run.branch || null,
+        createdAt: run.createdAt || run.creationDate || run.queueTime || run.finishTime || null,
+        url: run.url || run.webUrl || run._links?.web?.href || null,
+      });
+    });
+  });
+
+  return rows;
+}
+
+function relativeTime(iso) {
+  if (!iso) {
+    return "unknown";
+  }
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) {
+    return "unknown";
+  }
+  const elapsedSec = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (elapsedSec < 60) {
+    return `${elapsedSec}s ago`;
+  }
+  if (elapsedSec < 3600) {
+    return `${Math.floor(elapsedSec / 60)}m ago`;
+  }
+  if (elapsedSec < 86400) {
+    return `${Math.floor(elapsedSec / 3600)}h ago`;
+  }
+  return `${Math.floor(elapsedSec / 86400)}d ago`;
+}
+
+function buildJumpCommand(session, host) {
+  if (!host || host.is_local) {
+    return `tmux attach -t ${session.name}`;
+  }
+  const sshUser = host.ssh_user || "<ssh_user>";
+  return `ssh ${sshUser}@${host.address} tmux attach -t ${session.name}`;
+}
+
+function sessionStyle(session) {
+  const baseOpacity = session.status === "stopped" ? 0.55 : 1;
+  if (!session.host || session.host.reachable) {
+    return { opacity: baseOpacity };
+  }
+
+  return {
+    opacity: baseOpacity * 0.75,
+    filter: "grayscale(1)",
+  };
+}
+
+function hostLabel(host) {
+  if (!host) {
+    return "unknown-host";
+  }
+  return host.name || host.address || `host-${host.id}`;
+}
+
+function hostBadge(host) {
+  if (!host) {
+    return "unknown";
+  }
+  if (host.reachable) {
+    return host.is_local ? "local" : "reachable";
+  }
+  return `last seen ${relativeTime(host.last_seen)}`;
+}
+
+function CiBadges({ session }) {
+  const [showGithubPrs, setShowGithubPrs] = useState(false);
+
+  if (!session.ciEntries.length) {
+    return null;
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+        {session.ciEntries.map((entry, index) => {
+          if (entry.status === "tool_unavailable") {
+            const installHint =
+              entry.provider === "github"
+                ? "Install gh CLI: brew install gh"
+                : entry.provider === "azure"
+                  ? "Install az CLI: brew install azure-cli"
+                  : "Install required CLI tool";
+            return (
+              <span
+                key={`${entry.provider}-${index}`}
+                title={entry.toolMessage || installHint}
+                style={{
+                  fontSize: 9,
+                  color: "#94a3b8",
+                  background: "#1e293b",
+                  borderRadius: 3,
+                  padding: "1px 6px",
+                }}
+              >
+                {entry.provider}: unavailable
+              </span>
+            );
+          }
+
+          if (entry.provider === "github") {
+            return (
+              <button
+                key={`${entry.provider}-${index}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setShowGithubPrs((prev) => !prev);
+                }}
+                title={`GitHub Actions: ${session.ciRuns.filter((run) => run.provider === "github").length} runs`}
+                style={{
+                  fontSize: 9,
+                  color: "#60a5fa",
+                  background: "#172554",
+                  borderRadius: 3,
+                  padding: "1px 6px",
+                  border: "none",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                }}
+              >
+                GH PRs: {session.openPrCount}
+              </button>
+            );
+          }
+
+          if (entry.provider === "azure") {
+            return (
+              <span
+                key={`${entry.provider}-${index}`}
+                title={`Azure Pipelines: ${session.ciRuns.filter((run) => run.provider === "azure").length} runs`}
+                style={{
+                  fontSize: 9,
+                  color: "#38bdf8",
+                  background: "#082f49",
+                  borderRadius: 3,
+                  padding: "1px 6px",
+                }}
+              >
+                Azure: {entry.status}
+              </span>
+            );
+          }
+
+          return null;
+        })}
+      </div>
+
+      {showGithubPrs && (
+        <div
+          onClick={(event) => event.stopPropagation()}
+          style={{
+            background: "#0a0e14",
+            border: "1px solid #131820",
+            borderRadius: 4,
+            padding: "6px 8px",
+            minWidth: 180,
+          }}
+        >
+          {session.prs.length === 0 && (
+            <div style={{ fontSize: 10, color: "#64748b" }}>No open PRs.</div>
+          )}
+          {session.prs.map((pr, index) => (
+            <a
+              key={`${pr.url || "pr"}-${index}`}
+              href={pr.url || "#"}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => event.stopPropagation()}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 6,
+                textDecoration: "none",
+                padding: "3px 0",
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 9,
+                  color: "#60a5fa",
+                  background: "#172554",
+                  borderRadius: 3,
+                  padding: "1px 5px",
+                  flexShrink: 0,
+                }}
+              >
+                #{pr.num || "?"}
+              </span>
+              <span
+                style={{
+                  fontSize: 10,
+                  color: "#94a3b8",
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                }}
+              >
+                {pr.title || "Untitled PR"}
+              </span>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function JumpModal({ baseUrl, defaultTerminal, session, onClose }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [feedback, setFeedback] = useState(null);
+
+  useEffect(() => {
+    if (!session) {
+      return undefined;
+    }
+
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [session, onClose]);
+
+  useEffect(() => {
+    setFeedback(null);
+    setSubmitting(false);
+  }, [session]);
+
+  if (!session) {
+    return null;
+  }
+
+  const pc = PROJECT_COLORS[session.project] || "#3b82f6";
+  const cmd = buildJumpCommand(session, session.host);
+  const ciEntries = Array.isArray(session.ciEntries) ? session.ciEntries : [];
+  const ciRuns = Array.isArray(session.ciRuns) ? session.ciRuns : [];
+
+  const handleJump = async () => {
+    setSubmitting(true);
+    try {
+      const response = await fetch(
+        `${baseUrl}/sessions/${encodeURIComponent(session.name)}/jump`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            terminal: defaultTerminal,
+            host_id: session.host_id,
+          }),
+        },
+      );
+      const body = await response.json();
+      if (!response.ok) {
+        setFeedback({ ok: false, message: body.message || `HTTP ${response.status}` });
+      } else {
+        setFeedback({ ok: body.ok, message: body.message || "No message" });
+      }
+    } catch (error) {
+      setFeedback({ ok: false, message: String(error) });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.8)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 200,
+        backdropFilter: "blur(6px)",
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: "#0d1117",
+          border: `1px solid ${pc}50`,
+          borderRadius: 12,
+          padding: 24,
+          minWidth: 360,
+          maxWidth: 680,
+          width: "92vw",
+          fontFamily: "inherit",
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.12em", marginBottom: 6 }}>
+          JUMP TO SESSION
+        </div>
+        <div style={{ fontSize: 20, color: "#f1f5f9", fontWeight: 700, marginBottom: 3 }}>
+          {session.name}
+        </div>
+        <div style={{ fontSize: 11, color: pc, marginBottom: 6 }}>
+          {session.project || "unassigned"} on {hostLabel(session.host)}
+        </div>
+        <div style={{ fontSize: 10, color: "#64748b", marginBottom: 16 }}>
+          {session.host?.reachable ? "host reachable" : `host unreachable (${hostBadge(session.host)})`}
         </div>
 
-        <div style={{ marginBottom: 18 }}>
-          <div style={{ fontSize: 10, color: "#1e2535", letterSpacing: "0.1em", marginBottom: 8 }}>PANES</div>
-          {team.panes.map((p, i) => (
-            <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, padding: "4px 0", borderBottom: i < team.panes.length - 1 ? "1px solid #0d1117" : "none" }}>
-              <Dot status={p.status} size={6} />
-              <span style={{ fontSize: 12, color: "#94a3b8", flex: 1 }}>{p.name}</span>
-              <span style={{ fontSize: 10, color: "#334155" }}>{p.lastActivity}</span>
+        <div
+          style={{
+            background: "#060810",
+            borderRadius: 6,
+            padding: "10px 14px",
+            marginBottom: 18,
+            fontSize: 11,
+            color: "#94a3b8",
+            overflowX: "auto",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <span style={{ color: "#334155" }}>$ </span>
+          {cmd}
+        </div>
+
+        <div style={{ marginBottom: 16 }}>
+          <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.1em", marginBottom: 8 }}>
+            PANES
+          </div>
+          {session.panes.length === 0 && (
+            <div style={{ fontSize: 11, color: "#475569" }}>No panes reported.</div>
+          )}
+          {session.panes.map((pane, index) => (
+            <div
+              key={`${pane.name}-${index}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "4px 0",
+                borderBottom: index < session.panes.length - 1 ? "1px solid #0f172a" : "none",
+              }}
+            >
+              <Dot status={pane.status} size={6} />
+              <span style={{ fontSize: 12, color: "#94a3b8", flex: 1 }}>{pane.name}</span>
+              <span style={{ fontSize: 10, color: "#475569" }}>{pane.lastActivity}</span>
             </div>
           ))}
         </div>
 
-        {team.prs.length > 0 && (
-          <div style={{ marginBottom: 20 }}>
-            <div style={{ fontSize: 10, color: "#1e2535", letterSpacing: "0.1em", marginBottom: 8 }}>OPEN PRS</div>
-            {team.prs.map((pr, i) => (
-              <a key={i} href={pr.url} style={{ display: "flex", alignItems: "center", gap: 8, padding: "5px 0", textDecoration: "none", borderBottom: i < team.prs.length - 1 ? "1px solid #0d1117" : "none" }}>
-                <span style={{ fontSize: 10, color: pc, background: `${pc}18`, borderRadius: 3, padding: "2px 6px", flexShrink: 0 }}>#{pr.num}</span>
-                <span style={{ fontSize: 11, color: "#64748b", flex: 1 }}>{pr.title}</span>
+        {session.prs.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.1em", marginBottom: 8 }}>
+              OPEN PRS
+            </div>
+            {session.prs.map((pr, index) => (
+              <a
+                key={`${pr.url || "pr"}-${index}`}
+                href={pr.url || "#"}
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "5px 0",
+                  textDecoration: "none",
+                  borderBottom: index < session.prs.length - 1 ? "1px solid #0f172a" : "none",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: pc,
+                    background: `${pc}18`,
+                    borderRadius: 3,
+                    padding: "2px 6px",
+                    flexShrink: 0,
+                  }}
+                >
+                  #{pr.num || "?"}
+                </span>
+                <span style={{ fontSize: 11, color: "#94a3b8", flex: 1 }}>
+                  {pr.title || "Untitled PR"}
+                </span>
                 <span style={{ fontSize: 11, color: "#334155" }}>↗</span>
               </a>
             ))}
           </div>
         )}
 
+        {ciEntries.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 10, color: "#334155", letterSpacing: "0.1em", marginBottom: 8 }}>
+              CI RUN STATUS
+            </div>
+            {ciRuns.length === 0 && (
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                {ciEntries.map((entry, index) => (
+                  <div
+                    key={`${entry.provider}-${index}`}
+                    style={{ display: "flex", alignItems: "center", gap: 8, padding: "3px 0" }}
+                  >
+                    <span
+                      style={{
+                        fontSize: 9,
+                        color: entry.provider === "github" ? "#60a5fa" : "#38bdf8",
+                        background: entry.provider === "github" ? "#172554" : "#082f49",
+                        borderRadius: 3,
+                        padding: "1px 5px",
+                        flexShrink: 0,
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      {entry.provider}
+                    </span>
+                    <span style={{ fontSize: 10, color: "#64748b" }}>{entry.status}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {ciRuns.slice(0, 8).map((run, index) => (
+              <div
+                key={`${run.provider}-${run.title}-${index}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "5px 0",
+                  borderBottom: index < Math.min(ciRuns.length, 8) - 1 ? "1px solid #0f172a" : "none",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: 9,
+                    color: run.provider === "github" ? "#60a5fa" : "#38bdf8",
+                    background: run.provider === "github" ? "#172554" : "#082f49",
+                    borderRadius: 3,
+                    padding: "1px 5px",
+                    flexShrink: 0,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {run.provider}
+                </span>
+                <span style={{ fontSize: 11, color: "#94a3b8", flex: 1 }}>
+                  {run.title}
+                </span>
+                <span style={{ fontSize: 10, color: "#64748b" }}>
+                  {run.conclusion || run.status}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {feedback && (
+          <div
+            style={{
+              fontSize: 11,
+              marginBottom: 14,
+              color: feedback.ok ? "#34d399" : "#f87171",
+            }}
+          >
+            {feedback.message}
+          </div>
+        )}
+
         <div style={{ display: "flex", gap: 8 }}>
-          <button style={{ flex: 1, padding: "10px 0", background: pc, border: "none", borderRadius: 6, color: "#fff", fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", letterSpacing: "0.05em" }}>
-            Open in WezTerm →
+          <button
+            onClick={handleJump}
+            disabled={submitting}
+            style={{
+              flex: 1,
+              padding: "10px 0",
+              background: pc,
+              border: "none",
+              borderRadius: 6,
+              color: "#fff",
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: submitting ? "default" : "pointer",
+              fontFamily: "inherit",
+              letterSpacing: "0.05em",
+              opacity: submitting ? 0.7 : 1,
+            }}
+          >
+            {submitting ? "Launching..." : "Open in iTerm2 ->"}
           </button>
-          <button style={{ padding: "10px 16px", background: "transparent", border: "1px solid #1e2535", borderRadius: 6, color: "#475569", fontSize: 12, cursor: "pointer", fontFamily: "inherit" }} onClick={onClose}>
+          <button
+            style={{
+              padding: "10px 16px",
+              background: "transparent",
+              border: "1px solid #1e2535",
+              borderRadius: 6,
+              color: "#475569",
+              fontSize: 12,
+              cursor: "pointer",
+              fontFamily: "inherit",
+            }}
+            onClick={onClose}
+          >
             esc
           </button>
         </div>
@@ -114,81 +684,147 @@ function JumpModal({ team, onClose }) {
   );
 }
 
-function GridCard({ team, onJump }) {
-  const pc = PROJECT_COLORS[team.project] || "#6b7280";
-  const activePanes = team.panes.filter(p => p.status === "active").length;
-  const isStopped = team.sessionStatus === "stopped";
+function GridCard({ session, onJump }) {
+  const pc = PROJECT_COLORS[session.project] || "#6b7280";
+  const activePanes = session.panes.filter((pane) => pane.status === "active").length;
   return (
-    <div onClick={() => onJump(team)} style={{ background: "#0d1117", border: "1px solid #131820", borderRadius: 8, overflow: "hidden", cursor: "pointer", opacity: isStopped ? 0.5 : 1, transition: "border-color 0.15s, transform 0.1s" }}
-      onMouseEnter={e => { e.currentTarget.style.borderColor = pc + "55"; e.currentTarget.style.transform = "translateY(-1px)"; }}
-      onMouseLeave={e => { e.currentTarget.style.borderColor = "#131820"; e.currentTarget.style.transform = "translateY(0)"; }}
+    <div
+      onClick={() => onJump(session)}
+      style={{
+        background: "#0d1117",
+        border: "1px solid #131820",
+        borderRadius: 8,
+        overflow: "hidden",
+        cursor: "pointer",
+        transition: "border-color 0.15s, transform 0.1s",
+        ...sessionStyle(session),
+      }}
+      onMouseEnter={(event) => {
+        event.currentTarget.style.borderColor = `${pc}55`;
+        event.currentTarget.style.transform = "translateY(-1px)";
+      }}
+      onMouseLeave={(event) => {
+        event.currentTarget.style.borderColor = "#131820";
+        event.currentTarget.style.transform = "translateY(0)";
+      }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 12px", borderBottom: "1px solid #0a0e14" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 12px",
+          borderBottom: "1px solid #0a0e14",
+        }}
+      >
         <div style={{ width: 3, height: 26, borderRadius: 2, background: pc, flexShrink: 0 }} />
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 12, fontWeight: 600, color: "#e2e8f0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{team.name}</div>
-          <div style={{ fontSize: 10, color: pc, opacity: 0.8 }}>{team.project}</div>
+          <div
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: "#e2e8f0",
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {session.name}
+          </div>
+          <div style={{ fontSize: 10, color: pc, opacity: 0.8 }}>
+            {(session.project || "unassigned") + " | " + hostLabel(session.host)}
+          </div>
         </div>
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 3, flexShrink: 0 }}>
-          <Dot status={team.sessionStatus} size={7} />
-          {!isStopped && <span style={{ fontSize: 9, color: "#334155" }}>{activePanes}/{team.panes.length}</span>}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 3 }}>
+          <Dot status={session.status} size={7} />
+          <span style={{ fontSize: 9, color: "#334155" }}>
+            {activePanes}/{session.panes.length}
+          </span>
         </div>
       </div>
-      <div style={{ padding: "6px 12px 8px" }}>
-        {team.panes.map((pane, i) => (
-          <div key={i} style={{ display: "flex", alignItems: "center", gap: 6, padding: "2px 0" }}>
+
+      <div style={{ padding: "6px 12px 10px" }}>
+        {session.panes.slice(0, 4).map((pane, index) => (
+          <div key={`${pane.name}-${index}`} style={{ display: "flex", alignItems: "center", gap: 6, padding: "2px 0" }}>
             <Dot status={pane.status} size={5} />
-            <span style={{ fontSize: 10, color: pane.status === "active" ? "#94a3b8" : "#2d3748", flex: 1 }}>{pane.name}</span>
-            <span style={{ fontSize: 9, color: "#1a2030" }}>{pane.lastActivity}</span>
+            <span style={{ fontSize: 10, color: "#94a3b8", flex: 1 }}>{pane.name}</span>
+            <span style={{ fontSize: 9, color: "#334155" }}>{pane.lastActivity}</span>
           </div>
         ))}
-        {team.prs.length > 0 && (
-          <div style={{ marginTop: 6, paddingTop: 5, borderTop: "1px solid #0a0e14", display: "flex", gap: 3, flexWrap: "wrap" }}>
-            {team.prs.map((pr, i) => (
-              <span key={i} style={{ fontSize: 9, color: pc, background: `${pc}18`, borderRadius: 3, padding: "1px 5px" }}>#{pr.num}</span>
-            ))}
-          </div>
-        )}
+
+        <div style={{ marginTop: 8, display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+          <CiBadges session={session} />
+          <span style={{ fontSize: 9, color: "#475569" }}>{hostBadge(session.host)}</span>
+        </div>
       </div>
     </div>
   );
 }
 
-function ListView({ teams, onJump }) {
+function ListView({ sessions, onJump }) {
   return (
-    <div style={{ padding: "0 24px 24px" }}>
-      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+    <div style={{ padding: "0 24px 24px", overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12, minWidth: 780 }}>
         <thead>
           <tr style={{ borderBottom: "1px solid #131820" }}>
-            {["", "Session", "Project", "Status", "Panes", "Active", "Open PRs", "Last Activity"].map((h, i) => (
-              <th key={i} style={{ padding: "8px 12px", textAlign: "left", fontSize: 10, color: "#1e2535", letterSpacing: "0.1em", fontWeight: 600 }}>{h}</th>
-            ))}
+            {["", "Session", "Project", "Host", "Status", "Panes", "Active", "Open PRs", "Last Activity"].map(
+              (header) => (
+                <th
+                  key={header}
+                  style={{
+                    padding: "8px 12px",
+                    textAlign: "left",
+                    fontSize: 10,
+                    color: "#1e2535",
+                    letterSpacing: "0.1em",
+                    fontWeight: 600,
+                  }}
+                >
+                  {header}
+                </th>
+              ),
+            )}
           </tr>
         </thead>
         <tbody>
-          {teams.map((team, i) => {
-            const pc = PROJECT_COLORS[team.project] || "#6b7280";
-            const activePanes = team.panes.filter(p => p.status === "active").length;
+          {sessions.map((session, index) => {
+            const pc = PROJECT_COLORS[session.project] || "#6b7280";
+            const activePanes = session.panes.filter((pane) => pane.status === "active").length;
             return (
-              <tr key={i} onClick={() => onJump(team)} style={{ borderBottom: "1px solid #0a0e14", cursor: "pointer", opacity: team.sessionStatus === "stopped" ? 0.5 : 1, transition: "background 0.1s" }}
-                onMouseEnter={e => e.currentTarget.style.background = "#0f1117"}
-                onMouseLeave={e => e.currentTarget.style.background = "transparent"}
+              <tr
+                key={`${session.name}-${index}`}
+                onClick={() => onJump(session)}
+                style={{
+                  borderBottom: "1px solid #0a0e14",
+                  cursor: "pointer",
+                  transition: "background 0.1s",
+                  ...sessionStyle(session),
+                }}
+                onMouseEnter={(event) => {
+                  event.currentTarget.style.background = "#0f1117";
+                }}
+                onMouseLeave={(event) => {
+                  event.currentTarget.style.background = "transparent";
+                }}
               >
-                <td style={{ padding: "7px 12px" }}><div style={{ width: 3, height: 18, borderRadius: 2, background: pc }} /></td>
-                <td style={{ padding: "7px 12px", color: "#cbd5e1", fontWeight: 500 }}>{team.name}</td>
-                <td style={{ padding: "7px 12px", color: pc, fontSize: 11 }}>{team.project}</td>
-                <td style={{ padding: "7px 12px" }}><div style={{ display: "flex", alignItems: "center", gap: 6 }}><Dot status={team.sessionStatus} size={6} /><span style={{ color: "#334155", fontSize: 11 }}>{team.sessionStatus}</span></div></td>
-                <td style={{ padding: "7px 12px", color: "#334155" }}>{team.panes.length}</td>
-                <td style={{ padding: "7px 12px", color: activePanes > 0 ? "#10b981" : "#1e2535" }}>{activePanes}</td>
                 <td style={{ padding: "7px 12px" }}>
-                  <div style={{ display: "flex", gap: 3, flexWrap: "wrap" }}>
-                    {team.prs.length === 0
-                      ? <span style={{ color: "#1e2535" }}>—</span>
-                      : team.prs.map((pr, j) => <span key={j} style={{ fontSize: 9, color: pc, background: `${pc}18`, borderRadius: 3, padding: "1px 5px" }}>#{pr.num}</span>)
-                    }
+                  <div style={{ width: 3, height: 18, borderRadius: 2, background: pc }} />
+                </td>
+                <td style={{ padding: "7px 12px", color: "#cbd5e1", fontWeight: 500 }}>{session.name}</td>
+                <td style={{ padding: "7px 12px", color: pc, fontSize: 11 }}>{session.project || "unassigned"}</td>
+                <td style={{ padding: "7px 12px", color: "#94a3b8", fontSize: 11 }}>{hostLabel(session.host)}</td>
+                <td style={{ padding: "7px 12px" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <Dot status={session.status} size={6} />
+                    <span style={{ color: "#64748b", fontSize: 11 }}>{session.status}</span>
                   </div>
                 </td>
-                <td style={{ padding: "7px 12px", color: "#1e2535", fontSize: 11 }}>{team.panes[0]?.lastActivity || "—"}</td>
+                <td style={{ padding: "7px 12px", color: "#334155" }}>{session.panes.length}</td>
+                <td style={{ padding: "7px 12px", color: activePanes > 0 ? "#10b981" : "#1e2535" }}>{activePanes}</td>
+                <td style={{ padding: "7px 12px", color: "#60a5fa" }}>{session.openPrCount || "-"}</td>
+                <td style={{ padding: "7px 12px", color: "#475569", fontSize: 11 }}>
+                  {session.panes[0]?.lastActivity || relativeTime(session.polled_at)}
+                </td>
               </tr>
             );
           })}
@@ -198,25 +834,91 @@ function ListView({ teams, onJump }) {
   );
 }
 
-function GroupedView({ teams, onJump }) {
-  const byProject = {};
-  teams.forEach(t => { if (!byProject[t.project]) byProject[t.project] = []; byProject[t.project].push(t); });
+function GroupedView({ sessions, onJump }) {
+  const byProject = useMemo(() => {
+    const grouped = new Map();
+    sessions.forEach((session) => {
+      const project = session.project || "unassigned";
+      if (!grouped.has(project)) {
+        grouped.set(project, []);
+      }
+      grouped.get(project).push(session);
+    });
+    return grouped;
+  }, [sessions]);
+
   return (
     <div style={{ padding: "0 24px 24px", display: "flex", flexDirection: "column", gap: 28 }}>
-      {Object.entries(byProject).map(([project, projectTeams]) => {
+      {Array.from(byProject.entries()).map(([project, projectSessions]) => {
         const pc = PROJECT_COLORS[project] || "#6b7280";
-        const running = projectTeams.filter(t => t.sessionStatus === "running").length;
-        const totalPRs = projectTeams.reduce((n, t) => n + t.prs.length, 0);
+        const running = projectSessions.filter((session) => session.status === "running").length;
+        const totalPrs = projectSessions.reduce((sum, session) => sum + session.openPrCount, 0);
+
+        const byHost = new Map();
+        projectSessions.forEach((session) => {
+          const key = session.host?.id || `unknown-${session.host_id}`;
+          if (!byHost.has(key)) {
+            byHost.set(key, { host: session.host, sessions: [] });
+          }
+          byHost.get(key).sessions.push(session);
+        });
+
         return (
           <div key={project}>
-            <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 12, paddingBottom: 8, borderBottom: `1px solid ${pc}25` }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 10,
+                marginBottom: 12,
+                paddingBottom: 8,
+                borderBottom: `1px solid ${pc}25`,
+              }}
+            >
               <div style={{ width: 4, height: 16, borderRadius: 2, background: pc }} />
               <span style={{ fontSize: 12, fontWeight: 700, color: pc, letterSpacing: "0.06em" }}>{project}</span>
-              <span style={{ fontSize: 10, color: "#1e2535" }}>{running}/{projectTeams.length} running</span>
-              {totalPRs > 0 && <span style={{ fontSize: 10, color: pc, background: `${pc}18`, borderRadius: 3, padding: "1px 7px" }}>{totalPRs} PR{totalPRs !== 1 ? "s" : ""}</span>}
+              <span style={{ fontSize: 10, color: "#334155" }}>
+                {running}/{projectSessions.length} running
+              </span>
+              {totalPrs > 0 && (
+                <span
+                  style={{
+                    fontSize: 10,
+                    color: pc,
+                    background: `${pc}18`,
+                    borderRadius: 3,
+                    padding: "1px 7px",
+                  }}
+                >
+                  {totalPrs} PR{totalPrs !== 1 ? "s" : ""}
+                </span>
+              )}
             </div>
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 8 }}>
-              {projectTeams.map((team, i) => <GridCard key={i} team={team} onJump={onJump} />)}
+
+            <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+              {Array.from(byHost.values()).map(({ host, sessions: hostSessions }) => (
+                <div key={host?.id || `unknown-${hostSessions[0]?.host_id || "na"}`}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                    <span style={{ fontSize: 10, color: "#64748b", letterSpacing: "0.08em" }}>
+                      HOST {hostLabel(host).toUpperCase()}
+                    </span>
+                    <span style={{ fontSize: 10, color: host?.reachable ? "#10b981" : "#94a3b8" }}>
+                      {host?.reachable ? "reachable" : `last seen ${relativeTime(host?.last_seen)}`}
+                    </span>
+                  </div>
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+                      gap: 8,
+                    }}
+                  >
+                    {hostSessions.map((session, index) => (
+                      <GridCard key={`${session.name}-${index}`} session={session} onJump={onJump} />
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         );
@@ -226,106 +928,378 @@ function GroupedView({ teams, onJump }) {
 }
 
 export default function Dashboard() {
+  const baseUrl = useMemo(() => daemonBaseUrl(), []);
   const [view, setView] = useState("grouped");
   const [statusFilter, setStatusFilter] = useState("all");
   const [projectFilter, setProjectFilter] = useState("all");
   const [search, setSearch] = useState("");
   const [jumpTarget, setJumpTarget] = useState(null);
+  const [hosts, setHosts] = useState([]);
+  const [sessions, setSessions] = useState([]);
+  const [defaultTerminal, setDefaultTerminal] = useState("iterm2");
+  const [pollIntervalMs, setPollIntervalMs] = useState(DEFAULT_POLL_MS);
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
 
-  const projects = [...new Set(TEAMS.map(t => t.project))];
+  useEffect(() => {
+    let cancelled = false;
 
-  const filtered = TEAMS.filter(t => {
-    if (statusFilter === "running" && t.sessionStatus !== "running") return false;
-    if (statusFilter === "idle" && t.sessionStatus !== "idle") return false;
-    if (statusFilter === "stopped" && t.sessionStatus !== "stopped") return false;
-    if (projectFilter !== "all" && t.project !== projectFilter) return false;
-    if (search && !t.name.includes(search.toLowerCase())) return false;
-    return true;
-  });
+    async function loadConfig() {
+      try {
+        const response = await fetch(`${baseUrl}/dashboard-config.json`);
+        if (!response.ok) {
+          throw new Error(`dashboard-config HTTP ${response.status}`);
+        }
+        const config = await response.json();
+        if (cancelled) {
+          return;
+        }
+        if (Array.isArray(config.hosts)) {
+          setHosts(config.hosts);
+        }
+        if (typeof config.default_terminal === "string" && config.default_terminal.length > 0) {
+          setDefaultTerminal(config.default_terminal);
+        }
+        if (Number.isFinite(config.poll_interval_ms) && config.poll_interval_ms > 0) {
+          setPollIntervalMs(config.poll_interval_ms);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(`Failed to load dashboard config: ${String(error)}`);
+        }
+      }
+    }
 
-  const runningCount = TEAMS.filter(t => t.sessionStatus === "running").length;
-  const idleCount = TEAMS.filter(t => t.sessionStatus === "idle").length;
-  const stoppedCount = TEAMS.filter(t => t.sessionStatus === "stopped").length;
-  const activeAgents = TEAMS.flatMap(t => t.panes).filter(p => p.status === "active").length;
-  const openPRs = TEAMS.reduce((n, t) => n + t.prs.length, 0);
+    loadConfig();
+    return () => {
+      cancelled = true;
+    };
+  }, [baseUrl]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refresh() {
+      try {
+        const [sessionsResponse, hostsResponse] = await Promise.all([
+          fetch(`${baseUrl}/sessions`),
+          fetch(`${baseUrl}/hosts`),
+        ]);
+        if (!sessionsResponse.ok) {
+          throw new Error(`/sessions HTTP ${sessionsResponse.status}`);
+        }
+        if (!hostsResponse.ok) {
+          throw new Error(`/hosts HTTP ${hostsResponse.status}`);
+        }
+
+        const [sessionsBody, hostsBody] = await Promise.all([
+          sessionsResponse.json(),
+          hostsResponse.json(),
+        ]);
+        if (cancelled) {
+          return;
+        }
+
+        const hostRows = Array.isArray(hostsBody) ? hostsBody : [];
+        const hostMap = new Map(hostRows.map((host) => [host.id, host]));
+
+        const normalizedSessions = (Array.isArray(sessionsBody) ? sessionsBody : []).map((row) => {
+          const ciEntries = normalizeCi(row);
+          const prs = extractPrs(row, ciEntries);
+          const ciRuns = extractRuns(ciEntries);
+          return {
+            ...row,
+            status: row.status || "stopped",
+            project: row.project || "unassigned",
+            panes: normalizePanes(row),
+            ciEntries,
+            ciRuns,
+            prs,
+            openPrCount: extractOpenPrCount(row, ciEntries),
+            host: hostMap.get(row.host_id) || null,
+          };
+        });
+
+        setHosts(hostRows);
+        setSessions(normalizedSessions);
+        setErrorMessage(null);
+        setLastUpdated(new Date());
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(`Refresh failed: ${String(error)}`);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    refresh();
+    const timer = window.setInterval(refresh, pollIntervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [baseUrl, pollIntervalMs]);
+
+  const projects = useMemo(
+    () => [...new Set(sessions.map((session) => session.project).filter(Boolean))],
+    [sessions],
+  );
+
+  const filtered = useMemo(() => {
+    const searchText = search.trim().toLowerCase();
+    return sessions.filter((session) => {
+      if (statusFilter !== "all" && session.status !== statusFilter) {
+        return false;
+      }
+      if (projectFilter !== "all" && session.project !== projectFilter) {
+        return false;
+      }
+      if (searchText && !session.name.toLowerCase().includes(searchText)) {
+        return false;
+      }
+      return true;
+    });
+  }, [sessions, statusFilter, projectFilter, search]);
+
+  const runningCount = sessions.filter((session) => session.status === "running").length;
+  const idleCount = sessions.filter((session) => session.status === "idle").length;
+  const stoppedCount = sessions.filter((session) => session.status === "stopped").length;
+  const activeAgents = sessions
+    .flatMap((session) => session.panes)
+    .filter((pane) => pane.status === "active").length;
+  const openPrs = sessions.reduce((sum, session) => sum + session.openPrCount, 0);
 
   return (
-    <div style={{ background: "#060810", minHeight: "100vh", color: "#e2e8f0", fontFamily: "'Berkeley Mono', 'Fira Code', 'JetBrains Mono', monospace" }}>
+    <div
+      style={{
+        background: "#060810",
+        minHeight: "100vh",
+        color: "#e2e8f0",
+        fontFamily: "'Berkeley Mono', 'Fira Code', 'JetBrains Mono', monospace",
+      }}
+    >
       <style>{`
         @keyframes ping { 75%, 100% { transform: scale(2.2); opacity: 0; } }
         * { box-sizing: border-box; margin: 0; padding: 0; }
         input::placeholder { color: #1a2030; }
+        button { font-family: inherit; }
       `}</style>
 
-      {/* Top bar */}
-      <div style={{ borderBottom: "1px solid #0a0e14", padding: "12px 24px", display: "flex", alignItems: "center", gap: 20, position: "sticky", top: 0, background: "#060810", zIndex: 10 }}>
-        <div style={{ fontSize: 11, fontWeight: 800, color: "#475569", letterSpacing: "0.16em" }}>TEAM CONTROL</div>
-        <div style={{ width: 1, height: 14, background: "#131820" }} />
-        <div style={{ display: "flex", gap: 14, fontSize: 11 }}>
-          <span><span style={{ color: "#10b981" }}>{runningCount}</span><span style={{ color: "#1e2535" }}> run</span></span>
-          <span><span style={{ color: "#f59e0b" }}>{idleCount}</span><span style={{ color: "#1e2535" }}> idle</span></span>
-          <span><span style={{ color: "#1e2535" }}>{stoppedCount}</span><span style={{ color: "#131820" }}> off</span></span>
-          <span style={{ color: "#131820" }}>·</span>
-          <span><span style={{ color: "#10b981" }}>{activeAgents}</span><span style={{ color: "#1e2535" }}> agents</span></span>
-          <span style={{ color: "#131820" }}>·</span>
-          <span><span style={{ color: "#3b82f6" }}>{openPRs}</span><span style={{ color: "#1e2535" }}> PRs</span></span>
+      <div
+        style={{
+          borderBottom: "1px solid #0a0e14",
+          padding: "12px 24px",
+          display: "flex",
+          alignItems: "center",
+          gap: 20,
+          position: "sticky",
+          top: 0,
+          background: "#060810",
+          zIndex: 10,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 800, color: "#475569", letterSpacing: "0.16em" }}>
+          TEAM CONTROL
         </div>
-        <div style={{ flex: 1 }} />
-        <input value={search} onChange={e => setSearch(e.target.value)} placeholder="search sessions…"
-          style={{ background: "#0a0e14", border: "1px solid #131820", borderRadius: 5, padding: "5px 10px", fontSize: 11, color: "#94a3b8", outline: "none", width: 150 }} />
-        <div style={{ display: "flex", background: "#0a0e14", borderRadius: 5, border: "1px solid #131820", overflow: "hidden" }}>
-          {[["grid", "⊞ Grid"], ["list", "≡ List"], ["grouped", "❏ Project"]].map(([v, label]) => (
-            <button key={v} onClick={() => setView(v)} style={{
-              padding: "5px 12px", background: view === v ? "#1e2535" : "transparent",
-              border: "none", color: view === v ? "#cbd5e1" : "#334155", cursor: "pointer",
-              fontSize: 10, fontFamily: "inherit", letterSpacing: "0.04em", transition: "background 0.1s"
-            }}>{label}</button>
-          ))}
+        <div style={{ width: 1, height: 14, background: "#131820" }} />
+        <div style={{ display: "flex", gap: 14, fontSize: 11, flexWrap: "wrap" }}>
+          <span>
+            <span style={{ color: "#10b981" }}>{runningCount}</span>
+            <span style={{ color: "#1e2535" }}> run</span>
+          </span>
+          <span>
+            <span style={{ color: "#f59e0b" }}>{idleCount}</span>
+            <span style={{ color: "#1e2535" }}> idle</span>
+          </span>
+          <span>
+            <span style={{ color: "#94a3b8" }}>{stoppedCount}</span>
+            <span style={{ color: "#1e2535" }}> off</span>
+          </span>
+          <span style={{ color: "#131820" }}>.</span>
+          <span>
+            <span style={{ color: "#10b981" }}>{activeAgents}</span>
+            <span style={{ color: "#1e2535" }}> agents</span>
+          </span>
+          <span style={{ color: "#131820" }}>.</span>
+          <span>
+            <span style={{ color: "#3b82f6" }}>{openPrs}</span>
+            <span style={{ color: "#1e2535" }}> PRs</span>
+          </span>
+        </div>
+
+        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 10, color: "#475569" }}>poll {pollIntervalMs}ms</span>
+          {lastUpdated && (
+            <span style={{ fontSize: 10, color: "#475569" }}>updated {relativeTime(lastUpdated.toISOString())}</span>
+          )}
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="search sessions..."
+            style={{
+              background: "#0a0e14",
+              border: "1px solid #131820",
+              borderRadius: 5,
+              padding: "5px 10px",
+              fontSize: 11,
+              color: "#94a3b8",
+              outline: "none",
+              width: 180,
+            }}
+          />
+          <div
+            style={{
+              display: "flex",
+              background: "#0a0e14",
+              borderRadius: 5,
+              border: "1px solid #131820",
+              overflow: "hidden",
+            }}
+          >
+            {[
+              ["grid", "Grid"],
+              ["list", "List"],
+              ["grouped", "Project"],
+            ].map(([value, label]) => (
+              <button
+                key={value}
+                onClick={() => setView(value)}
+                style={{
+                  padding: "5px 12px",
+                  background: view === value ? "#1e2535" : "transparent",
+                  border: "none",
+                  color: view === value ? "#cbd5e1" : "#334155",
+                  cursor: "pointer",
+                  fontSize: 10,
+                  letterSpacing: "0.04em",
+                  transition: "background 0.1s",
+                }}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 
-      {/* Filter bar */}
-      <div style={{ padding: "8px 24px", borderBottom: "1px solid #0a0e14", display: "flex", gap: 5, flexWrap: "wrap", alignItems: "center" }}>
-        {["all", "running", "idle", "stopped"].map(f => (
-          <button key={f} onClick={() => setStatusFilter(f)} style={{
-            padding: "3px 8px", borderRadius: 4, fontSize: 10, cursor: "pointer", fontFamily: "inherit",
-            background: statusFilter === f ? "#131820" : "transparent",
-            border: statusFilter === f ? "1px solid #1e2535" : "1px solid transparent",
-            color: statusFilter === f ? "#94a3b8" : "#1e2535", letterSpacing: "0.04em"
-          }}>{f}</button>
+      <div
+        style={{
+          padding: "8px 24px",
+          borderBottom: "1px solid #0a0e14",
+          display: "flex",
+          gap: 5,
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
+        {["all", "running", "idle", "stopped"].map((filterValue) => (
+          <button
+            key={filterValue}
+            onClick={() => setStatusFilter(filterValue)}
+            style={{
+              padding: "3px 8px",
+              borderRadius: 4,
+              fontSize: 10,
+              cursor: "pointer",
+              background: statusFilter === filterValue ? "#131820" : "transparent",
+              border:
+                statusFilter === filterValue
+                  ? "1px solid #1e2535"
+                  : "1px solid transparent",
+              color: statusFilter === filterValue ? "#94a3b8" : "#1e2535",
+              letterSpacing: "0.04em",
+            }}
+          >
+            {filterValue}
+          </button>
         ))}
         <div style={{ width: 1, height: 12, background: "#131820", margin: "0 4px" }} />
-        <button onClick={() => setProjectFilter("all")} style={{
-          padding: "3px 8px", borderRadius: 4, fontSize: 10, cursor: "pointer", fontFamily: "inherit",
-          background: projectFilter === "all" ? "#131820" : "transparent",
-          border: projectFilter === "all" ? "1px solid #1e2535" : "1px solid transparent",
-          color: projectFilter === "all" ? "#94a3b8" : "#1e2535"
-        }}>all projects</button>
-        {projects.map(p => {
-          const pc = PROJECT_COLORS[p] || "#6b7280";
+        <button
+          onClick={() => setProjectFilter("all")}
+          style={{
+            padding: "3px 8px",
+            borderRadius: 4,
+            fontSize: 10,
+            cursor: "pointer",
+            background: projectFilter === "all" ? "#131820" : "transparent",
+            border:
+              projectFilter === "all"
+                ? "1px solid #1e2535"
+                : "1px solid transparent",
+            color: projectFilter === "all" ? "#94a3b8" : "#1e2535",
+          }}
+        >
+          all projects
+        </button>
+        {projects.map((project) => {
+          const pc = PROJECT_COLORS[project] || "#6b7280";
           return (
-            <button key={p} onClick={() => setProjectFilter(p)} style={{
-              padding: "3px 8px", borderRadius: 4, fontSize: 10, cursor: "pointer", fontFamily: "inherit",
-              background: projectFilter === p ? `${pc}15` : "transparent",
-              border: projectFilter === p ? `1px solid ${pc}40` : "1px solid transparent",
-              color: projectFilter === p ? pc : "#1e2535"
-            }}>{p}</button>
+            <button
+              key={project}
+              onClick={() => setProjectFilter(project)}
+              style={{
+                padding: "3px 8px",
+                borderRadius: 4,
+                fontSize: 10,
+                cursor: "pointer",
+                background: projectFilter === project ? `${pc}15` : "transparent",
+                border:
+                  projectFilter === project
+                    ? `1px solid ${pc}40`
+                    : "1px solid transparent",
+                color: projectFilter === project ? pc : "#1e2535",
+              }}
+            >
+              {project}
+            </button>
           );
         })}
       </div>
 
-      {/* Content */}
-      <div style={{ paddingTop: 20 }}>
-        {view === "grid" && (
-          <div style={{ padding: "0 24px 24px", display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))", gap: 10 }}>
-            {filtered.map((team, i) => <GridCard key={i} team={team} onJump={setJumpTarget} />)}
-          </div>
-        )}
-        {view === "list" && <ListView teams={filtered} onJump={setJumpTarget} />}
-        {view === "grouped" && <GroupedView teams={filtered} onJump={setJumpTarget} />}
-      </div>
+      {errorMessage && (
+        <div style={{ padding: "10px 24px", color: "#f87171", fontSize: 12 }}>{errorMessage}</div>
+      )}
 
-      <JumpModal team={jumpTarget} onClose={() => setJumpTarget(null)} />
+      {loading ? (
+        <div style={{ padding: "30px 24px", color: "#64748b", fontSize: 12 }}>Loading dashboard data...</div>
+      ) : (
+        <div style={{ paddingTop: 20 }}>
+          {view === "grid" && (
+            <div
+              style={{
+                padding: "0 24px 24px",
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+                gap: 10,
+              }}
+            >
+              {filtered.map((session, index) => (
+                <GridCard key={`${session.name}-${index}`} session={session} onJump={setJumpTarget} />
+              ))}
+            </div>
+          )}
+          {view === "list" && <ListView sessions={filtered} onJump={setJumpTarget} />}
+          {view === "grouped" && <GroupedView sessions={filtered} onJump={setJumpTarget} />}
+        </div>
+      )}
+
+      <JumpModal
+        baseUrl={baseUrl}
+        defaultTerminal={defaultTerminal}
+        session={jumpTarget}
+        onClose={() => setJumpTarget(null)}
+      />
+
+      {hosts.length === 0 && !loading && (
+        <div style={{ padding: "0 24px 24px", color: "#475569", fontSize: 11 }}>
+          No hosts reported by daemon.
+        </div>
+      )}
     </div>
   );
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,38 +25,26 @@ scmux provides:
 ```
 ┌─ Mac Studio ────────────────────────────────────────────┐
 │                                                         │
-│  scmux-daemon  (HTTP :7700)                               │
-│  ├── SQLite  ~/.config/scmux/scmux.db  (SSOT)              │
+│  Browser Dashboard + scmux CLI                          │
+│          │                                              │
+│          └───────────── HTTP :7878 ───────────────┐     │
+│                                                    ▼     │
+│  local scmux-daemon (aggregation + SSOT)                │
+│  ├── SQLite  ~/.config/scmux/scmux.db                   │
 │  ├── poll_loop        every 15s  → tmux ls              │
 │  ├── ci_loop          adaptive   → gh / az cli          │
 │  ├── health_loop      every 60s  → heartbeat            │
-│  └── axum HTTP server            → web + CLI clients    │
-│                                                         │
-│  Clients:                                               │
-│  ├── Browser  →  dashboard (static files from daemon)   │
-│  └── scmux CLI  →  same HTTP API                          │
+│  ├── host_loop        polls remote daemons              │
+│  └── axum HTTP server                                    │
 │                                                         │
 └──────────────────────────┬──────────────────────────────┘
-                           │ HTTP :7700
-┌─ DGX Spark ──────────────┼──────────────────────────────┐
-│  scmux-daemon  (HTTP :7700)│                               │
-│  SQLite  ~/.config/scmux/scmux.db                           │
+                           │ daemon-to-daemon polling
+                           │
+┌─ DGX Spark ──────────────▼──────────────────────────────┐
+│  remote scmux-daemon (HTTP :7878)                       │
+│  SQLite  ~/.config/scmux/scmux.db                       │
 │  ... (same structure)                                   │
-└──────────────────────────┼──────────────────────────────┘
-                           │
-                  ┌────────┴────────┐
-                  │  Browser        │
-                  │  Dashboard      │
-                  │  (polls all     │
-                  │   known hosts)  │
-                  └────────┬────────┘
-                           │ POST /sessions/:name/jump
-                           │
-                  ┌────────▼────────┐
-                  │  scmux-daemon     │
-                  │  spawns iTerm2  │
-                  │  returns status │
-                  └─────────────────┘
+└─────────────────────────────────────────────────────────┘
 ```
 
 ## 4. Components
@@ -214,7 +202,7 @@ Hosts are defined in `scmux.toml` (version-controlled, seeded into SQLite on fir
 
 ```toml
 [daemon]
-port = 7700
+port = 7878
 default_terminal = "iterm2"
 
 [[hosts]]
@@ -226,7 +214,7 @@ is_local = true
 name = "dgx-spark"
 address = "192.168.1.50"
 ssh_user = "randlee"
-api_port = 7700
+api_port = 7878
 ```
 
 #### VPN-gated hosts
@@ -287,7 +275,7 @@ scmux daemon status
 scmux daemon restart
 ```
 
-CLI connects to daemon at `http://localhost:7700` by default. Override with `SCMUX_HOST` env var or `--host` flag for managing remote hosts directly.
+CLI connects to daemon at `http://localhost:7878` by default. Override with `SCMUX_HOST` env var or `--host` flag for managing remote hosts directly.
 
 ### 4.6 Dashboard
 
@@ -299,15 +287,15 @@ The dashboard is configuration-aware via `GET /dashboard-config.json`:
 ```json
 {
   "hosts": [
-    { "name": "mac-studio", "url": "http://localhost:7700",     "is_local": true },
-    { "name": "dgx-spark",  "url": "http://192.168.1.50:7700", "is_local": false }
+    { "name": "mac-studio", "url": "http://localhost:7878",     "is_local": true },
+    { "name": "dgx-spark",  "url": "http://192.168.1.50:7878", "is_local": false }
   ],
   "default_terminal": "iterm2",
   "poll_interval_ms": 15000
 }
 ```
 
-Dashboard polls each host's `/sessions` endpoint independently. Unreachable hosts render in monochrome with last-known data and a "last seen N ago" indicator.
+Dashboard polls the local daemon only. The local daemon polls remote hosts, merges their latest cached session snapshots, and serves unified `/sessions` and `/hosts` responses. Unreachable hosts render in monochrome with last-known data and a "last seen N ago" indicator.
 
 ## 5. SQLite Schema Summary
 
@@ -330,7 +318,7 @@ One database per machine at `~/.config/scmux/scmux.db`. Schema applied via migra
 
 ```toml
 [daemon]
-port = 7700
+port = 7878
 db_path = "~/.config/scmux/scmux.db"
 default_terminal = "iterm2"
 log_level = "info"
@@ -350,7 +338,7 @@ is_local = true
 name     = "dgx-spark"
 address  = "192.168.1.50"
 ssh_user = "randlee"
-api_port = 7700
+api_port = 7878
 ```
 
 ## 7. Process Supervision

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -117,7 +117,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| API-01 | The daemon shall expose HTTP on a configurable port (default 7700) | 1.2 |
+| API-01 | The daemon shall expose HTTP on a configurable port (default 7878) | 1.2 |
 | API-02 | All responses shall be JSON | 1.2 |
 | API-03 | CORS shall be permissive | 1.2 |
 | API-04 | `GET /health` — daemon status, host_id, running count, timestamp | 1.2 |
@@ -192,7 +192,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 |----|-------------|--------|
 | CLI-01 | `scmux` shall be a separate binary from `scmux-daemon` | 3.2 |
 | CLI-02 | `scmux` shall communicate exclusively via the daemon HTTP API | 3.2 |
-| CLI-03 | Default daemon URL: `http://localhost:7700`; override with `SCMUX_HOST` env var or `--host` flag | 3.2 |
+| CLI-03 | Default daemon URL: `http://localhost:7878`; override with `SCMUX_HOST` env var or `--host` flag | 3.2 |
 | CLI-04 | `scmux list` — list sessions with status | 3.2 |
 | CLI-05 | `scmux show <name>` — full session detail | 3.2 |
 | CLI-06 | `scmux start <name>` — start session | 3.2 |

--- a/docs/sprint-specs/p2-s2-dashboard-test-checklist.md
+++ b/docs/sprint-specs/p2-s2-dashboard-test-checklist.md
@@ -1,0 +1,88 @@
+# Sprint 2.2 Dashboard Manual Test Checklist
+
+This checklist maps `T-UI-01..T-UI-17` to explicit manual verification steps.
+
+## T-UI-01 Grid view renders all sessions
+- Precondition: daemon running with at least 3 sessions.
+- Action: open dashboard, click `Grid` view.
+- Expected: one card per session currently returned by `GET /sessions`.
+
+## T-UI-02 List view renders all sessions in table
+- Precondition: daemon running with at least 3 sessions.
+- Action: click `List` view.
+- Expected: table rows match session count from `GET /sessions`.
+
+## T-UI-03 Grouped view groups by project
+- Precondition: sessions exist across at least 2 projects.
+- Action: click `Project` view.
+- Expected: sessions are grouped under project headers with per-project summary counts.
+
+## T-UI-04 Status filters work correctly
+- Precondition: dataset includes `running`, `idle`, and `stopped` sessions.
+- Action: click each status filter (`running`, `idle`, `stopped`).
+- Expected: only sessions with selected status remain visible.
+
+## T-UI-05 Project filter shows only correct sessions
+- Precondition: sessions exist in at least 2 projects.
+- Action: select one project filter chip.
+- Expected: only sessions for that project are shown.
+
+## T-UI-06 Search filters by name substring
+- Precondition: at least one session has a distinct name substring.
+- Action: type substring in search input.
+- Expected: visible sessions are limited to names containing substring (case-insensitive).
+
+## T-UI-07 Clicking session opens jump modal
+- Precondition: at least one session is visible.
+- Action: click any session card/row.
+- Expected: jump modal opens for that session.
+
+## T-UI-08 Modal shows correct pane list
+- Precondition: target session has pane data in `panes` array.
+- Action: open jump modal for target session.
+- Expected: pane names and statuses match current session pane payload.
+
+## T-UI-09 Modal shows correct PR badges with links
+- Precondition: target session has GitHub PR metadata in session CI payload.
+- Action: open jump modal.
+- Expected: PR badges/list show expected PR numbers/titles and links open in new tab.
+
+## T-UI-10 Modal "Open in iTerm2" sends POST /jump and shows feedback
+- Precondition: daemon reachable; target session exists.
+- Action: click `Open in iTerm2 ->` in modal.
+- Expected: `POST /sessions/:name/jump` is sent to daemon, and modal displays daemon `message` response.
+
+## T-UI-11 Stopped sessions are visually de-emphasized
+- Precondition: at least one session status is `stopped`.
+- Action: observe stopped session in any view.
+- Expected: stopped session has reduced visual emphasis (lower opacity).
+
+## T-UI-12 Unreachable host sessions render in monochrome
+- Precondition: at least one host is reported `reachable=false` by `GET /hosts`.
+- Action: observe sessions mapped to that host.
+- Expected: those sessions render with grayscale/monochrome styling.
+
+## T-UI-13 "Last seen N ago" shows for unreachable hosts
+- Precondition: unreachable host has non-null `last_seen`.
+- Action: inspect grouped host header and/or session host status labels.
+- Expected: text shows `last seen <relative time>`.
+
+## T-UI-14 Full color resumes when host returns
+- Precondition: host transitions from unreachable to reachable in `/hosts`.
+- Action: wait for next poll interval or trigger refresh.
+- Expected: sessions for that host return to full color rendering.
+
+## T-UI-15 Tool-unavailable CI badges show install tooltip
+- Precondition: session CI entry has `status="tool_unavailable"` and message.
+- Action: hover tool-unavailable badge.
+- Expected: tooltip displays install/help message from daemon payload.
+
+## T-UI-16 Escape key closes modal
+- Precondition: jump modal is open.
+- Action: press `Escape`.
+- Expected: modal closes.
+
+## T-UI-17 Header counts match data
+- Precondition: sessions include mixed statuses and pane activity.
+- Action: compare header counters with computed values from current sessions payload.
+- Expected: running/idle/stopped/active-agents/open-PR counts are correct.

--- a/docs/sprint-specs/p3-s2-cli.md
+++ b/docs/sprint-specs/p3-s2-cli.md
@@ -46,8 +46,9 @@ agent-team-b    stopped   dgx-spark  0 9 * * *   work
 agent-team-c    running   local      —           main
 ```
 
-- `CRON/AUTO`: shows cron expression if set; `auto` if `auto_start=1` and no cron; `—` otherwise.
-- `WINDOW`: active tmux window name, or `—` if session is stopped.
+- `CRON/AUTO`: shows cron expression if set. If no cron is set and `auto_start=1`, shows `auto`; otherwise shows `—`.
+  If both cron and auto-start are configured, cron is shown (cron takes precedence in display).
+- `WINDOW`: active tmux window name proxy derived from pane metadata (`pane.name`) until daemon adds a dedicated window field; `—` if session is stopped.
 - `--json` flag (future scope, not MVP): outputs raw JSON from `GET /sessions`.
 
 ### Error behavior


### PR DESCRIPTION
## Summary

Reconciles main branch (which had 5 direct release-hotfix commits) with develop (Phase 2+3 complete). Supersedes PR #12.

### Included in this release (v0.2.0)

**Phase 2:**
- S2.1: Multi-host reachability — per-host health polling, `/hosts` with `reachable`/`last_seen`, monochrome for unreachable hosts
- S2.2: Live dashboard — wired to daemon APIs, clickable CI badges with PR links, jump modal, grid/list/grouped views, combinable filters

**Phase 3:**
- S3.1: CI integration — `gh`/`az` polling, adaptive scheduling (1min active / 5min idle), graceful `tool_unavailable` handling
- S3.2: `scmux` CLI — `list`, `show`, `start`, `stop`, `jump`, `add`, `edit`, `disable`, `enable`, `remove`, `hosts`, `daemon status`

**Release workflow fixes (from hotfixes):**
- Targets: aarch64-apple-darwin, x86_64-unknown-linux-gnu, x86_64-pc-windows-msvc
- Windows packaging via PowerShell `Compress-Archive`
- crates.io publish dropped (dashboard `include_str!` outside crate boundary)

### QA
All 4 sprints passed dual QA gate (rust-qa + scmux-qa). All blocking findings resolved before merge.

## Test plan
- [ ] `cargo build --workspace` succeeds
- [ ] `scmux-daemon` starts and `/health` responds  
- [ ] `scmux list` shows sessions
- [ ] Dashboard loads at `http://localhost:7878`

🤖 Generated with [Claude Code](https://claude.com/claude-code)