### PR TITLE
docs: definition-first architecture and writer-gate requirements

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,10 +14,11 @@ Primary value: show all defined projects at once (running or stopped), expose pe
 
 2. Exactly one persistent writer subsystem exists.
 - Multiple editor entry points are allowed (`New Project`, `Project Editor`, card-level `Edit`), but all persistent writes must route through the same writer subsystem.
+- Compile boundary is enforced via Rust visibility: persistent-write functions in `db.rs` are restricted (`pub(crate)`/`pub(super)`) and callable only from `definition_writer`.
 - All pollers and runtime loops are SQLite read-only.
 
 3. Approved-project write policy is mandatory.
-- Any persistent write must validate that target project is approved.
+- Any persistent write must validate that target project is approved (`enabled = 1` and non-empty `config_json.panes[]` created via editor flow).
 
 4. Discovery is read-only.
 - Raw tmux discovery is informational and never mutates project definitions.
@@ -49,6 +50,8 @@ Runtime projection
   -> Dashboard + CLI
 ```
 
+P6 decision: runtime cache tables (`session_status`, `session_ci`, `session_atm`) are replaced by in-memory projection for runtime display paths.
+
 ## 4. Module Responsibilities
 
 ### 4.1 `definition_writer` (new/central)
@@ -74,13 +77,14 @@ Runtime projection
 
 ### 4.5 `atm.rs`
 - Reads ATM socket runtime state per agent.
-- Maps per-pane state via `config_json` (`atm_agent`, `atm_team`).
+- Maps per-pane state via canonical key (`pane.atm_team`, `pane.atm_agent`).
 - Permanent roster changes are editor-driven writes only.
 
 ### 4.6 `api.rs`
 - Read endpoints expose aggregated runtime + persisted definitions.
 - Action endpoints (`start/stop/jump`) control runtime only.
 - Persistent writes are only via definition-editor endpoints.
+- Discovery endpoint is explicit: `GET /discovery` for read-only raw tmux view.
 
 ## 5. Session Lifecycle Model
 
@@ -90,9 +94,10 @@ State machine:
 
 - `stopped`: project exists in definitions; runtime session absent.
 - `starting`: launch requested; tmux/agents being created.
+- `starting` failure edge: if tmux/session creation or pane launch fails, transition back to `stopped` with structured error details.
 - `running`: tmux exists and at least one pane agent is ATM-active.
 - `idle`: tmux exists; all pane agents idle/offline.
-- `done`: semantics and auto-teardown policy are intentionally unresolved and remain non-destructive by default.
+- `done`: semantics and auto-teardown policy are intentionally unresolved; no transition-in path is required in P6 and behavior remains non-destructive by default.
 
 ## 6. Key Flows
 
@@ -123,7 +128,7 @@ State machine:
 - Running projects show per-pane ATM + CI runtime status.
 
 ### 7.2 Secondary View
-- Raw tmux discovery tab.
+- Raw tmux discovery tab backed by `GET /discovery`.
 - Informational only, no persistence side effects.
 
 ## 8. Definition Schema (`config_json`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,9 @@ P6 decision: runtime cache tables (`session_status`, `session_ci`, `session_atm`
 - Reads remote daemon health/runtime snapshots.
 - Aggregates reachability and stale status for dashboard.
 - No persistent writes from discovery.
+- In-memory projection retains last-known remote session snapshots across consecutive failed poll cycles.
+- `last_seen` is updated on each successful poll in-memory for display.
+- Runtime host projection data is lost on daemon restart (acceptable for P6).
 
 ### 4.4 `ci.rs`
 - Reads CI status from `gh`/`az`.
@@ -92,7 +95,11 @@ State machine:
 
 `stopped -> starting -> running -> idle -> done`
 
-- `stopped`: project exists in definitions; runtime session absent.
+Additional explicit stop edges:
+- `running -> stopped` via `POST /sessions/:name/stop`.
+- `idle -> stopped` via `POST /sessions/:name/stop`.
+
+- `stopped`: entered when (1) project is defined but never started, or (2) session is stopped from `running`/`idle`.
 - `starting`: launch requested; tmux/agents being created.
 - `starting` failure edge: if tmux/session creation or pane launch fails, transition back to `stopped` with structured error details.
 - `running`: tmux exists and at least one pane agent is ATM-active.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,440 +1,194 @@
 # scmux — Architecture
 
-## 1. Purpose
+## 1. Product Architecture (Target)
 
-scmux solves a specific problem: when running 20–30 concurrent Claude Code agent teams across multiple machines and terminal emulators, there is no single place to see what is running, find a session by name, or jump to it instantly.
+scmux is a multi-team operations dashboard and launcher for AI agent teams.
 
-scmux provides:
-- A **daemon** per machine — sole owner of SQLite, session lifecycle, CI polling, and terminal launch
-- A **web dashboard** — browser UI, read/command only, talks to daemon via HTTP
-- A **CLI** (`scmux`) — shell client, same HTTP API as the web UI
-- **Graceful degradation** — missing tools, unreachable hosts, and VPN gaps are normal operating conditions, not errors
+Primary value: show all defined projects at once (running or stopped), expose per-agent runtime state, show CI health, and start/stop safely without requiring a terminal window.
 
-## 2. Core Design Principles
+## 2. Hard Invariants
 
-**Daemon is the single source of truth.** All state lives in SQLite. Only the daemon writes to SQLite. The CLI and web UI are pure clients — they send commands to the daemon and read responses. This keeps the system in sync regardless of how many clients are connected simultaneously.
+1. SQLite is a definition store only.
+- Stores user-approved project/host/roster definitions.
+- Does not auto-ingest tmux discovery.
 
-**Browser → daemon → terminal.** The web UI never launches processes directly. A "jump" button click sends `POST /sessions/:name/jump` to the daemon, which spawns the terminal. This eliminates race conditions and stale state from multiple browser tabs.
+2. Exactly one persistent writer subsystem exists.
+- Multiple editor entry points are allowed (`New Project`, `Project Editor`, card-level `Edit`), but all persistent writes must route through the same writer subsystem.
+- All pollers and runtime loops are SQLite read-only.
 
-**Unavailability is normal.** A host behind a VPN that goes offline is not an error — it is an expected state. The dashboard shows last known data in monochrome. When the host returns, it resumes full color automatically.
+3. Approved-project write policy is mandatory.
+- Any persistent write must validate that target project is approved.
 
-**Missing tools degrade gracefully.** If `gh` or `az` CLI are not installed, CI status shows "unavailable" with a tooltip explaining what to install. The rest of the system works normally.
+4. Discovery is read-only.
+- Raw tmux discovery is informational and never mutates project definitions.
 
-## 3. System Diagram
+5. Safety-first session control.
+- Stop is graceful-first (ATM shutdown request), then scoped hard-stop only if needed.
+- Panic/error paths must not bulk-stop unrelated sessions.
 
-```
-┌─ Mac Studio ────────────────────────────────────────────┐
-│                                                         │
-│  Browser Dashboard + scmux CLI                          │
-│          │                                              │
-│          └───────────── HTTP :7878 ───────────────┐     │
-│                                                    ▼     │
-│  local scmux-daemon (aggregation + SSOT)                │
-│  ├── SQLite  ~/.config/scmux/scmux.db                   │
-│  ├── poll_loop        every 15s  → tmux ls              │
-│  ├── ci_loop          adaptive   → gh / az cli          │
-│  ├── health_loop      every 60s  → heartbeat            │
-│  ├── host_loop        polls remote daemons              │
-│  └── axum HTTP server                                    │
-│                                                         │
-└──────────────────────────┬──────────────────────────────┘
-                           │ daemon-to-daemon polling
-                           │
-┌─ DGX Spark ──────────────▼──────────────────────────────┐
-│  remote scmux-daemon (HTTP :7878)                       │
-│  SQLite  ~/.config/scmux/scmux.db                       │
-│  ... (same structure)                                   │
-└─────────────────────────────────────────────────────────┘
-```
+6. Runtime state is live/ephemeral.
+- Runtime status is refreshed continuously for UI/CLI display.
+- Runtime status is not persisted as definition truth.
 
-## 4. Components
+## 3. Runtime Data Flow
 
-### 4.1 scmux-daemon
+```text
+User Form/Edit Action
+  -> Definition Write Module (only persistent writer)
+  -> SQLite definitions (projects/hosts/approved roster)
 
-**Language:** Rust
-**Binary:** `scmux-daemon`
-**Owns:** SQLite database, tmux lifecycle, CI polling, terminal launch, HTTP server, static file serving
+Pollers (read-only persistence)
+  -> tmux_poller reads tmux runtime
+  -> atm_poller reads ATM socket runtime
+  -> ci_poller reads gh/az runtime
+  -> hosts_poller reads remote health/runtime
 
-#### Internal task structure
-
-```
-main()
-  ├── spawn: poll_loop        every 15s
-  │     └── scheduler::poll_cycle()
-  │           ├── tmux::live_sessions()
-  │           ├── update session_status
-  │           ├── detect stops → session_events
-  │           ├── check auto_start → tmuxp load
-  │           └── check cron_schedule → tmuxp load
-  │
-  ├── spawn: ci_loop          adaptive interval
-  │     └── ci::poll_all_sessions()
-  │           ├── for each session with github_repo → gh pr list / gh run list
-  │           ├── for each session with azure_project → az pipelines list
-  │           ├── write results to session_ci table
-  │           └── adjust next interval based on agent activity
-  │
-  ├── spawn: health_loop      every 60s
-  │     └── db::write_health()
-  │
-  └── axum::serve
-        ├── GET  /                         → serve dashboard HTML
-        ├── GET  /dashboard-config.json    → host list + settings
-        ├── GET  /health
-        ├── GET  /sessions
-        ├── GET  /sessions/:name
-        ├── POST /sessions/:name/start
-        ├── POST /sessions/:name/stop
-        └── POST /sessions/:name/jump      → spawn terminal
+Runtime projection
+  -> in-memory aggregate session/project view
+  -> HTTP API
+  -> Dashboard + CLI
 ```
 
-#### Shared state
+## 4. Module Responsibilities
 
-```rust
-pub struct AppState {
-    pub db:          Mutex<rusqlite::Connection>,
-    pub db_path:     String,
-    pub host_id:     i64,
-    pub config:      Config,   // loaded from scmux.toml at startup
-    pub started_at:  Instant,
-}
-```
+### 4.1 `definition_writer` (new/central)
+- Only module allowed to persist project definitions.
+- Can be invoked by multiple editor UX entry points.
+- Handles create/edit/delete for projects/hosts/approved roster changes.
+- Enforces approved-project constraints.
 
