### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "scmux"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "scmux-daemon"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["scmux contributors"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps workspace version from 0.3.0 to 0.4.1 for release

## Test plan
- [ ] CI passes (cargo check, clippy, format, perf-gate)
- [ ] After merge, tag v0.4.1 on main to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)