-Only the daemon writes to SQLite. HTTP handlers read from `session_status` (written by poll_loop). Start/stop/jump handlers call subprocess, then write events.
+### 4.2 `tmux_poller` (rename target for current `scheduler.rs`)
+- Reads tmux session/pane runtime state.
+- Computes runtime state (`stopped|starting|running|idle|done`) for API projection.
+- No persistent writes.
 
-`GET /health` returns:
-- `status`
-- `uptime_secs`
-- `session_count`
-- `db_path`
-- `version`
+### 4.3 `hosts.rs`
+- Reads remote daemon health/runtime snapshots.
+- Aggregates reachability and stale status for dashboard.
+- No persistent writes from discovery.
 
-### 4.2 Jump Flow
+### 4.4 `ci.rs`
+- Reads CI status from `gh`/`az`.
+- Produces runtime snapshot list per project (PRs + run statuses).
+- No persistent writes from CI polling.
 
-The browser never launches terminals. The daemon does.
+### 4.5 `atm.rs`
+- Reads ATM socket runtime state per agent.
+- Maps per-pane state via `config_json` (`atm_agent`, `atm_team`).
+- Permanent roster changes are editor-driven writes only.
 
-```
-1. User clicks "Jump" in dashboard
-2. Browser sends:  POST /sessions/ui-template/jump
-                   Body: { "terminal": "iterm2" }
-3. Daemon:
-   a. Looks up session → host (local or remote)
-   b. Constructs command:
-      Local:  tmux attach -t ui-template
-      Remote: ssh user@host tmux attach -t ui-template
-   c. Spawns iTerm2 with that command (via AppleScript or open)
-   d. Returns: { "ok": true, "message": "launched iTerm2" }
-4. Dashboard shows success/failure toast
-```
+### 4.6 `api.rs`
+- Read endpoints expose aggregated runtime + persisted definitions.
+- Action endpoints (`start/stop/jump`) control runtime only.
+- Persistent writes are only via definition-editor endpoints.
 
-#### iTerm2 launch (macOS)
+## 5. Session Lifecycle Model
 
-```bash
-# Local session
-osascript -e '
-  tell application "iTerm2"
-    create window with default profile
-    tell current session of current window
-      write text "tmux attach -t ui-template"
-    end tell
-  end tell
-'
+State machine:
 
-# Remote session
-osascript -e '
-  tell application "iTerm2"
-    create window with default profile
-    tell current session of current window
-      write text "ssh user@dgx-spark tmux attach -t rust-imgproc"
-    end tell
-  end tell
-'
-```
+`stopped -> starting -> running -> idle -> done`
 
-This approach gives a clean new iTerm2 window with the session attached, no URI scheme required, no race conditions.
+- `stopped`: project exists in definitions; runtime session absent.
+- `starting`: launch requested; tmux/agents being created.
+- `running`: tmux exists and at least one pane agent is ATM-active.
+- `idle`: tmux exists; all pane agents idle/offline.
+- `done`: semantics and auto-teardown policy are intentionally unresolved and remain non-destructive by default.
 
-#### Future terminal support
+## 6. Key Flows
 
-WezTerm and Warp support added later via the same `POST /sessions/:name/jump` endpoint — just different spawn logic in the daemon. The `terminal` field in the request selects the handler. Default terminal configured in `scmux.toml`.
+### 6.1 Start
+`POST /sessions/:name/start`
+1. Read `config_json` definition from SQLite.
+2. Create tmux session/window/pane layout.
+3. Launch each pane command.
+4. Publish runtime transitions to API/dashboard.
 
-### 4.3 CI Integration
+### 6.2 Stop
+`POST /sessions/:name/stop`
+1. Send ATM shutdown signal/message to configured agents.
+2. Wait configurable grace period.
+3. If still running, apply scoped hard-stop to target session only (exact retries/timeouts are product-configurable and pending finalization).
+4. Never kill unrelated sessions.
 
-#### Providers
+### 6.3 Jump
+`POST /sessions/:name/jump`
+- Opens iTerm (or selected terminal) as a viewer.
+- Attach/detach does not control lifecycle.
 
-| Provider | CLI | Column | Status when missing |
-|----------|-----|--------|-------------------|
-| GitHub | `gh` | `github_repo` | "unavailable" + tooltip |
-| Azure DevOps | `az` | `azure_project` | "unavailable" + tooltip |
+## 7. Views
 
-Both are optional. Sessions can have one, both, or neither.
+### 7.1 Primary View
+- All defined projects from SQLite.
+- Includes stopped projects with Start affordance.
+- Running projects show per-pane ATM + CI runtime status.
 
-#### Adaptive polling interval
+### 7.2 Secondary View
+- Raw tmux discovery tab.
+- Informational only, no persistence side effects.
 
-CI polling frequency adapts based on agent activity:
-
-```
-if any pane in session has status = "active":
-    poll_interval = 1 minute   (agents working → PRs/pipelines changing)
-else:
-    poll_interval = 5 minutes  (idle → less frequent)
-```
-
-Each session tracks its own next poll time in `session_ci.next_poll_at`.
-
-#### Data collected
-
-Per session, per provider:
-- Open PRs: number, title, URL, author, draft flag
-- Pipeline/action runs: status (passing/failing/running), branch, timestamp
-
-Stored in `session_ci` table as JSON blobs with `provider`, `polled_at`, `next_poll_at`.
-
-#### Missing tool handling
-
-On daemon startup, check for `gh` and `az` in PATH. Store availability in `AppState`. When a session has `github_repo` set but `gh` is unavailable, `session_ci` gets:
+## 8. Definition Schema (`config_json`)
 
 ```json
 {
-  "provider": "github",
-  "status": "tool_unavailable",
-  "message": "Install gh CLI: brew install gh"
-}
-```
-
-Dashboard renders this as a grayed badge with tooltip.
-
-### 4.4 Multi-Host Management
-
-#### Host discovery
-
-Hosts are defined in `scmux.toml` (version-controlled, seeded into SQLite on first run). Once in SQLite, the daemon monitors them actively.
-
-```toml
-[daemon]
-port = 7878
-default_terminal = "iterm2"
-
-[[hosts]]
-name = "mac-studio"
-address = "localhost"
-is_local = true
-
-[[hosts]]
-name = "dgx-spark"
-address = "192.168.1.50"
-ssh_user = "randlee"
-api_port = 7878
-```
-
-#### VPN-gated hosts
-
-Hosts that go offline (VPN disconnect, machine sleep, network change) are **normal operating conditions**, not errors. The daemon handles this as follows:
-
-```
-poll remote host /health:
-  success → update last_seen, show full color, merge fresh data
-  timeout/error → do NOT update last_seen, keep last known data
-                   mark host as "unreachable" in memory (not SQLite)
-
-dashboard receives:
-  host.reachable = false → render all sessions in monochrome
-  host.reachable = true  → render in full color
-  host.last_seen         → show "last seen 4m ago" in host header
-```
-
-No error dialogs. No red alerts. Monochrome = "we have stale data, host is away."
-
-When the host returns (VPN reconnects, machine wakes), the next poll cycle picks it up automatically and resumes full color.
-
-### 4.5 scmux CLI
-
-**Binary:** `scmux` (separate from `scmux-daemon`)
-**Talks to:** `scmux-daemon` HTTP API (same endpoints as web UI)
-
-The CLI is a thin HTTP client. All business logic lives in the daemon.
-
-```bash
-# Session management
-scmux list                          # all sessions + status
-scmux list --project radiant-p3     # filtered
-scmux show ui-template              # full detail + recent events
-scmux start ui-template
-scmux stop ui-template
-scmux jump ui-template              # daemon launches iTerm2
-
-# Session registration
-scmux add --name ui-template \
-        --project radiant-p3 \
-        --config ./ui-template.json \
-        --auto-start
-
-scmux edit ui-template --cron "0 9 * * 1-5"
-scmux disable ui-template
-scmux enable ui-template
-scmux remove ui-template
-
-# Host management
-scmux hosts                         # list hosts + reachability
-scmux host add --name dgx-spark \
-             --address 192.168.1.50 \
-             --ssh-user randlee
-
-# Daemon control
-scmux daemon status
-scmux daemon restart
-```
-
-CLI connects to daemon at `http://localhost:7878` by default. Override with `SCMUX_HOST` env var or `--host` flag for managing remote hosts directly.
-
-### 4.6 Dashboard
-
-**Served by:** `scmux-daemon` as static files at `/`
-**Framework:** React (single JSX file for dev; Vite build for production embedding)
-
-The dashboard is configuration-aware via `GET /dashboard-config.json`:
-
-```json
-{
-  "hosts": [
-    { "name": "mac-studio", "url": "http://localhost:7878",     "is_local": true },
-    { "name": "dgx-spark",  "url": "http://192.168.1.50:7878", "is_local": false }
+  "panes": [
+    {
+      "name": "team-lead",
+      "command": "claude --profile team-lead",
+      "atm_agent": "team-lead",
+      "atm_team": "scmux-dev"
+    },
+    {
+      "name": "arch-cmux",
+      "command": "codex --profile arch-cmux",
+      "atm_agent": "arch-cmux",
+      "atm_team": "scmux-dev"
+    }
   ],
-  "default_terminal": "iterm2",
-  "poll_interval_ms": 15000
+  "repo": "/Users/randlee/Documents/github/scmux",
+  "window_layout": "even-horizontal",
+  "atm_team": "scmux-dev"
 }
 ```
 
-Dashboard polls the local daemon only. The local daemon polls remote hosts, merges their latest cached session snapshots, and serves unified `/sessions` and `/hosts` responses. Unreachable hosts render in monochrome with last-known data and a "last seen N ago" indicator.
+## 9. Observability Direction
 
-## 5. SQLite Schema Summary
+Current logging should remain structured and stable with OpenTelemetry in mind.
 
-One database per machine at `~/.config/scmux/scmux.db`. Schema applied via migration on daemon startup.
+Required now:
+- Correlation identifiers on lifecycle/action events.
+- Consistent key/value fields for session/project/agent/host.
+- Log/event schema that can be mapped to OTel traces/spans without redesign.
 
-| Table | Purpose | Written by |
-|-------|---------|-----------|
-| `hosts` | Known machines | daemon (seeded from scmux.toml) |
-| `sessions` | Session definitions + configs | daemon (via CLI/API) |
-| `session_status` | Live tmux state | poll_loop only |
-| `session_events` | Immutable start/stop log | poll_loop + API handlers |
-| `session_ci` | CI/PR status per session | ci_loop only |
-| `daemon_health` | Heartbeat, 7-day retention | health_loop only |
+## 10. Prohibited Behaviors
 
-**Only the daemon writes to SQLite.** CLI and web UI read via HTTP.
+- Auto-writing project definitions from tmux discovery.
+- Reconstructing deleted definitions from live tmux.
+- Poller-based persistent writes (tmux/hosts/ci/atm loops).
+- Session-level-only ATM model as final representation.
+- Panic/error bulk-stop behavior.
 
-## 6. Configuration
+## 11. Refactor Scope (Code Conflicts to Remove)
 
-`~/.config/scmux/scmux.toml` — loaded at daemon startup, seeds SQLite if tables are empty.
+Conflicting current modules and expected direction:
 
-```toml
-[daemon]
-port = 7878
-db_path = "~/.config/scmux/scmux.db"
-default_terminal = "iterm2"
-log_level = "info"
+- `scheduler.rs`
+  - Remove discovery-to-definition persistence and reconstruction logic.
+  - Rename responsibility toward read-only runtime polling (`tmux_poller`).
 
-[polling]
-tmux_interval_secs = 15
-health_interval_secs = 60
-ci_active_interval_secs = 60
-ci_idle_interval_secs = 300
+- `hosts.rs`
+  - Remove remote discovery persistence paths.
+  - Keep health/runtime aggregation only.
 
-[[hosts]]
-name    = "mac-studio"
-address = "localhost"
-is_local = true
+- `ci.rs`
+  - Remove CI snapshot persistence writes.
+  - Keep runtime CI projection only.
 
-[[hosts]]
-name     = "dgx-spark"
-address  = "192.168.1.50"
-ssh_user = "randlee"
-api_port = 7878
-```
+- `atm.rs`
+  - Remove autonomous persistent runtime writes.
+  - Keep per-pane runtime mapping; route roster persistence through editor.
 
-## 7. Process Supervision
+- `api.rs`
+  - Ensure only definition-editor routes can persist data.
+  - Keep start/stop/jump as runtime control paths.
 
-The daemon is a long-running process. Supervision keeps it alive across reboots and crashes.
-
-### macOS (launchd)
-
-`~/Library/LaunchAgents/com.scmux.scmux-daemon.plist`:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>com.scmux.scmux-daemon</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/bin/scmux-daemon</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>/tmp/scmux-daemon.log</string>
-  <key>StandardErrorPath</key><string>/tmp/scmux-daemon.err</string>
-</dict>
-</plist>
-```
-
-```bash
-launchctl load ~/Library/LaunchAgents/com.scmux.scmux-daemon.plist
-```
-
-### Linux (systemd)
-
-```ini
-[Unit]
-Description=scmux-daemon
-After=network.target
-
-[Service]
-ExecStart=/usr/local/bin/scmux-daemon
-Restart=always
-RestartSec=5
-
-[Install]
-WantedBy=default.target
-```
-
-## 8. Build Layout
-
-```
-scmux/
-├── crates/
-│   ├── scmux-daemon/      # Cargo workspace member — HTTP daemon + SQLite
-│   └── scmux/             # Cargo workspace member — CLI client
-├── dashboard/           # React source (built output embedded in scmux-daemon)
-├── docs/
-│   ├── architecture.md
-│   ├── requirements.md
-│   ├── schema.sql
-│   └── example-session.json
-├── Cargo.toml           # workspace root
-└── scmux.toml.example     # reference config
-```
-
-```bash
-# Build everything
-cargo build --release --workspace
-
-# Install
-cp target/release/scmux-daemon /usr/local/bin/
-cp target/release/scmux       /usr/local/bin/
-
-# Run
-scmux-daemon
-```
-
-## 9. Future Work
-
-| Item | Notes |
-|------|-------|
-| WezTerm jump | AppleScript equivalent or `wezterm` CLI via daemon |
-| Warp jump | Monitor for URI scheme support |
-| Browser terminal | ttyd integration for remote sessions without local terminal |
-| Dashboard build pipeline | Embed built React into scmux-daemon binary via `include_str!` |
-| `scmux edit` TUI | Interactive session config editor |
-| Azure DevOps deep integration | PR links, pipeline status, work items |
-| Host auto-discovery | mDNS broadcast from daemon |
-| Session templates | Parameterized configs for spinning up new teams quickly |
+This architecture supersedes earlier discovery-first assumptions.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-scmux is delivered in four phases with explicit integration branches and version targets.
+scmux is delivered in six phases with explicit integration branches and version targets.
 
 | Phase | Theme | Target Version | Integration Branch |
 |-------|-------|----------------|--------------------|
@@ -10,6 +10,8 @@ scmux is delivered in four phases with explicit integration branches and version
 | 2 | Multi-host + Dashboard | 0.2.0 | `integrate/phase-2` |
 | 3 | CI + CLI | 0.3.0 | `integrate/phase-3` |
 | 4 | Supervision + Release | 0.3.0 | `integrate/phase-4` |
+| 5 | Dashboard Embed + Release Automation + ATM Activity | 0.4.x | `integrate/phase-5` |
+| 6 | Definition-First Architecture Realignment | 0.5.0 | `integrate/phase-6` (planned) |
 
 ## Execution Model
 
@@ -46,6 +48,10 @@ scmux is delivered in four phases with explicit integration branches and version
 | S3.2 | Pending |
 | S4.1 | Pending |
 | S4.2 | Pending |
+| S5.1 | Complete |
+| S5.2 | Complete |
+| S5.3 | Complete |
+| S6.0 | In Progress (requirements/architecture realignment) |
 
 ## Sprint S0 — Foundation (Complete)
 
@@ -235,6 +241,43 @@ scmux is delivered in four phases with explicit integration branches and version
 - Requirement IDs: `T-E-01..T-E-11`, `AC-1..AC-10`.
 - Detailed spec: [docs/sprint-specs/p4-s2-release.md](./sprint-specs/p4-s2-release.md)
 
+## Phase 5 — Dashboard Embed + Release Automation + ATM Activity (Complete)
+
+**Goal:** make dashboard self-contained for packaging, automate Homebrew updates, and add ATM activity visibility.
+**Version:** `0.4.x`
+**Integration branch:** `integrate/phase-5`
+
+### Sprint 5.1 — Dashboard Embed + crates.io
+- Status: Complete
+- Primary outcomes: embedded dashboard assets, release publish order fixes, CI dashboard drift checks.
+
+### Sprint 5.2 — Homebrew Release Automation
+- Status: Complete
+- Primary outcomes: `update-homebrew` workflow, formula patch automation and docs alignment.
+
+### Sprint 5.3 — ATM Integration
+- Status: Complete
+- Primary outcomes: ATM daemon polling, API/CLI/dashboard activity display, follow-up artifact sync fixes.
+
+## Phase 6 — Definition-First Architecture Realignment (Current)
+
+**Goal:** replace discovery-first assumptions with definition-first architecture and writer-subsystem constraints.
+**Version:** `0.5.0` (planned)
+**Integration branch:** `integrate/phase-6` (planned; current docs work targets `develop`)
+
+### Sprint 6.0 — Requirements + Architecture Rewrite
+
+- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p6-requirements-revision`
+- Base branch: `develop`
+- PR target: `develop`
+- Status: In Progress
+- Scope:
+  - hard-replace `docs/requirements.md` and `docs/architecture.md` to definition-first model
+  - define writer subsystem boundaries and prohibited poller writes
+  - define in-memory runtime projection approach and discovery endpoint contract
+  - capture refactor scope for conflicting runtime-write paths
+- Related PR: `#27`
+
 ## Dependencies Across Sprints
 
 - `1.1` must merge before `1.2`.
@@ -244,9 +287,11 @@ scmux is delivered in four phases with explicit integration branches and version
 - `3.1` must merge before `3.2`.
 - `3.2` must merge before any phase 4 sprint.
 - `4.1` must merge before `4.2`.
+- `4.2` must merge before phase 5 implementation sprints.
+- phase 5 completion is a prerequisite for phase 6 realignment implementation.
 
 ## Current Phase Entry Point
 
-- Active planning baseline: `Phase 1`.
-- Next implementation sprint: `1.1`.
-- First QA gate: after `1.1` PR opens on `integrate/phase-1`.
+- Active planning baseline: `Phase 6`.
+- Current sprint: `6.0` (requirements + architecture realignment).
+- Next implementation sprint: `6.1` (writer subsystem + runtime projection refactor, pending approval).

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -276,6 +276,13 @@ scmux is delivered in six phases with explicit integration branches and version 
   - define writer subsystem boundaries and prohibited poller writes
   - define in-memory runtime projection approach and discovery endpoint contract
   - capture refactor scope for conflicting runtime-write paths
+- Acceptance criteria:
+  - requirements + architecture reflect the definition-first model with no conflicting discovery-first language
+  - writer subsystem boundary is specified (including compile-boundary enforcement notes)
+  - in-memory runtime projection is explicitly defined for runtime API views
+  - discovery endpoint contract (`GET /discovery`) is defined
+  - refactor-scope document includes Must Remove, Must Constrain, and Must Implement sections
+  - QA re-review reports no blocking findings for Sprint 6.0 docs
 - Related PR: `#27`
 
 ## Dependencies Across Sprints

--- a/docs/refactor-scope-v0.5.md
+++ b/docs/refactor-scope-v0.5.md
@@ -21,6 +21,7 @@ This document lists code paths that conflict with the corrected architecture and
   - writes to `session_atm` from ATM polling.
 - `crates/scmux-daemon/src/hosts.rs`
   - discovery-driven write paths for remote runtime data.
+  - `update_host_last_seen` persistence path must be removed from poller writes and replaced by in-memory host runtime projection.
 
 ## 2. Must Constrain
 
@@ -45,7 +46,21 @@ This document lists code paths that conflict with the corrected architecture and
   3. scoped hard-stop only if needed.
 - Panic/error paths must never bulk-stop unrelated sessions.
 
-## 5. Keep and Reuse
+## 5. Must Implement (New Behavior)
+
+1. `definition_writer` module:
+- Single persistent writer subsystem for project/host/approved-roster edits.
+- Rust visibility boundary so non-editor modules cannot call persistent write helpers.
+
+2. In-memory runtime projection layer:
+- Replace poller persistence into `session_status`, `session_ci`, `session_atm`.
+- Serve runtime state to API/dashboard/CLI from projection + persisted definitions.
+
+3. Graceful ATM stop integration:
+- `stop_session` sends ATM shutdown request first.
+- Applies scoped hard-stop only after grace timeout if needed.
+
+## 6. Keep and Reuse
 
 - Existing host reachability display concepts.
 - Existing dashboard embed/release automation paths.

--- a/docs/refactor-scope-v0.5.md
+++ b/docs/refactor-scope-v0.5.md
@@ -1,0 +1,53 @@
+# Refactor Scope — v0.5 Definition-First Architecture
+
+This document lists code paths that conflict with the corrected architecture and should be removed or rewritten.
+
+## 1. Must Remove
+
+### 1.1 Discovery-to-Definition Persistence
+- `crates/scmux-daemon/src/scheduler.rs`
+  - NF-06 recovery path that reconstructs `sessions` from live tmux when DB is empty.
+  - Any `INSERT/UPSERT` into `sessions` based on tmux discovery.
+
+- `crates/scmux-daemon/src/hosts.rs` + `crates/scmux-daemon/src/db.rs`
+  - Remote session upsert path (`upsert_remote_session`) that persists discovery snapshots.
+
+### 1.2 Poller Runtime Writes (outside editor path)
+- `crates/scmux-daemon/src/scheduler.rs`
+  - writes to `session_status`, `session_events` from poll loop.
+- `crates/scmux-daemon/src/ci.rs`
+  - writes to `session_ci` from CI polling.
+- `crates/scmux-daemon/src/atm.rs`
+  - writes to `session_atm` from ATM polling.
+- `crates/scmux-daemon/src/hosts.rs`
+  - discovery-driven write paths for remote runtime data.
+
+## 2. Must Constrain
+
+### 2.1 API Write Surface
+- `crates/scmux-daemon/src/api.rs`
+  - only project-definition editor routes may persist to SQLite.
+  - runtime control routes (`start`, `stop`, `jump`) must not perform definition writes.
+
+### 2.2 DB Access Ownership
+- Introduce a dedicated writer module for approved project edits.
+- Restrict direct write helpers in `db.rs` from general use.
+
+## 3. Rename/Responsibility Alignment
+
+- `scheduler.rs` should be renamed to `tmux_poller.rs` (or `runtime_poller.rs`) to avoid confusion with future cron scheduler responsibilities.
+
+## 4. Safety-Critical Behavior
+
+- `stop` must be graceful-first:
+  1. send ATM shutdown request,
+  2. wait configurable grace timeout,
+  3. scoped hard-stop only if needed.
+- Panic/error paths must never bulk-stop unrelated sessions.
+
+## 5. Keep and Reuse
+
+- Existing host reachability display concepts.
+- Existing dashboard embed/release automation paths.
+- Existing tmux attach/jump viewer flow (iTerm as viewer only).
+- Existing structured logging foundation, extended for OpenTelemetry compatibility.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -38,9 +38,9 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 |----|-------------|--------|
 | DG-01 | The daemon shall be a single self-contained binary (`scmux-daemon`) | 1.1 |
 | DG-02 | SQLite shall be a definition store only (projects/hosts/approved roster edits), not a tmux discovery cache | 6.0 |
-| DG-03 | Persistent SQLite writes shall be allowed only through the project-definition writer subsystem; multiple user editor entry points are allowed, but all must route through that subsystem | 6.0 |
-| DG-04 | The write module shall enforce an approved-project policy before accepting any persistent write | 6.0 |
-| DG-05 | Poller modules (`tmux_poller`, `hosts`, `ci`, `atm`) shall not persist runtime observations to SQLite | 6.0 |
+| DG-03 | Persistent SQLite writes shall be allowed only through a dedicated `definition_writer` module; persistent-write functions in `db.rs` shall be visibility-restricted (`pub(crate)`/`pub(super)`) so non-editor modules cannot call them directly | 6.0 |
+| DG-04 | Approved-project policy: a project is approved when created via the editor write path and valid with `enabled = 1` and non-empty `config_json.panes[]`; `definition_writer` shall reject persistent writes for non-approved/invalid projects | 6.0 |
+| DG-05 | Poller modules (`tmux_poller`, `hosts`, `ci`, `atm`) shall not persist runtime observations to SQLite; runtime state shall be served from an in-memory projection layer | 6.0 |
 | DG-06 | Deleting SQLite definitions shall not trigger reconstruction from tmux discovery; missing definitions remain missing until user redefines them | 6.0 |
 | DG-07 | The daemon shall serve the web dashboard as static files at `GET /` | 1.2 |
 | DG-08 | The daemon shall load configuration from `~/.config/scmux/scmux.toml` at startup | 1.1 |
@@ -48,6 +48,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | DG-10 | Logging paths shall be structured and OpenTelemetry-ready (trace context propagation and consistent event attributes) for near-term OTel integration | 6.0 |
 | DG-11 | On panic or partial failure, the daemon shall isolate failures and shall not mass-stop unrelated sessions/agents | 6.0 |
 | DG-12 | Runtime state is live/ephemeral and shall not be treated as persistent source-of-truth data in SQLite | 6.0 |
+| DG-13 | Legacy runtime cache tables (`session_status`, `session_ci`, `session_atm`) are deprecated in P6 and replaced by in-memory projection for API responses | 6.0 |
 
 ### 4.2 Daemon — Session Lifecycle
 
@@ -62,6 +63,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | SL-07 | Start/stop failures shall be isolated to the target session and shall not cascade to other sessions | 6.0 |
 | SL-08 | Polling tmux/ATM/CI shall update runtime view only and shall not persist discovery-derived project definitions | 6.0 |
 | SL-09 | Auto-start/cron may trigger `start` only for already-defined projects in SQLite | 6.0 |
+| SL-10 | If `starting` fails (tmux/session creation or pane launch error), the session shall transition back to `stopped` with structured error details | 6.0 |
 
 ### 4.3 Daemon — Pane Status
 
@@ -72,6 +74,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | PS-03 | Pane presentation shall include: pane name, configured command, ATM agent/team mapping, current runtime state, and optional current task | 6.0 |
 | PS-04 | Missing ATM data shall degrade to `unknown` without failing session rendering | 6.0 |
 | PS-05 | Pane runtime snapshots are derived data; pollers shall not persist them as project-definition writes | 6.0 |
+| PS-06 | Per-pane runtime state shall be ephemeral in-memory projection data (not persisted runtime cache tables) | 6.0 |
 
 ### 4.4 Daemon — Terminal Launch (Jump)
 
@@ -122,8 +125,8 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | API-02 | All responses shall be JSON | 1.2 |
 | API-03 | CORS shall be permissive | 1.2 |
 | API-04 | `GET /health` — daemon status, uptime seconds, enabled session count, DB path, version | 1.2 |
-| API-05 | `GET /sessions` — all defined projects with live runtime status (running or stopped) | 6.0 |
-| API-06 | `GET /sessions/:name` — full detail: definition, pane mappings, ATM state, CI snapshot | 6.0 |
+| API-05 | `GET /sessions` — all defined projects with live runtime status (running or stopped), sourced from in-memory runtime projection + persisted definitions | 6.0 |
+| API-06 | `GET /sessions/:name` — full detail: definition, pane mappings, ATM state, CI snapshot, sourced from in-memory runtime projection + persisted definitions | 6.0 |
 | API-07 | `GET /sessions/:name` — 404 if not found | 1.2 |
 | API-08 | `POST /sessions/:name/start` — launch from stored project definition, return ok/error | 6.0 |
 | API-09 | `POST /sessions/:name/stop` — graceful-first shutdown path, return ok/error | 6.0 |
@@ -133,7 +136,8 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | API-13 | `DELETE /sessions/:name` — remove/disable project definition (editor-only persistent write path) | 6.0 |
 | API-14 | `GET /hosts` — list all hosts with reachability status | 1.2 |
 | API-15 | `GET /dashboard-config.json` — host list + dashboard settings for web UI | 1.2 |
-| API-16 | A secondary endpoint/view shall expose raw tmux discovery without mutating SQLite definitions | 6.0 |
+| API-16 | `GET /discovery` shall expose raw tmux discovery (including non-defined sessions) without mutating SQLite definitions | 6.0 |
+| API-17 | `POST /sessions/:name/start` shall reject missing/malformed `config_json` with a structured validation error payload | 6.0 |
 
 ### 4.8 Multi-Host / VPN Handling
 
@@ -164,8 +168,9 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | DV-09 | Text search by session name | 2.2 |
 | DV-10 | Filters shall be combinable | 2.2 |
 | DV-11 | Header shall show global counts: running, idle, stopped, active agents, open PRs | 2.2 |
-| DV-12 | A secondary tab/view shall show raw tmux discovery for sessions not linked to defined projects; this view is informational only | 6.0 |
+| DV-12 | A secondary tab/view shall show `GET /discovery` raw tmux sessions not linked to defined projects; this view is informational only | 6.0 |
 | DV-13 | Each project card shall provide an Edit affordance that opens the project editor for definition updates | 6.0 |
+| DV-14 | The dashboard shall provide a `New Project` flow that creates project definitions through the `definition_writer` subsystem | 6.0 |
 
 ### 4.10 Dashboard — CI Display
 
@@ -252,6 +257,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | ATM-04 | `stuck` shall be derived from prolonged active state over configurable threshold (`atm.stuck_minutes`) | P5.3 |
 | ATM-05 | ATM unavailability shall degrade gracefully: project remains visible, ATM fields marked unavailable/unknown, no daemon crash | P5.3 |
 | ATM-06 | Runtime ATM observations shall not be auto-persisted as project-definition writes | 6.0 |
+| ATM-07 | Canonical per-pane ATM lookup key shall be (`pane.atm_team`, `pane.atm_agent`); pane index/name are display metadata only | 6.0 |
 
 ---
 
@@ -264,7 +270,6 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | NF-03 | Poll cycle shall complete in < 500ms for up to 50 projects | 4.1 |
 | NF-04 | HTTP read endpoints shall respond in < 100ms | 4.1 |
 | NF-05 | The system shall work on macOS (primary) and Linux (DGX Spark) | 4.1 |
-| NF-06 | Deleting SQLite definitions shall not trigger reconstruction from tmux discovery; definitions are restored only via explicit user edits/import | 6.0 |
 | NF-07 | All CI/ATM/network errors shall be handled gracefully and logged with trace context | 6.0 |
 | NF-08 | Single-host or single-session failures shall not crash the daemon or stop unrelated sessions | 4.1 |
 | NF-09 | Stop behavior shall be graceful-first and must not perform bulk kill on panic/error paths | 6.0 |
@@ -288,10 +293,11 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | ID | Test | Sprint |
 |----|------|--------|
 | T-LC-01 | `POST /sessions/:name/start` launches tmux session and pane commands from `config_json` | 6.0 |
-| T-LC-02 | Session transitions `stopped -> starting -> running -> idle` follow deterministic criteria; `done` transitions are validated once lifecycle policy is finalized | 6.0 |
+| T-LC-02 | Session transitions `stopped -> starting -> running -> idle` follow deterministic criteria; `done` transition-in behavior is deferred pending lifecycle decision | 6.0 |
 | T-LC-03 | `POST /sessions/:name/stop` sends ATM shutdown first, waits grace period, then performs scoped hard-stop only if needed | 6.0 |
 | T-LC-04 | Panic/error in one session does not stop or tear down unrelated sessions | 6.0 |
 | T-LC-05 | Closing iTerm does not stop tmux session or running agents | 6.0 |
+| T-LC-06 | `starting` failures transition session back to `stopped` with structured error details | 6.0 |
 
 ### 6.3 API Tests
 
@@ -305,7 +311,8 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | T-A-06 | `POST /sessions/:name/stop` returns ok true/false with graceful-stop diagnostics | 6.0 |
 | T-A-07 | `POST /sessions/:name/jump` opens viewer terminal without affecting session lifecycle | 6.0 |
 | T-A-08 | Editor endpoints (`POST/PATCH/DELETE /sessions`) are the only persistent-write API paths | 6.0 |
-| T-A-09 | Raw tmux discovery endpoint/view is read-only and does not mutate definitions | 6.0 |
+| T-A-09 | `GET /discovery` is read-only and does not mutate definitions | 6.0 |
+| T-A-10 | `POST /sessions/:name/start` returns structured validation errors for malformed/missing `config_json` | 6.0 |
 
 ### 6.4 Dashboard Manual Tests
 
@@ -391,3 +398,5 @@ The system is complete when:
 | OQ-5 | `scmux` CLI scope? | Separate binary, HTTP client to daemon. Same API as web UI. Persistent writes are restricted to the project-definition editor path. |
 | OQ-6 | Final `done` semantics and auto-teardown policy? | Pending product decision; keep default non-destructive behavior until explicitly approved. |
 | OQ-7 | Stop escalation exact parameters (timeouts/retries/hard-stop policy)? | Pending product decision; keep graceful-first and scoped behavior mandatory. |
+| OQ-8 | Runtime state persistence model? | P6 uses in-memory runtime projection; pollers do not persist runtime snapshots to SQLite. |
+| OQ-9 | Secondary discovery endpoint path? | `GET /discovery`. |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -37,40 +37,41 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | ID | Requirement | Sprint |
 |----|-------------|--------|
 | DG-01 | The daemon shall be a single self-contained binary (`scmux-daemon`) | 1.1 |
-| DG-02 | The daemon shall own all SQLite writes; no other component writes to the database | 1.1 |
-| DG-03 | The daemon shall serve the web dashboard as static files at `GET /` | 1.2 |
-| DG-04 | The daemon shall load configuration from `~/.config/scmux/scmux.toml` at startup | 1.1 |
-| DG-05 | The daemon shall seed the SQLite `hosts` table from `scmux.toml` on first run if the table is empty | 1.1 |
-| DG-06 | The daemon shall apply SQLite schema migrations on every startup (idempotent) | 1.1 |
-| DG-07 | The daemon shall log structured output via `tracing` at INFO level by default | 1.1 |
-| DG-08 | The daemon shall initialize logging via a `logging.rs` module that: reads `SCMUX_LOG` env var (trace/debug/info/warn/error, default info); writes human-readable output to stderr with `with_target(false)`; writes JSONL-formatted events to `~/.config/scmux/scmux-daemon.log` with 50 MiB size limit and 5-file rotation; exposes `init_logging()` returning `LoggingGuards` (RAII); supports `--verbose`/`-v` flag (sets `SCMUX_LOG=debug`). | 1.1 |
+| DG-02 | SQLite shall be a definition store only (projects/hosts/approved roster edits), not a tmux discovery cache | 6.0 |
+| DG-03 | Persistent SQLite writes shall be allowed only through the project-definition writer subsystem; multiple user editor entry points are allowed, but all must route through that subsystem | 6.0 |
+| DG-04 | The write module shall enforce an approved-project policy before accepting any persistent write | 6.0 |
+| DG-05 | Poller modules (`tmux_poller`, `hosts`, `ci`, `atm`) shall not persist runtime observations to SQLite | 6.0 |
+| DG-06 | Deleting SQLite definitions shall not trigger reconstruction from tmux discovery; missing definitions remain missing until user redefines them | 6.0 |
+| DG-07 | The daemon shall serve the web dashboard as static files at `GET /` | 1.2 |
+| DG-08 | The daemon shall load configuration from `~/.config/scmux/scmux.toml` at startup | 1.1 |
+| DG-09 | The daemon shall apply SQLite schema migrations on every startup (idempotent) | 1.1 |
+| DG-10 | Logging paths shall be structured and OpenTelemetry-ready (trace context propagation and consistent event attributes) for near-term OTel integration | 6.0 |
+| DG-11 | On panic or partial failure, the daemon shall isolate failures and shall not mass-stop unrelated sessions/agents | 6.0 |
+| DG-12 | Runtime state is live/ephemeral and shall not be treated as persistent source-of-truth data in SQLite | 6.0 |
 
 ### 4.2 Daemon — Session Lifecycle
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| SL-01 | The daemon shall poll `tmux list-sessions` every 15 seconds | 1.2 |
-| SL-02 | The daemon shall update `session_status` for all enabled sessions on every poll | 1.2 |
-| SL-03 | A session not found in `tmux list-sessions` shall be marked `stopped` | 1.2 |
-| SL-04 | A session found in `tmux list-sessions` shall be marked `running` | 1.2 |
-| SL-05 | When a running session disappears between polls, the daemon shall write a `stopped` event to `session_events` | 1.2 |
-| SL-06 | Sessions with `auto_start = 1` that are stopped shall be started by the daemon on the next poll cycle | 1.2 |
-| SL-07 | Sessions with a `cron_schedule` shall be started when the cron expression fires, if currently stopped | 1.2 |
-| SL-08 | Cron evaluation shall use a 15-second window to avoid missing fires between poll cycles | 1.2 |
-| SL-09 | Sessions shall be started via `tmuxp load -d <temp_config_file>` | 1.2 |
-| SL-10 | If `tmuxp load` fails, the daemon shall write a `failed` event with the error message to `session_events` | 1.2 |
-| SL-11 | Failed starts shall not be retried in the same poll cycle | 1.2 |
+| SL-01 | Runtime state machine shall be: `stopped -> starting -> running -> idle -> done` | 6.0 |
+| SL-02 | `POST /sessions/:name/start` shall load the project definition from SQLite `config_json`, create tmux layout, and launch all pane commands without requiring iTerm | 6.0 |
+| SL-03 | `running` means tmux session exists and at least one configured agent is ATM-active | 6.0 |
+| SL-04 | `idle` means tmux session exists and all configured agents are ATM-idle/offline | 6.0 |
+| SL-05 | `done` semantics are provisional and shall be finalized in a dedicated lifecycle decision; auto-teardown shall default to disabled until finalized | 6.0 |
+| SL-06 | `POST /sessions/:name/stop` shall be graceful-first: send ATM shutdown signal/message, wait a configurable grace period, then escalate to scoped hard-stop only if still running; escalation parameters are configurable and subject to product-level finalization | 6.0 |
+| SL-07 | Start/stop failures shall be isolated to the target session and shall not cascade to other sessions | 6.0 |
+| SL-08 | Polling tmux/ATM/CI shall update runtime view only and shall not persist discovery-derived project definitions | 6.0 |
+| SL-09 | Auto-start/cron may trigger `start` only for already-defined projects in SQLite | 6.0 |
 
 ### 4.3 Daemon — Pane Status
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| PS-01 | The daemon shall collect pane info for each running session via `tmux list-panes` | 1.2 |
-| PS-02 | Each pane shall report: index, name (pane_title), current_command, active flag | 1.2 |
-| PS-03 | A pane with `pane_active = 1` shall be reported as status `active` | 1.2 |
-| PS-04 | All other panes in a running session shall be reported as `idle` | 1.2 |
-| PS-05 | If `pane_title` is empty, fall back to `pane-<index>` | 1.2 |
-| PS-06 | Pane data shall be stored as JSON in `session_status.panes_json` | 1.2 |
+| PS-01 | Pane identity shall be definition-driven from `config_json.panes[]` (`name`, `command`, `atm_agent`, `atm_team`) | 6.0 |
+| PS-02 | Per-pane runtime state shall be resolved from ATM first (`active`, `idle`, `stuck`, `offline`) and tmux signals second | 6.0 |
+| PS-03 | Pane presentation shall include: pane name, configured command, ATM agent/team mapping, current runtime state, and optional current task | 6.0 |
+| PS-04 | Missing ATM data shall degrade to `unknown` without failing session rendering | 6.0 |
+| PS-05 | Pane runtime snapshots are derived data; pollers shall not persist them as project-definition writes | 6.0 |
 
 ### 4.4 Daemon — Terminal Launch (Jump)
 
@@ -92,14 +93,14 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | CI-01 | The daemon shall support two CI providers: GitHub (`gh` CLI) and Azure DevOps (`az` CLI) | 3.1 |
 | CI-02 | Both providers are optional; sessions may have one, both, or neither | 3.1 |
 | CI-03 | On startup, the daemon shall detect whether `gh` and `az` are available in PATH | 3.1 |
-| CI-04 | If a required CLI tool is not available, the daemon shall record `tool_unavailable` status in `session_ci` with an install message | 3.1 |
+| CI-04 | If a required CLI tool is not available, the daemon shall expose `tool_unavailable` runtime status with install guidance | 3.1 |
 | CI-05 | The daemon shall poll CI status on an adaptive interval per session | 3.1 |
 | CI-06 | When any pane in a session has status `active`, the CI poll interval shall be 1 minute | 3.1 |
 | CI-07 | When all panes are idle or session is stopped, the CI poll interval shall be 5 minutes | 3.1 |
-| CI-08 | Each session shall track its own `next_poll_at` in `session_ci` | 3.1 |
-| CI-09 | GitHub polling shall collect: open PRs (number, title, URL, author, draft flag) and recent workflow runs (status, branch, timestamp) via `gh pr list` and `gh run list` | 3.1 |
-| CI-10 | Azure polling shall collect: open PRs and pipeline run status via `az pipelines` | 3.1 |
-| CI-11 | CI results shall be stored as JSON blobs in `session_ci` with provider, polled_at, next_poll_at | 3.1 |
+| CI-08 | GitHub polling shall collect open PR list and recent workflow runs (`#`, title, URL, status, branch, timestamp) | 3.1 |
+| CI-09 | Azure polling shall collect open PRs and pipeline run status | 3.1 |
+| CI-10 | Project cards shall expose CI summary counts: active PRs, passing jobs, failing jobs, running jobs | 6.0 |
+| CI-11 | CI polling modules shall not persist runtime snapshots to SQLite | 6.0 |
 | CI-12 | The `github_repo` column on `sessions` shall hold the repo in `owner/repo` format | 3.1 |
 | CI-13 | The `azure_project` column on `sessions` shall hold the Azure DevOps project URL or identifier | 3.1 |
 
@@ -107,9 +108,9 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| DH-01 | The daemon shall write a heartbeat row to `daemon_health` every 60 seconds | 1.1 |
-| DH-02 | Each heartbeat shall include: host_id, status ("ok"), running session count, timestamp | 1.1 |
-| DH-03 | The daemon shall prune `daemon_health` rows older than 7 days on each write | 1.1 |
+| DH-01 | `GET /health` shall expose daemon liveness, uptime, and poller health | 1.1 |
+| DH-02 | Host polling shall expose reachability, last-seen timestamp, and stale-data status for display | 2.1 |
+| DH-03 | Single host/session poll errors shall not crash the daemon and shall not degrade unrelated project state | 4.1 |
 | DH-04 | The daemon shall start automatically on machine boot (launchd / systemd) | 4.1 |
 | DH-05 | The daemon shall restart automatically if it crashes | 4.1 |
 
@@ -121,24 +122,24 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | API-02 | All responses shall be JSON | 1.2 |
 | API-03 | CORS shall be permissive | 1.2 |
 | API-04 | `GET /health` — daemon status, uptime seconds, enabled session count, DB path, version | 1.2 |
-| API-05 | `GET /sessions` — all enabled sessions with live status, panes, CI summary | 1.2 |
-| API-06 | `GET /sessions/:name` — full detail: config, panes, CI, last 20 events | 1.2 |
+| API-05 | `GET /sessions` — all defined projects with live runtime status (running or stopped) | 6.0 |
+| API-06 | `GET /sessions/:name` — full detail: definition, pane mappings, ATM state, CI snapshot | 6.0 |
 | API-07 | `GET /sessions/:name` — 404 if not found | 1.2 |
-| API-08 | `POST /sessions/:name/start` — start session, log event, return ok/error | 1.2 |
-| API-09 | `POST /sessions/:name/stop` — stop session, log event, return ok/error | 1.2 |
+| API-08 | `POST /sessions/:name/start` — launch from stored project definition, return ok/error | 6.0 |
+| API-09 | `POST /sessions/:name/stop` — graceful-first shutdown path, return ok/error | 6.0 |
 | API-10 | `POST /sessions/:name/jump` — spawn terminal, return ok/error | 1.2 |
-| API-11 | `POST /sessions` — register new session (from CLI or UI) | 1.2 |
-| API-12 | `PATCH /sessions/:name` — update session fields | 1.2 |
-| API-13 | `DELETE /sessions/:name` — disable or remove session | 1.2 |
+| API-11 | `POST /sessions` — create project definition (persistent write path via writer subsystem; e.g. New Project editor entry point) | 6.0 |
+| API-12 | `PATCH /sessions/:name` — update project definition (persistent write path via writer subsystem; e.g. Project Editor/card Edit entry points) | 6.0 |
+| API-13 | `DELETE /sessions/:name` — remove/disable project definition (editor-only persistent write path) | 6.0 |
 | API-14 | `GET /hosts` — list all hosts with reachability status | 1.2 |
 | API-15 | `GET /dashboard-config.json` — host list + dashboard settings for web UI | 1.2 |
-| API-16 | Start, stop, and jump actions shall be logged to `session_events` | 1.2 |
+| API-16 | A secondary endpoint/view shall expose raw tmux discovery without mutating SQLite definitions | 6.0 |
 
 ### 4.8 Multi-Host / VPN Handling
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| MH-01 | Hosts shall be defined in `scmux.toml` and seeded into SQLite on first run | 2.1 |
+| MH-01 | Hosts shall be user-defined in the project/host editor and persisted in SQLite | 6.0 |
 | MH-02 | The dashboard shall poll all known hosts independently | 2.1 |
 | MH-03 | A host that is unreachable (timeout, network error) shall NOT be treated as an error condition | 2.1 |
 | MH-04 | When a host is unreachable, the daemon shall retain the last known session data | 2.1 |
@@ -153,7 +154,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | ID | Requirement | Sprint |
 |----|-------------|--------|
 | DV-01 | The dashboard shall support three views: Grid, List, Grouped-by-project | 2.2 |
-| DV-02 | Grid: one card per session — name, project, status dot, pane list, CI/PR badges | 2.2 |
+| DV-02 | Primary dashboard view shall show all defined projects (running or stopped), one card per project | 6.0 |
 | DV-03 | List: table — name, project, status, pane count, active count, open PRs, last activity | 2.2 |
 | DV-04 | Grouped: sessions under project headers with per-project running count and PR count | 2.2 |
 | DV-05 | Stopped sessions shall be visually de-emphasized (reduced opacity) | 2.2 |
@@ -163,14 +164,16 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | DV-09 | Text search by session name | 2.2 |
 | DV-10 | Filters shall be combinable | 2.2 |
 | DV-11 | Header shall show global counts: running, idle, stopped, active agents, open PRs | 2.2 |
+| DV-12 | A secondary tab/view shall show raw tmux discovery for sessions not linked to defined projects; this view is informational only | 6.0 |
+| DV-13 | Each project card shall provide an Edit affordance that opens the project editor for definition updates | 6.0 |
 
 ### 4.10 Dashboard — CI Display
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| DC-01 | Each session card shall show CI badges for configured providers | 2.2 |
-| DC-02 | GitHub: show open PR count badge; click expands PR list with links | 2.2 |
-| DC-03 | Azure: show pipeline status badge (passing / failing / running) | 2.2 |
+| DC-01 | Each project card shall show CI summary badges for configured providers | 2.2 |
+| DC-02 | GitHub: show expandable PR list with links and per-run status (green/yellow/red/running) | 6.0 |
+| DC-03 | Azure: show pipeline status list with pass/fail/running indicators | 6.0 |
 | DC-04 | When a tool is unavailable, show a grayed badge with tooltip: "Install gh CLI: brew install gh" | 2.2 |
 | DC-05 | When a session has no CI configured, show nothing (no empty badge) | 2.2 |
 
@@ -198,25 +201,25 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | CLI-06 | `scmux start <name>` — start session | 3.2 |
 | CLI-07 | `scmux stop <name>` — stop session | 3.2 |
 | CLI-08 | `scmux jump <name>` — launch terminal via daemon | 3.2 |
-| CLI-09 | `scmux add --name --project --config --auto-start` — register session | 3.2 |
-| CLI-10 | `scmux edit <name> [--cron] [--auto-start] [--config]` — update session | 3.2 |
-| CLI-11 | `scmux disable <name>` / `scmux enable <name>` — toggle enabled flag | 3.2 |
-| CLI-12 | `scmux remove <name>` — delete session | 3.2 |
-| CLI-13 | `scmux hosts` — list hosts with reachability | 3.2 |
-| CLI-14 | `scmux daemon status` — show daemon health | 3.2 |
-| CLI-15 | `scmux host add` — deferred to v2. Not implemented in Phase 3. | — |
-| CLI-16 | `scmux daemon restart` — deferred to v2. Not implemented in Phase 3. | — |
+| CLI-09 | Project-definition create/edit/delete shall be dashboard editor-only in the current release (CLI write commands deferred) | 6.0 |
+| CLI-10 | `scmux hosts` — list hosts with reachability | 3.2 |
+| CLI-11 | `scmux daemon status` — show daemon health | 3.2 |
+| CLI-12 | Reserved for future non-editor write flows (requires explicit approval model) | 6.0 |
+| CLI-13 | `scmux host add` — deferred; host persistence remains editor-only in current release | 6.0 |
+| CLI-14 | `scmux daemon restart` — deferred to v2. Not implemented in current release | — |
 
 ### 4.13 Session Registry
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| SR-01 | Sessions shall be stored in SQLite with: name, project, host_id, config_json, cron_schedule, auto_start, enabled, github_repo, azure_project | 1.1 |
-| SR-02 | `config_json` shall be a valid tmuxp JSON blob with `session_name` matching the session `name` | 1.2 |
+| SR-01 | Project definitions shall be stored in SQLite with: name, project, host_id, config_json, scheduling fields, enabled flag, repo metadata | 6.0 |
+| SR-02 | `config_json` shall define pane-level agent launch metadata (`name`, `command`, `atm_agent`, `atm_team`), repo path, and optional layout | 6.0 |
 | SR-03 | Session names shall be unique per host | 1.2 |
 | SR-04 | Sessions shall be soft-deletable via `enabled = 0` | 1.2 |
 | SR-05 | `cron_schedule` shall use standard 5-field cron format; NULL = manual-only | 1.2 |
 | SR-06 | `github_repo` format: `owner/repo` (e.g. `randlee/scmux`) | 1.2 |
+| SR-07 | Runtime discovery data (tmux sessions, pane activity, CI runs, ATM state) shall not be auto-persisted as project definitions | 6.0 |
+| SR-08 | Permanent ATM roster/team composition edits shall be user-approved and persisted only via the editor write path | 6.0 |
 
 ### 4.14 Dashboard Embed & Self-Contained Binary (v0.4.0 / P5.1)
 
@@ -243,15 +246,12 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 
 | ID | Requirement | Sprint |
 |----|-------------|--------|
-| ATM-01 | For sessions whose `name` matches the session component of an ATM entry's `session_id` field (e.g., `"scmux"` from `"scmux:1.2"`), the daemon shall query the local ATM daemon via Unix socket IPC (`${ATM_HOME}/.claude/daemon/atm-daemon.sock`, overridable via `scmux.toml atm.socket_path`) for agent state | P5.3 |
-| ATM-02 | The daemon shall store ATM state in a new `session_atm` table: `session_name, agent_id, team, state, last_transition, updated_at`; state values: `active\|idle\|offline\|unknown\|stuck` | P5.3 |
-| ATM-03 | `GET /sessions` shall include an `atm` field (state object or null) for each session | P5.3 |
-| ATM-04 | The dashboard shall display an activity indicator (active / idle / stuck) for ATM-enrolled sessions | P5.3 |
-| ATM-05 | `scmux list` shall include an activity column for ATM-enrolled sessions | P5.3 |
-| ATM-06 | When the ATM daemon is unreachable, the `atm` field shall be null and the rest of the system shall be unaffected | P5.3 |
-| ATM-07 | Non-ATM sessions shall fall back to `pane_last_activity` from tmux as a proxy for agent activity | P5.3 |
-| ATM-08 | The daemon shall derive a `stuck` state for ATM sessions where `state == "active"` and `(now - last_transition) > atm.stuck_minutes` (default 10); this derived state shall be stored in `session_atm` and returned in `/sessions` | P5.3 |
-| ATM-09 | The ATM socket path shall default to `${ATM_HOME}/.claude/daemon/atm-daemon.sock` and be overridable via `[atm] socket_path` in `scmux.toml`; `atm.stuck_minutes` shall be configurable (default 10) | P5.3 |
+| ATM-01 | The daemon shall query the local ATM daemon via Unix socket IPC (`${ATM_HOME}/.claude/daemon/atm-daemon.sock`, overridable via `scmux.toml atm.socket_path`) for per-agent state | P5.3 |
+| ATM-02 | ATM state shall be mapped per configured pane (`atm_agent`, `atm_team`) and exposed in session/project responses | 6.0 |
+| ATM-03 | Dashboard and CLI shall render per-pane ATM state (`active|idle|stuck|offline|unknown`) rather than only a session-level badge | 6.0 |
+| ATM-04 | `stuck` shall be derived from prolonged active state over configurable threshold (`atm.stuck_minutes`) | P5.3 |
+| ATM-05 | ATM unavailability shall degrade gracefully: project remains visible, ATM fields marked unavailable/unknown, no daemon crash | P5.3 |
+| ATM-06 | Runtime ATM observations shall not be auto-persisted as project-definition writes | 6.0 |
 
 ---
 
@@ -261,119 +261,72 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 |----|-------------|--------|
 | NF-01 | The daemon binary shall be self-contained (no runtime deps beyond tmux, tmuxp, gh/az) | 4.1 |
 | NF-02 | The daemon shall use < 50MB RAM in normal operation | 4.1 |
-| NF-03 | Poll cycle shall complete in < 500ms for up to 50 sessions | 4.1 |
+| NF-03 | Poll cycle shall complete in < 500ms for up to 50 projects | 4.1 |
 | NF-04 | HTTP read endpoints shall respond in < 100ms | 4.1 |
 | NF-05 | The system shall work on macOS (primary) and Linux (DGX Spark) | 4.1 |
-| NF-06 | If the SQLite database is deleted while the daemon is stopped, the next start shall reconstruct currently-running session state from live tmux output without error. Stopped or disabled session definitions that were not in tmux at restart time are not recoverable and need not be reconstructed. | 4.1 |
-| NF-07 | All CI errors (network failure, auth error, rate limit) shall be handled gracefully and logged | 3.1 |
-| NF-08 | The daemon shall not crash on any single-host or single-session failure | 4.1 |
+| NF-06 | Deleting SQLite definitions shall not trigger reconstruction from tmux discovery; definitions are restored only via explicit user edits/import | 6.0 |
+| NF-07 | All CI/ATM/network errors shall be handled gracefully and logged with trace context | 6.0 |
+| NF-08 | Single-host or single-session failures shall not crash the daemon or stop unrelated sessions | 4.1 |
+| NF-09 | Stop behavior shall be graceful-first and must not perform bulk kill on panic/error paths | 6.0 |
+| NF-10 | Logging/event schema shall remain OpenTelemetry-compatible to enable near-term instrumentation rollout | 6.0 |
 
 ---
 
 ## 6. Test Requirements
 
-### 6.1 Daemon Unit Tests
+### 6.1 Writer-Gate and Persistence Tests
 
 | ID | Test | Sprint |
-|----|-------------|--------|
-| T-D-01 | `db::open()` creates schema on fresh database | 1.1 |
-| T-D-02 | `db::open()` is idempotent on existing database | 1.1 |
-| T-D-03 | `db::ensure_local_host()` inserts local host if absent | 1.1 |
-| T-D-04 | `db::ensure_local_host()` returns existing host_id if present | 1.1 |
-| T-D-05 | `should_run_now()` true when cron fires in 15s window | 1.1 |
-| T-D-06 | `should_run_now()` false when cron does not fire in window | 1.1 |
-| T-D-07 | `should_run_now()` false for invalid cron expression | 1.1 |
-| T-D-08 | `tmux::live_sessions()` returns empty map when tmux not running | 1.2 |
-| T-D-09 | `tmux::live_sessions()` parses session names correctly | 1.2 |
-| T-D-10 | CI interval is 1 minute when any pane is active | 3.1 |
-| T-D-11 | CI interval is 5 minutes when all panes are idle | 3.1 |
-| T-D-12 | `tool_unavailable` recorded when `gh` not in PATH | 3.1 |
-| T-D-13 | `tool_unavailable` recorded when `az` not in PATH | 3.1 |
-| T-D-14 | `init_logging()` creates `~/.config/scmux/scmux-daemon.log` on startup | 1.1 |
-| T-D-15 | `SCMUX_LOG=warn` suppresses INFO-level messages on stderr | 1.1 |
-| T-D-16 | `--verbose` flag sets effective log level to DEBUG | 1.1 |
-| T-D-17 | CI fetch with network failure (simulated) does not crash daemon; records error in `session_ci` | 3.1 |
-| T-D-18 | CI fetch with auth/rate-limit error does not crash daemon; records error in `session_ci` | 3.1 |
-| T-D-19 | Single unreachable host does not abort poll cycle; remaining hosts and sessions processed normally | 4.1 |
-| T-D-20 | Single session with bad tmux state does not abort session loop; other sessions processed normally | 4.1 |
-| T-D-22 | Poll cycle p95 < 500ms with 50 seeded sessions using deterministic fake tmux (`SCMUX_TMUX_BIN`), run in `--release` mode with warm-up cycle before measurement (NF-03) | 4.1 |
-| T-D-23 | GET /sessions p95 < 100ms with 50 seeded sessions, `--release` mode (NF-04) | 4.1 |
-| T-D-24 | Daemon RSS < 50MB after loading 20 sessions (NF-02) | 4.1 |
+|----|------|--------|
+| T-WG-01 | Only the project-definition editor path can mutate SQLite; all other modules are denied at compile boundary and runtime checks | 6.0 |
+| T-WG-02 | Poller modules (`tmux_poller`, `hosts`, `ci`, `atm`) perform zero SQLite writes during runtime polling | 6.0 |
+| T-WG-03 | Unapproved project write attempts are rejected with explicit error | 6.0 |
+| T-WG-04 | Deleting SQLite and restarting does not reconstruct definitions from tmux discovery | 6.0 |
 
-### 6.2 Daemon Integration Tests
+### 6.2 Lifecycle and Safety Tests
 
 | ID | Test | Sprint |
-|----|-------------|--------|
-| T-I-01 | Poll cycle with no sessions completes without error | 1.2 |
-| T-I-02 | Poll cycle marks session running when found in tmux | 1.2 |
-| T-I-03 | Poll cycle marks session stopped when not found in tmux | 1.2 |
-| T-I-04 | Poll cycle writes stopped event when session disappears | 1.2 |
-| T-I-05 | Poll cycle starts auto_start session when stopped | 1.2 |
-| T-I-06 | Poll cycle does not start disabled session | 1.2 |
-| T-I-07 | Poll cycle does not restart already-running auto_start session | 1.2 |
-| T-I-08 | Health write inserts daemon_health row | 1.2 |
-| T-I-09 | Health write prunes rows older than 7 days | 1.2 |
-| T-I-10 | Unreachable remote host does not crash poll cycle | 2.1 |
-| T-I-11 | Host marked unreachable when /health times out | 2.1 |
-| T-I-12 | Host resumes reachable when /health responds again | 2.1 |
-| T-I-20 | DB deleted while daemon stopped → next start reconstructs currently-running tmux sessions without error; daemon does not crash or return errors on /health or /sessions | 4.1 |
+|----|------|--------|
+| T-LC-01 | `POST /sessions/:name/start` launches tmux session and pane commands from `config_json` | 6.0 |
+| T-LC-02 | Session transitions `stopped -> starting -> running -> idle` follow deterministic criteria; `done` transitions are validated once lifecycle policy is finalized | 6.0 |
+| T-LC-03 | `POST /sessions/:name/stop` sends ATM shutdown first, waits grace period, then performs scoped hard-stop only if needed | 6.0 |
+| T-LC-04 | Panic/error in one session does not stop or tear down unrelated sessions | 6.0 |
+| T-LC-05 | Closing iTerm does not stop tmux session or running agents | 6.0 |
 
 ### 6.3 API Tests
 
 | ID | Test | Sprint |
-|----|-------------|--------|
-| T-A-01 | GET /health returns 200 with correct fields | 1.2 |
-| T-A-02 | GET /sessions returns empty array when no sessions | 1.2 |
-| T-A-03 | GET /sessions returns sessions with correct status and panes | 1.2 |
-| T-A-04 | GET /sessions/:name returns 200 with config and events | 1.2 |
-| T-A-05 | GET /sessions/:name returns 404 for unknown session | 1.2 |
-| T-A-06 | POST /sessions/:name/start returns ok:true and logs event | 1.2 |
-| T-A-07 | POST /sessions/:name/start returns ok:false on tmuxp failure | 1.2 |
-| T-A-08 | POST /sessions/:name/stop returns ok:true and logs event | 1.2 |
-| T-A-09 | POST /sessions/:name/jump returns ok:true when iTerm2 launched | 1.2 |
-| T-A-10 | POST /sessions/:name/jump returns ok:false when terminal unavailable | 1.2 |
-| T-A-11 | POST /sessions (add) creates session in SQLite | 1.2 |
-| T-A-12 | PATCH /sessions/:name updates cron_schedule | 1.2 |
-| T-A-13 | DELETE /sessions/:name disables session | 1.2 |
-| T-A-14 | GET /hosts returns all hosts with reachability flag | 1.2 |
+|----|------|--------|
+| T-A-01 | `GET /health` returns daemon and poller health | 1.2 |
+| T-A-02 | `GET /sessions` returns all defined projects including stopped projects | 6.0 |
+| T-A-03 | `GET /sessions/:name` includes config, per-pane ATM state, and CI snapshot | 6.0 |
+| T-A-04 | `GET /sessions/:name` returns 404 for unknown project | 1.2 |
+| T-A-05 | `POST /sessions/:name/start` returns ok true/false with actionable message | 6.0 |
+| T-A-06 | `POST /sessions/:name/stop` returns ok true/false with graceful-stop diagnostics | 6.0 |
+| T-A-07 | `POST /sessions/:name/jump` opens viewer terminal without affecting session lifecycle | 6.0 |
+| T-A-08 | Editor endpoints (`POST/PATCH/DELETE /sessions`) are the only persistent-write API paths | 6.0 |
+| T-A-09 | Raw tmux discovery endpoint/view is read-only and does not mutate definitions | 6.0 |
 
 ### 6.4 Dashboard Manual Tests
 
 | ID | Test | Sprint |
-|----|-------------|--------|
-| T-UI-01 | Grid view renders all sessions | 2.2 |
-| T-UI-02 | List view renders all sessions in table | 2.2 |
-| T-UI-03 | Grouped view groups by project | 2.2 |
-| T-UI-04 | Status filters work correctly | 2.2 |
-| T-UI-05 | Project filter shows only correct sessions | 2.2 |
-| T-UI-06 | Search filters by name substring | 2.2 |
-| T-UI-07 | Clicking session opens jump modal | 2.2 |
-| T-UI-08 | Modal shows correct pane list | 2.2 |
-| T-UI-09 | Modal shows correct PR badges with links | 2.2 |
-| T-UI-10 | Modal "Open in iTerm2" sends POST /jump and shows feedback | 2.2 |
-| T-UI-11 | Stopped sessions are visually de-emphasized | 2.2 |
-| T-UI-12 | Unreachable host sessions render in monochrome | 2.2 |
-| T-UI-13 | "Last seen N ago" shows for unreachable hosts | 2.2 |
-| T-UI-14 | Full color resumes when host returns | 2.2 |
-| T-UI-15 | Tool-unavailable CI badges show tooltip with install instructions | 2.2 |
-| T-UI-16 | Escape key closes modal | 2.2 |
-| T-UI-17 | Header counts match data | 2.2 |
+|----|------|--------|
+| T-UI-01 | Primary dashboard view shows all defined projects (running and stopped) | 6.0 |
+| T-UI-02 | Secondary discovery tab shows raw tmux sessions not linked to definitions | 6.0 |
+| T-UI-03 | Project cards show per-pane ATM state (active/idle/stuck/offline/unknown) | 6.0 |
+| T-UI-04 | CI panel shows per-project PR list and run indicators (green/yellow/red/running) | 6.0 |
+| T-UI-05 | Unreachable host sessions render monochrome and recover automatically on reconnect | 2.1 |
+| T-UI-06 | Jump modal attaches viewer terminal and does not change agent run state | 6.0 |
 
-### 6.5 End-to-End Tests
+### 6.5 Reliability and Observability Tests
 
 | ID | Test | Sprint |
-|----|-------------|--------|
-| T-E-01 | Daemon starts, creates DB, serves /health | 4.2 |
-| T-E-02 | Add session → daemon starts it via auto_start within 15s | 4.2 |
-| T-E-03 | Kill session externally → daemon detects stopped within 15s | 4.2 |
-| T-E-04 | POST /start → session appears in tmux | 4.2 |
-| T-E-05 | POST /stop → session disappears from tmux | 4.2 |
-| T-E-06 | POST /jump → iTerm2 opens, attaches to correct session (manual runbook) | 4.2 |
-| T-E-07 | Cron session starts at scheduled time with injected test clock | 4.2 |
-| T-E-08 | Disconnect from VPN → remote host goes monochrome, no error dialog (manual runbook) | 4.2 |
-| T-E-09 | Reconnect VPN → remote host resumes full color (manual runbook) | 4.2 |
-| T-E-10 | `scmux list` → matches dashboard data | 4.2 |
-| T-E-11 | `scmux jump <name>` → iTerm2 opens via daemon | 4.2 |
+|----|------|--------|
+| T-RB-01 | Single host failure does not degrade unrelated hosts/projects | 4.1 |
+| T-RB-02 | Single session launch/stop failure does not cascade to other sessions | 6.0 |
+| T-RB-03 | No panic/error path issues bulk stop for all sessions | 6.0 |
+| T-RB-04 | Logs include correlation fields suitable for OpenTelemetry export mapping | 6.0 |
+| T-RB-05 | Runtime polling refreshes live state continuously without requiring persistent runtime writes | 6.0 |
 
 ### 6.6 Dashboard Embed Tests (v0.4.0 / P5.1)
 
@@ -386,14 +339,14 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | T-DE-05 | `SCMUX_DASHBOARD_DIR=/path` causes daemon to serve files from disk instead of embedded | P5.1 |
 | T-DE-06 | `cargo install --path crates/scmux-daemon` on a clean machine serves the dashboard | P5.1 |
 
-### 6.7 ATM Integration Tests (v0.4.0 / P5.3)
+### 6.7 ATM Integration Tests (v0.4.0 / P5.3+)
 
 | ID | Test | Sprint |
 |----|------|--------|
-| T-ATM-01 | `GET /sessions` includes `"atm": null` for non-ATM sessions | P5.3 |
-| T-ATM-02 | `GET /sessions` includes `"atm": {"state": "active", ...}` for ATM-enrolled sessions when ATM daemon is reachable | P5.3 |
-| T-ATM-03 | ATM daemon unreachable → `atm` field is null, no daemon crash, no error in response body | P5.3 |
-| T-ATM-04 | Dashboard renders activity badge for ATM sessions; no badge for non-ATM sessions | P5.3 |
+| T-ATM-01 | `GET /sessions` returns per-pane ATM state mapping for ATM-enrolled projects | 6.0 |
+| T-ATM-02 | `stuck` derivation is threshold-driven and test-validated | 6.0 |
+| T-ATM-03 | ATM daemon unreachable degrades gracefully without daemon crash | P5.3 |
+| T-ATM-04 | Dashboard renders per-pane activity states; non-ATM panes show `unknown` fallback | 6.0 |
 
 ---
 
@@ -407,14 +360,14 @@ The system is complete when:
 
 1. `cargo build --release --workspace` succeeds with no warnings
 2. Daemon survives 24 hours on macOS without crashing
-3. All T-D, T-I, and T-A tests pass
-4. Dashboard shows real live data from daemon
-5. Jump via dashboard opens iTerm2 attached to correct session
-6. `auto_start` session killed externally restarts within 30 seconds
-7. Cron-scheduled session starts within 15 seconds of scheduled time
+3. All writer-gate, lifecycle, API, and reliability tests pass
+4. Primary dashboard shows all defined projects (running and stopped) with per-pane ATM state
+5. Jump via dashboard opens iTerm2 attached to correct session (viewer-only behavior)
+6. `stop` performs graceful ATM shutdown attempt before scoped hard-stop escalation
+7. Auto-start/cron only affect explicitly defined projects
 8. Disconnecting VPN for a remote host produces no error dialogs; host shows monochrome
 9. Reconnecting VPN restores full-color display within one poll cycle
-10. Missing `gh`/`az` tools show grayed badges with install tooltip
+10. Missing `gh`/`az` tools show degraded CI state with install guidance
 
 **v0.4.0 additional gates (AC-11..AC-16):**
 
@@ -434,5 +387,7 @@ The system is complete when:
 | OQ-1 | Dashboard served separately or by daemon? | Daemon serves static files at `/`. Single binary. |
 | OQ-2 | How does browser trigger terminal launch? | `POST /sessions/:name/jump` → daemon spawns iTerm2 via AppleScript. No URI schemes. |
 | OQ-3 | PR data: daemon or dashboard? | Daemon fetches via `gh`/`az` CLI. Adaptive interval: 1min active, 5min idle. Missing tools show gracefully. |
-| OQ-4 | Multi-host config location? | `scmux.toml` seeds SQLite. Hosts monitored continuously. VPN gaps are normal — monochrome, no errors. |
-| OQ-5 | `scmux` CLI scope? | Separate binary, HTTP client to daemon. Same API as web UI. Daemon is sole SQLite writer. |
+| OQ-4 | Multi-host config location? | Hosts are user-defined via editor and persisted in SQLite. VPN gaps are normal — monochrome, no errors. |
+| OQ-5 | `scmux` CLI scope? | Separate binary, HTTP client to daemon. Same API as web UI. Persistent writes are restricted to the project-definition editor path. |
+| OQ-6 | Final `done` semantics and auto-teardown policy? | Pending product decision; keep default non-destructive behavior until explicitly approved. |
+| OQ-7 | Stop escalation exact parameters (timeouts/retries/hard-stop policy)? | Pending product decision; keep graceful-first and scoped behavior mandatory. |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -138,6 +138,9 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | API-15 | `GET /dashboard-config.json` — host list + dashboard settings for web UI | 1.2 |
 | API-16 | `GET /discovery` shall expose raw tmux discovery (including non-defined sessions) without mutating SQLite definitions | 6.0 |
 | API-17 | `POST /sessions/:name/start` shall reject missing/malformed `config_json` with a structured validation error payload | 6.0 |
+| API-18 | `POST /hosts` — create host definition (editor-only persistent write path via `definition_writer`) | 6.0 |
+| API-19 | `PATCH /hosts/:id` — update host definition (editor-only persistent write path via `definition_writer`) | 6.0 |
+| API-20 | `DELETE /hosts/:id` — remove/disable host definition (editor-only persistent write path via `definition_writer`) | 6.0 |
 
 ### 4.8 Multi-Host / VPN Handling
 
@@ -270,6 +273,7 @@ When running 20–30 concurrent Claude Code agent teams across multiple machines
 | NF-03 | Poll cycle shall complete in < 500ms for up to 50 projects | 4.1 |
 | NF-04 | HTTP read endpoints shall respond in < 100ms | 4.1 |
 | NF-05 | The system shall work on macOS (primary) and Linux (DGX Spark) | 4.1 |
+| NF-06 | Removed — consolidated into DG-06 (no reconstruction from tmux discovery) | 6.0 |
 | NF-07 | All CI/ATM/network errors shall be handled gracefully and logged with trace context | 6.0 |
 | NF-08 | Single-host or single-session failures shall not crash the daemon or stop unrelated sessions | 4.1 |
 | NF-09 | Stop behavior shall be graceful-first and must not perform bulk kill on panic/error paths | 6.0 |


### PR DESCRIPTION
## Summary
- replace requirements/architecture with definition-first design model
- enforce writer-subsystem-only persistence model (multiple editor entry points allowed)
- remove discovery-first assumptions and NF-06 reconstruction behavior
- add refactor scope document for conflicting runtime write paths
- add graceful-first stop safety, runtime-ephemeral policy, and OTel-readiness notes

## Files
- docs/requirements.md
- docs/architecture.md
- docs/refactor-scope-v0.5.md

## Notes
Docs-only change; no code modifications.