### PR TITLE
feat(p6-s1): writer gate, in-memory runtime projection, tmux_poller rename, graceful stop

### DIFF
--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -6,17 +6,16 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use rusqlite::params;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 
-use crate::db;
+use crate::atm::ShutdownTarget;
+use crate::runtime::{AtmRuntimeSummary, CiRuntimeSummary};
 use crate::tmux::{self, HostTarget};
-use crate::AppState;
+use crate::{atm, db, definition_writer, AppState};
 
 pub fn router(state: Arc<AppState>) -> Router {
     let middleware_state = Arc::clone(&state);
@@ -26,8 +25,13 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/react.min.js", get(react_js))
         .route("/react-dom.min.js", get(react_dom_js))
         .route("/health", get(health))
-        .route("/hosts", get(list_hosts))
+        .route("/hosts", get(list_hosts).post(create_host))
+        .route(
+            "/hosts/:id",
+            axum::routing::patch(patch_host).delete(delete_host),
+        )
         .route("/dashboard-config.json", get(get_dashboard_config))
+        .route("/discovery", get(get_discovery))
         .route("/sessions", get(list_sessions).post(create_session))
         .route(
             "/sessions/:name",
@@ -46,6 +50,7 @@ const DASHBOARD_JS: &[u8] = include_bytes!("../assets/dashboard.js");
 const REACT_JS: &[u8] = include_bytes!("../assets/react.min.js");
 const REACT_DOM_JS: &[u8] = include_bytes!("../assets/react-dom.min.js");
 const DEFAULT_POLL_INTERVAL_SECS: u64 = 15;
+const DEFAULT_STOP_GRACE_SECS: u64 = 10;
 
 #[derive(Serialize)]
 struct HealthResponse {
@@ -109,6 +114,13 @@ struct ActionResponse {
     message: String,
 }
 
+#[derive(Serialize)]
+struct ErrorResponse {
+    ok: bool,
+    code: String,
+    message: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct CreateSessionRequest {
     name: String,
@@ -136,6 +148,23 @@ struct PatchSessionRequest {
 struct JumpRequest {
     terminal: Option<String>,
     host_id: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateHostRequest {
+    name: String,
+    address: String,
+    ssh_user: Option<String>,
+    api_port: Option<u16>,
+    is_local: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchHostRequest {
+    name: Option<String>,
+    address: Option<String>,
+    ssh_user: Option<Option<String>>,
+    api_port: Option<u16>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -237,50 +266,52 @@ async fn health(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
 }
 
 async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionSummary>> {
-    let sessions = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<SessionSummary>> {
-        let db = state.db.lock().unwrap();
-        let ci_by_session = load_ci_by_session(&db)?;
-        let atm_by_session = if state.atm_available.load(Ordering::Relaxed) {
-            load_atm_by_session_name(&db)?
-        } else {
-            HashMap::new()
-        };
-        let mut stmt = db.prepare(
-            "SELECT s.id, s.name, s.project, s.host_id, s.cron_schedule, s.auto_start,
-                    COALESCE(ss.status, 'stopped') as status,
-                    COALESCE(ss.panes_json, '[]') as panes_json,
-                    ss.polled_at
-                 FROM sessions s
-                 LEFT JOIN session_status ss ON ss.session_id = s.id
-                 WHERE s.enabled = 1
-                 ORDER BY s.host_id, s.project, s.name",
-        )?;
+    let session_rows = {
+        let state = Arc::clone(&state);
+        tokio::task::spawn_blocking(move || {
+            let db = state.db.lock().expect("db lock");
+            db::list_sessions_for_host(&db, state.host_id)
+        })
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .unwrap_or_default()
+    };
 
-        let rows = stmt.query_map([], |r| {
-            let panes_str: String = r.get(7)?;
-            let id: i64 = r.get(0)?;
-            let name: String = r.get(1)?;
-            Ok(SessionSummary {
-                id,
-                name: name.clone(),
-                project: r.get(2)?,
-                host_id: r.get(3)?,
-                cron_schedule: r.get(4)?,
-                auto_start: r.get(5)?,
-                status: r.get(6)?,
-                panes: serde_json::from_str(&panes_str).unwrap_or(serde_json::json!([])),
-                polled_at: r.get(8)?,
-                session_ci: ci_by_session.get(&id).cloned().unwrap_or_default(),
-                atm: atm_by_session.get(&name).cloned(),
+    let atm_available = state.atm_available.load(Ordering::Relaxed);
+    let sessions = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        session_rows
+            .into_iter()
+            .map(|row| {
+                let runtime_row = runtime.session(&row.name).cloned().unwrap_or_default();
+                let ci = runtime
+                    .ci_for_session(&row.name)
+                    .into_iter()
+                    .map(from_ci_runtime)
+                    .collect::<Vec<_>>();
+                let atm = if atm_available {
+                    runtime.atm_for_session(&row.name).map(from_atm_runtime)
+                } else {
+                    None
+                };
+
+                SessionSummary {
+                    id: row.id,
+                    name: row.name,
+                    project: row.project,
+                    host_id: row.host_id,
+                    status: runtime_row.status,
+                    cron_schedule: row.cron_schedule,
+                    auto_start: row.auto_start,
+                    panes: serde_json::to_value(runtime_row.panes).unwrap_or(serde_json::json!([])),
+                    polled_at: runtime_row.polled_at,
+                    session_ci: ci,
+                    atm,
+                }
             })
-        })?;
-
-        Ok(rows.filter_map(|r| r.ok()).collect::<Vec<_>>())
-    })
-    .await
-    .ok()
-    .and_then(Result::ok)
-    .unwrap_or_default();
+            .collect::<Vec<_>>()
+    };
 
     Json(sessions)
 }
@@ -289,112 +320,67 @@ async fn get_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<SessionDetail>, StatusCode> {
-    let result = tokio::task::spawn_blocking(move || {
-        let db = state.db.lock().unwrap();
+    let row = {
+        let state = Arc::clone(&state);
+        let name = name.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let db = state.db.lock().expect("db lock");
+            db::get_session_for_host(&db, state.host_id, &name)
+        })
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        result.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    }
+    .ok_or(StatusCode::NOT_FOUND)?;
 
-        let row = db
-            .query_row(
-                "SELECT s.id, s.host_id, s.name, s.project, s.cron_schedule, s.auto_start,
-                    s.config_json,
-                    COALESCE(ss.status, 'stopped'),
-                    COALESCE(ss.panes_json, '[]'),
-                    ss.polled_at
-             FROM sessions s
-             LEFT JOIN session_status ss ON ss.session_id = s.id
-             WHERE s.name = ?1 AND s.host_id = ?2 AND s.enabled = 1",
-                params![name, state.host_id],
-                |r| {
-                    let panes_str: String = r.get(8)?;
-                    let config_str: String = r.get(6)?;
-                    Ok((
-                        r.get::<_, i64>(0)?,
-                        r.get::<_, i64>(1)?,
-                        r.get::<_, String>(2)?,
-                        r.get::<_, Option<String>>(3)?,
-                        r.get::<_, Option<String>>(4)?,
-                        r.get::<_, bool>(5)?,
-                        config_str,
-                        r.get::<_, String>(7)?,
-                        panes_str,
-                        r.get::<_, Option<String>>(9)?,
-                    ))
-                },
-            )
-            .map_err(|_| StatusCode::NOT_FOUND)?;
-
-        let (
-            id,
-            host_id,
-            name,
-            project,
-            cron_schedule,
-            auto_start,
-            config_str,
-            status,
-            panes_str,
-            polled_at,
-        ) = row;
-        let session_ci =
-            load_ci_for_session(&db, id).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        let atm = if state.atm_available.load(Ordering::Relaxed) {
-            load_atm_for_session(&db, &name).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    let config_json = serde_json::from_str(&row.config_json).unwrap_or(serde_json::json!({}));
+    let atm_available = state.atm_available.load(Ordering::Relaxed);
+    let (runtime_row, ci, atm) = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        let runtime_row = runtime.session(&row.name).cloned().unwrap_or_default();
+        let ci = runtime
+            .ci_for_session(&row.name)
+            .into_iter()
+            .map(from_ci_runtime)
+            .collect::<Vec<_>>();
+        let atm = if atm_available {
+            runtime.atm_for_session(&row.name).map(from_atm_runtime)
         } else {
             None
         };
+        (runtime_row, ci, atm)
+    };
 
-        let mut estmt = db
-            .prepare(
-                "SELECT event, trigger, note, occurred_at
-             FROM session_events
-             WHERE session_id = ?1
-             ORDER BY occurred_at DESC LIMIT 20",
-            )
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-        let events: Vec<EventRow> = estmt
-            .query_map(params![id], |r| {
-                Ok(EventRow {
-                    event: r.get(0)?,
-                    trigger: r.get(1)?,
-                    note: r.get(2)?,
-                    occurred_at: r.get(3)?,
-                })
-            })
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        Ok::<_, StatusCode>(Json(SessionDetail {
-            summary: SessionSummary {
-                id,
-                name,
-                project,
-                host_id,
-                cron_schedule,
-                auto_start,
-                status,
-                panes: serde_json::from_str(&panes_str).unwrap_or(serde_json::json!([])),
-                polled_at,
-                session_ci,
-                atm,
-            },
-            config_json: serde_json::from_str(&config_str).unwrap_or(serde_json::json!({})),
-            recent_events: events,
-        }))
-    })
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    result
+    Ok(Json(SessionDetail {
+        summary: SessionSummary {
+            id: row.id,
+            name: row.name,
+            project: row.project,
+            host_id: row.host_id,
+            status: runtime_row.status,
+            cron_schedule: row.cron_schedule,
+            auto_start: row.auto_start,
+            panes: serde_json::to_value(runtime_row.panes).unwrap_or(serde_json::json!([])),
+            polled_at: runtime_row.polled_at,
+            session_ci: ci,
+            atm,
+        },
+        config_json,
+        recent_events: Vec::new(),
+    }))
 }
 
 async fn create_session(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateSessionRequest>,
-) -> Result<Json<ActionResponse>, StatusCode> {
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
     let host_id = req.host_id.unwrap_or(state.host_id);
-    let config_json =
-        serde_json::to_string(&req.config_json).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let config_json = serde_json::to_string(&req.config_json).map_err(|_| {
+        bad_request(
+            "invalid_json",
+            "config_json payload could not be serialized".to_string(),
+        )
+    })?;
 
     let new_session = db::NewSession {
         name: req.name.clone(),
@@ -408,24 +394,18 @@ async fn create_session(
     };
 
     let result = tokio::task::spawn_blocking(move || {
-        let db_conn = state.db.lock().unwrap();
-        db::create_session(&db_conn, &new_session)
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_session(&db_conn, &new_session)
     })
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|_| internal_error("failed to join create_session task".to_string()))?;
 
     match result {
         Ok(_) => Ok(Json(ActionResponse {
             ok: true,
             message: format!("session '{}' created", req.name),
         })),
-        Err(err) => {
-            let msg = err.to_string();
-            if msg.contains("UNIQUE constraint failed") {
-                return Err(StatusCode::CONFLICT);
-            }
-            Err(StatusCode::BAD_REQUEST)
-        }
+        Err(err) => Err(map_write_error(err)),
     }
 }
 
@@ -433,7 +413,7 @@ async fn patch_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
     Json(req): Json<PatchSessionRequest>,
-) -> Result<Json<ActionResponse>, StatusCode> {
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
     let response_name = name.clone();
     let patch = db::SessionPatch {
         project: req.project,
@@ -448,78 +428,117 @@ async fn patch_session(
         azure_project: req.azure_project,
     };
 
+    let host_id = state.host_id;
     let result = tokio::task::spawn_blocking(move || {
-        let db_conn = state.db.lock().unwrap();
-        db::update_session(&db_conn, state.host_id, &name, &patch)
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_session(&db_conn, host_id, &name, &patch)
     })
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|_| internal_error("failed to join patch_session task".to_string()))?;
 
     match result {
         Ok(true) => Ok(Json(ActionResponse {
             ok: true,
             message: format!("session '{response_name}' updated"),
         })),
-        Ok(false) => Err(StatusCode::NOT_FOUND),
-        Err(_) => Err(StatusCode::BAD_REQUEST),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("session '{response_name}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
     }
 }
 
 async fn delete_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
-) -> Result<Json<ActionResponse>, StatusCode> {
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
     let response_name = name.clone();
+    let host_id = state.host_id;
     let result = tokio::task::spawn_blocking(move || {
-        let db_conn = state.db.lock().unwrap();
-        db::soft_delete_session(&db_conn, state.host_id, &name)
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::delete_session(&db_conn, host_id, &name)
     })
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|_| internal_error("failed to join delete_session task".to_string()))?;
 
     match result {
         Ok(true) => Ok(Json(ActionResponse {
             ok: true,
             message: format!("session '{response_name}' disabled"),
         })),
-        Ok(false) => Err(StatusCode::NOT_FOUND),
-        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("session '{response_name}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
     }
 }
 
 async fn start_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
-) -> Result<Json<ActionResponse>, StatusCode> {
-    let state2 = Arc::clone(&state);
-    let name2 = name.clone();
-    let config_json = tokio::task::spawn_blocking(move || {
-        let db_conn = state2.db.lock().unwrap();
-        db_conn
-            .query_row(
-                "SELECT config_json FROM sessions WHERE name = ?1 AND host_id = ?2 AND enabled = 1",
-                params![name2, state2.host_id],
-                |r| r.get::<_, String>(0),
-            )
-            .map_err(|_| StatusCode::NOT_FOUND)
-    })
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)??;
-
-    let action = tmux::start_session(&name, &config_json).await;
-    log_action_result(&state, &name, "started", "manual", action.as_ref().err())
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let definition = {
+        let state = Arc::clone(&state);
+        let name = name.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let db_conn = state.db.lock().expect("db lock");
+            db::get_session_for_host(&db_conn, state.host_id, &name)
+        })
         .await
-        .ok();
+        .map_err(|_| internal_error("failed to join start_session read task".to_string()))?;
+        result.map_err(|_| internal_error("failed to read session definition".to_string()))?
+    }
+    .ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("session '{name}' not found"),
+            }),
+        )
+    })?;
 
+    if let Err(message) = validate_start_config(&definition.config_json, &name) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                ok: false,
+                code: "invalid_config".to_string(),
+                message,
+            }),
+        ));
+    }
+
+    {
+        let mut runtime = state.runtime.lock().expect("runtime lock");
+        runtime.mark_starting(&name);
+    }
+
+    let action = tmux::start_session(&name, &definition.config_json).await;
     match action {
         Ok(()) => Ok(Json(ActionResponse {
             ok: true,
             message: format!("session '{name}' started"),
         })),
-        Err(e) => Ok(Json(ActionResponse {
-            ok: false,
-            message: e.to_string(),
-        })),
+        Err(err) => {
+            let mut runtime = state.runtime.lock().expect("runtime lock");
+            runtime.mark_start_failed(&name, err.to_string());
+            Ok(Json(ActionResponse {
+                ok: false,
+                message: err.to_string(),
+            }))
+        }
     }
 }
 
@@ -527,41 +546,57 @@ async fn stop_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<ActionResponse>, StatusCode> {
-    let state2 = Arc::clone(&state);
-    let name2 = name.clone();
-    let exists = tokio::task::spawn_blocking(move || {
-        let db_conn = state2.db.lock().unwrap();
-        db_conn
-            .query_row(
-                "SELECT COUNT(*) > 0 FROM sessions WHERE name = ?1 AND host_id = ?2 AND enabled = 1",
-                params![name2, state2.host_id],
-                |r| r.get::<_, bool>(0),
-            )
-            .map_err(anyhow::Error::from)
-    })
-    .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    ;
-    if !exists {
-        return Err(StatusCode::NOT_FOUND);
-    }
-
-    let action = tmux::stop_session(&name).await;
-    log_action_result(&state, &name, "stopped", "manual", action.as_ref().err())
+    let definition = {
+        let state = Arc::clone(&state);
+        let name = name.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let db_conn = state.db.lock().expect("db lock");
+            db::get_session_for_host(&db_conn, state.host_id, &name)
+        })
         .await
-        .ok();
-
-    match action {
-        Ok(()) => Ok(Json(ActionResponse {
-            ok: true,
-            message: format!("session '{name}' stopped"),
-        })),
-        Err(e) => Ok(Json(ActionResponse {
-            ok: false,
-            message: e.to_string(),
-        })),
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        result.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     }
+    .ok_or(StatusCode::NOT_FOUND)?;
+
+    let targets = extract_shutdown_targets(&definition.config_json);
+    let _ = atm::send_shutdown_messages(&targets).await;
+
+    let grace_secs = state
+        .config
+        .atm
+        .stop_grace_secs
+        .unwrap_or(DEFAULT_STOP_GRACE_SECS)
+        .max(1);
+    tokio::time::sleep(tokio::time::Duration::from_secs(grace_secs)).await;
+
+    let live = tmux::live_sessions().await.unwrap_or_default();
+    let still_running = live.contains_key(&name);
+
+    let response = if still_running {
+        match tmux::stop_session(&name).await {
+            Ok(()) => ActionResponse {
+                ok: true,
+                message: format!("session '{name}' stopped after graceful timeout"),
+            },
+            Err(err) => ActionResponse {
+                ok: false,
+                message: err.to_string(),
+            },
+        }
+    } else {
+        ActionResponse {
+            ok: true,
+            message: format!("session '{name}' stopped gracefully"),
+        }
+    };
+
+    if response.ok {
+        let mut runtime = state.runtime.lock().expect("runtime lock");
+        runtime.mark_stopped(&name);
+    }
+
+    Ok(Json(response))
 }
 
 async fn jump_session(
@@ -573,58 +608,38 @@ async fn jump_session(
     let state2 = Arc::clone(&state);
     let name2 = name.clone();
     let session_data = tokio::task::spawn_blocking(move || {
-        let db_conn = state2.db.lock().unwrap();
-        db_conn
-            .query_row(
-                "SELECT s.id, s.name, h.address, h.is_local, h.ssh_user, h.api_port
-                 FROM sessions s
-                 INNER JOIN hosts h ON h.id = s.host_id
-                 WHERE s.name = ?1 AND s.host_id = ?2 AND s.enabled = 1
-                 LIMIT 1",
-                params![name2, host_id],
-                |r| {
-                    Ok((
-                        r.get::<_, i64>(0)?,
-                        r.get::<_, String>(1)?,
-                        r.get::<_, String>(2)?,
-                        r.get::<_, bool>(3)?,
-                        r.get::<_, Option<String>>(4)?,
-                        r.get::<_, u16>(5)?,
-                    ))
-                },
-            )
-            .map_err(|_| StatusCode::NOT_FOUND)
+        let db_conn = state2.db.lock().expect("db lock");
+        let session = db::get_session_for_host(&db_conn, host_id, &name2)?;
+        let host = db::get_host(&db_conn, host_id)?;
+        Ok::<_, anyhow::Error>((session, host))
     })
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)??;
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    let (session_id, _session_name, host, is_local, ssh_user, _api_port) = session_data;
+    let (_session, host) = session_data;
+    let host = host.ok_or(StatusCode::NOT_FOUND)?;
+
     let terminal = req
         .terminal
         .or_else(|| state.config.daemon.default_terminal.clone())
         .unwrap_or_else(|| "iterm2".to_string());
 
-    let target = if is_local {
+    let target = if host.is_local {
         HostTarget::Local
     } else {
         HostTarget::Remote {
-            user: ssh_user.ok_or(StatusCode::BAD_REQUEST)?,
-            host,
+            user: host.ssh_user.ok_or(StatusCode::BAD_REQUEST)?,
+            host: host.address,
         }
     };
 
     let result = tmux::jump_session(target, &name, &terminal).await;
-    let note = result.as_ref().err().map(|err| err.to_string());
-    let event = if result.is_ok() { "jumped" } else { "failed" };
-    log_session_event(&state, session_id, event, "manual", note.as_deref())
-        .await
-        .ok();
-
     match result {
         Ok(message) => Ok(Json(ActionResponse { ok: true, message })),
-        Err(e) => Ok(Json(ActionResponse {
+        Err(err) => Ok(Json(ActionResponse {
             ok: false,
-            message: e.to_string(),
+            message: err.to_string(),
         })),
     }
 }
@@ -632,6 +647,98 @@ async fn jump_session(
 async fn list_hosts(State(state): State<Arc<AppState>>) -> Json<Vec<HostSummary>> {
     let hosts = fetch_hosts(state).await.unwrap_or_default();
     Json(hosts)
+}
+
+async fn create_host(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateHostRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let host = db::NewHost {
+        name: req.name.clone(),
+        address: req.address,
+        ssh_user: req.ssh_user,
+        api_port: req.api_port.unwrap_or(7878),
+        is_local: req.is_local.unwrap_or(false),
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_host(&db_conn, &host)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_host task".to_string()))?;
+
+    match result {
+        Ok(_) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("host '{}' created", req.name),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_host(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchHostRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = db::HostPatch {
+        name: req.name,
+        address: req.address,
+        ssh_user: req.ssh_user,
+        api_port: req.api_port,
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_host(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_host task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("host '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("host '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn delete_host(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::delete_host(&db_conn, id)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join delete_host task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("host '{id}' disabled"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("host '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
 }
 
 async fn get_dashboard_config(
@@ -657,179 +764,182 @@ async fn get_dashboard_config(
     }))
 }
 
+async fn get_discovery(
+    State(state): State<Arc<AppState>>,
+) -> Json<Vec<crate::runtime::DiscoverySession>> {
+    let rows = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        runtime.discovery_rows()
+    };
+    Json(rows)
+}
+
 async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
     let reachability = {
         let map = state.reachability.lock().expect("reachability lock");
         map.clone()
     };
-    let hosts = tokio::task::spawn_blocking(move || {
-        let db_conn = state.db.lock().unwrap();
-        let mut stmt = db_conn.prepare(
-            "SELECT id, name, address, ssh_user, api_port, is_local, last_seen
-             FROM hosts ORDER BY is_local DESC, name",
-        )?;
-        let rows = stmt
-            .query_map([], |r| {
-                let id: i64 = r.get(0)?;
-                let is_local: bool = r.get(5)?;
-                let address: String = r.get(2)?;
-                let api_port: u16 = r.get(4)?;
-                let db_last_seen: Option<String> = r.get(6)?;
-                let reach = reachability.get(&id);
-                let reachable = if is_local {
-                    true
-                } else {
-                    reach.map(|entry| entry.reachable).unwrap_or(false)
-                };
-                let last_seen = reach
-                    .and_then(|entry| entry.last_seen.clone())
-                    .or(db_last_seen);
-                Ok(HostSummary {
-                    id,
-                    name: r.get(1)?,
-                    address: address.clone(),
-                    ssh_user: r.get(3)?,
-                    api_port,
-                    is_local,
-                    last_seen,
-                    reachable,
-                    url: format!("http://{address}:{api_port}"),
-                })
-            })?
-            .filter_map(|row| row.ok())
-            .collect::<Vec<_>>();
-        Ok::<_, anyhow::Error>(rows)
+
+    let rows = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        db::list_hosts(&db_conn)
     })
     .await??;
+
+    let hosts = rows
+        .into_iter()
+        .map(|row| {
+            let reach = reachability.get(&row.id);
+            let reachable = if row.is_local {
+                true
+            } else {
+                reach.map(|entry| entry.reachable).unwrap_or(false)
+            };
+            let last_seen = reach
+                .and_then(|entry| entry.last_seen.clone())
+                .or(row.last_seen);
+            HostSummary {
+                id: row.id,
+                name: row.name,
+                address: row.address.clone(),
+                ssh_user: row.ssh_user,
+                api_port: row.api_port,
+                is_local: row.is_local,
+                last_seen,
+                reachable,
+                url: format!("http://{}:{}", row.address, row.api_port),
+            }
+        })
+        .collect::<Vec<_>>();
+
     Ok(hosts)
 }
 
-fn load_ci_by_session(
-    db: &rusqlite::Connection,
-) -> anyhow::Result<HashMap<i64, Vec<SessionCiSummary>>> {
-    let mut stmt = db.prepare(
-        "SELECT session_id, provider, status, data_json, tool_message, polled_at, next_poll_at
-         FROM session_ci
-         ORDER BY session_id, provider",
-    )?;
-    let mut map: HashMap<i64, Vec<SessionCiSummary>> = HashMap::new();
-    let rows = stmt.query_map([], |r| {
-        let data_json: Option<String> = r.get(3)?;
-        Ok((
-            r.get::<_, i64>(0)?,
-            SessionCiSummary {
-                provider: r.get(1)?,
-                status: r.get(2)?,
-                data_json: data_json.and_then(|raw| serde_json::from_str(&raw).ok()),
-                tool_message: r.get(4)?,
-                polled_at: r.get(5)?,
-                next_poll_at: r.get(6)?,
-            },
-        ))
-    })?;
-
-    for row in rows {
-        let (session_id, entry) = row?;
-        map.entry(session_id).or_default().push(entry);
+fn from_ci_runtime(entry: CiRuntimeSummary) -> SessionCiSummary {
+    SessionCiSummary {
+        provider: entry.provider,
+        status: entry.status,
+        data_json: entry.data_json,
+        tool_message: entry.tool_message,
+        polled_at: entry.polled_at,
+        next_poll_at: entry.next_poll_at,
     }
-    Ok(map)
 }
 
-fn load_ci_for_session(
-    db: &rusqlite::Connection,
-    session_id: i64,
-) -> anyhow::Result<Vec<SessionCiSummary>> {
-    let mut stmt = db.prepare(
-        "SELECT provider, status, data_json, tool_message, polled_at, next_poll_at
-         FROM session_ci
-         WHERE session_id = ?1
-         ORDER BY provider",
-    )?;
-    let rows = stmt
-        .query_map(params![session_id], |r| {
-            let data_json: Option<String> = r.get(2)?;
-            Ok(SessionCiSummary {
-                provider: r.get(0)?,
-                status: r.get(1)?,
-                data_json: data_json.and_then(|raw| serde_json::from_str(&raw).ok()),
-                tool_message: r.get(3)?,
-                polled_at: r.get(4)?,
-                next_poll_at: r.get(5)?,
-            })
-        })?
-        .filter_map(|row| row.ok())
-        .collect::<Vec<_>>();
-    Ok(rows)
-}
-
-fn load_atm_by_session_name(
-    db: &rusqlite::Connection,
-) -> anyhow::Result<HashMap<String, SessionAtmSummary>> {
-    let rows = db::list_session_atm(db)?;
-    let mut map = HashMap::new();
-    for row in rows {
-        map.insert(
-            row.session_name,
-            SessionAtmSummary {
-                state: row.state,
-                last_transition: row.last_transition,
-            },
-        );
+fn from_atm_runtime(entry: AtmRuntimeSummary) -> SessionAtmSummary {
+    SessionAtmSummary {
+        state: entry.state,
+        last_transition: entry.last_transition,
     }
-    Ok(map)
 }
 
-fn load_atm_for_session(
-    db: &rusqlite::Connection,
-    session_name: &str,
-) -> anyhow::Result<Option<SessionAtmSummary>> {
-    let map = load_atm_by_session_name(db)?;
-    Ok(map.get(session_name).cloned())
+fn validate_start_config(config_json: &str, name: &str) -> Result<(), String> {
+    let value: serde_json::Value = serde_json::from_str(config_json)
+        .map_err(|err| format!("config_json is not valid JSON: {err}"))?;
+    let session_name = value
+        .get("session_name")
+        .and_then(|raw| raw.as_str())
+        .ok_or_else(|| "config_json.session_name is required".to_string())?;
+    if session_name != name {
+        return Err("config_json.session_name must equal route session name".to_string());
+    }
+    let panes = value
+        .get("panes")
+        .and_then(|raw| raw.as_array())
+        .ok_or_else(|| "config_json.panes[] is required".to_string())?;
+    if panes.is_empty() {
+        return Err("config_json.panes[] must contain at least one pane".to_string());
+    }
+    Ok(())
 }
 
-async fn log_action_result(
-    state: &Arc<AppState>,
-    name: &str,
-    success_event: &str,
-    trigger: &str,
-    err: Option<&anyhow::Error>,
-) -> anyhow::Result<()> {
-    let note = err.map(|e| e.to_string());
-    let event = if err.is_some() {
-        "failed".to_string()
-    } else {
-        success_event.to_string()
+fn extract_shutdown_targets(config_json: &str) -> Vec<ShutdownTarget> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(config_json) else {
+        return Vec::new();
     };
-    let trigger = trigger.to_string();
-    let name = name.to_string();
-    let state = Arc::clone(state);
-    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-        let db_conn = state.db.lock().unwrap();
-        let Some(session_id) = db::session_id(&db_conn, state.host_id, &name)? else {
-            return Ok(());
-        };
-        db::log_session_event(&db_conn, session_id, &event, &trigger, note.as_deref())?;
-        Ok(())
-    })
-    .await??;
-    Ok(())
+    let Some(panes) = value.get("panes").and_then(|raw| raw.as_array()) else {
+        return Vec::new();
+    };
+
+    panes
+        .iter()
+        .filter_map(|pane| {
+            let team = pane.get("atm_team").and_then(|raw| raw.as_str())?.trim();
+            let agent = pane.get("atm_agent").and_then(|raw| raw.as_str())?.trim();
+            if team.is_empty() || agent.is_empty() {
+                return None;
+            }
+            Some(ShutdownTarget {
+                team: team.to_string(),
+                agent: agent.to_string(),
+            })
+        })
+        .collect::<Vec<_>>()
 }
 
-async fn log_session_event(
-    state: &Arc<AppState>,
-    session_id: i64,
-    event: &str,
-    trigger: &str,
-    note: Option<&str>,
-) -> anyhow::Result<()> {
-    let event = event.to_string();
-    let trigger = trigger.to_string();
-    let note = note.map(ToOwned::to_owned);
-    let state = Arc::clone(state);
-    tokio::task::spawn_blocking(move || {
-        let db_conn = state.db.lock().unwrap();
-        db::log_session_event(&db_conn, session_id, &event, &trigger, note.as_deref())
-    })
-    .await??;
-    Ok(())
+fn map_write_error(err: definition_writer::WriteError) -> (StatusCode, Json<ErrorResponse>) {
+    match err {
+        definition_writer::WriteError::NotFound => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: "resource not found".to_string(),
+            }),
+        ),
+        definition_writer::WriteError::Conflict(message) => (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                ok: false,
+                code: "conflict".to_string(),
+                message,
+            }),
+        ),
+        definition_writer::WriteError::Validation(message) => (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                ok: false,
+                code: "validation_error".to_string(),
+                message,
+            }),
+        ),
+        definition_writer::WriteError::Forbidden(message) => (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse {
+                ok: false,
+                code: "forbidden".to_string(),
+                message,
+            }),
+        ),
+        definition_writer::WriteError::Internal(message) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                ok: false,
+                code: "internal_error".to_string(),
+                message,
+            }),
+        ),
+    }
+}
+
+fn bad_request(code: &str, message: String) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            ok: false,
+            code: code.to_string(),
+            message,
+        }),
+    )
+}
+
+fn internal_error(message: String) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse {
+            ok: false,
+            code: "internal_error".to_string(),
+            message,
+        }),
+    )
 }

--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -1,15 +1,22 @@
-use crate::{db, AppState};
+use crate::{runtime::AtmRuntimeUpdate, AppState};
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use tracing::warn;
 
 const SOCKET_TIMEOUT_SECS: u64 = 2;
 const DEFAULT_STUCK_MINUTES: u64 = 10;
+
+#[derive(Debug, Clone)]
+pub struct ShutdownTarget {
+    pub team: String,
+    pub agent: String,
+}
 
 #[derive(Debug, Deserialize)]
 struct SocketResponse<T> {
@@ -50,6 +57,8 @@ pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
 
     if teams.is_empty() {
         state.atm_available.store(false, Ordering::Relaxed);
+        let mut runtime = state.runtime.lock().expect("runtime lock");
+        runtime.clear_atm();
         return Ok(());
     }
 
@@ -59,7 +68,7 @@ pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
         .stuck_minutes
         .unwrap_or(DEFAULT_STUCK_MINUTES) as i64;
     let now = state.clock.now_utc();
-    let updated_at = now.to_rfc3339();
+
     let mut updates = Vec::new();
     let mut successful_teams = 0usize;
     let mut first_error: Option<anyhow::Error> = None;
@@ -71,7 +80,7 @@ pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
                 agents
             }
             Err(err) => {
-                warn!("atm list-agents failed for team '{team}': {err}");
+                tracing::warn!("atm list-agents failed for team '{}': {}", team, err);
                 if first_error.is_none() {
                     first_error = Some(err);
                 }
@@ -87,9 +96,11 @@ pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
             let state_entry = match query_agent_state(&socket_path, &team, &agent.agent).await {
                 Ok(entry) => Some(entry),
                 Err(err) => {
-                    warn!(
+                    tracing::warn!(
                         "atm agent-state failed for team='{}' agent='{}': {}",
-                        team, agent.agent, err
+                        team,
+                        agent.agent,
+                        err
                     );
                     None
                 }
@@ -112,34 +123,83 @@ pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
                 derived_state = "stuck".to_string();
             }
 
-            updates.push(db::SessionAtmUpdate {
+            updates.push(AtmRuntimeUpdate {
                 session_name,
-                agent_id: agent.agent.clone(),
-                team: team.clone(),
                 state: derived_state,
                 last_transition,
-                updated_at: updated_at.clone(),
             });
         }
     }
 
     if successful_teams == 0 {
         state.atm_available.store(false, Ordering::Relaxed);
+        let mut runtime = state.runtime.lock().expect("runtime lock");
+        runtime.clear_atm();
         return Err(first_error.unwrap_or_else(|| anyhow!("ATM query failed for all teams")));
     }
 
     {
-        let state = Arc::clone(state);
-        let updates_for_db = updates;
-        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            let db_conn = state.db.lock().expect("db lock");
-            db::replace_session_atm(&db_conn, &updates_for_db)
-        })
-        .await??;
+        let mut runtime = state.runtime.lock().expect("runtime lock");
+        runtime.apply_atm_updates(updates);
     }
 
     state.atm_available.store(true, Ordering::Relaxed);
     Ok(())
+}
+
+pub async fn send_shutdown_messages(targets: &[ShutdownTarget]) -> anyhow::Result<usize> {
+    if targets.is_empty() {
+        return Ok(0);
+    }
+
+    let unique = targets
+        .iter()
+        .map(|target| (target.team.clone(), target.agent.clone()))
+        .collect::<HashSet<_>>();
+
+    let mut sent = 0usize;
+    for (team, agent) in unique {
+        let output = tokio::process::Command::new(atm_bin())
+            .arg("send")
+            .arg(&agent)
+            .arg("--team")
+            .arg(&team)
+            .arg("scmux: graceful shutdown requested; please stop current work and exit")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await;
+
+        match output {
+            Ok(result) if result.status.success() => {
+                sent += 1;
+            }
+            Ok(result) => {
+                let message = String::from_utf8_lossy(&result.stderr).trim().to_string();
+                tracing::warn!(
+                    "atm shutdown message failed team='{}' agent='{}': {}",
+                    team,
+                    agent,
+                    if message.is_empty() {
+                        format!("exit {}", result.status)
+                    } else {
+                        message
+                    }
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "atm shutdown message execution failed team='{}' agent='{}': {}",
+                    team,
+                    agent,
+                    err
+                );
+            }
+        }
+    }
+
+    Ok(sent)
 }
 
 fn resolve_socket_path(state: &AppState) -> PathBuf {
@@ -158,7 +218,7 @@ fn resolve_socket_path(state: &AppState) -> PathBuf {
 fn atm_home_dir() -> PathBuf {
     std::env::var_os("ATM_HOME")
         .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(PathBuf::from)) // QA-046+P5S3: macOS-only daemon, HOME always set
+        .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
@@ -279,6 +339,10 @@ fn request_id() -> String {
         std::process::id(),
         Utc::now().timestamp_nanos_opt().unwrap_or_default()
     )
+}
+
+fn atm_bin() -> String {
+    std::env::var("SCMUX_ATM_BIN").unwrap_or_else(|_| "atm".to_string())
 }
 
 #[cfg(unix)]

--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -39,8 +39,6 @@ struct AgentEntry {
     agent: String,
     #[serde(default)]
     state: String,
-    #[serde(default)]
-    session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -89,10 +87,6 @@ pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
         };
 
         for agent in agents {
-            let Some(session_name) = extract_session_name(agent.session_id.as_deref()) else {
-                continue;
-            };
-
             let state_entry = match query_agent_state(&socket_path, &team, &agent.agent).await {
                 Ok(entry) => Some(entry),
                 Err(err) => {
@@ -124,7 +118,8 @@ pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
             }
 
             updates.push(AtmRuntimeUpdate {
-                session_name,
+                team: team.clone(),
+                agent: agent.agent.clone(),
                 state: derived_state,
                 last_transition,
             });
@@ -250,19 +245,6 @@ fn normalize_state(state: &str) -> &'static str {
         "unknown" => "unknown",
         "stuck" => "stuck",
         _ => "unknown",
-    }
-}
-
-fn extract_session_name(session_id: Option<&str>) -> Option<String> {
-    let value = session_id?.trim();
-    if value.is_empty() {
-        return None;
-    }
-    let session = value.split(':').next().unwrap_or_default().trim();
-    if session.is_empty() {
-        None
-    } else {
-        Some(session.to_string())
     }
 }
 

--- a/crates/scmux-daemon/src/ci.rs
+++ b/crates/scmux-daemon/src/ci.rs
@@ -1,11 +1,9 @@
-use crate::{db, AppState};
+use crate::{db, runtime::CiRuntimeSummary, AppState};
 use chrono::Utc;
 use serde::Serialize;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::process::Command;
-use tracing::warn;
 
 const GH_INSTALL_HINT: &str = "Install gh CLI: brew install gh";
 const AZ_INSTALL_HINT: &str = "Install az CLI: brew install azure-cli";
@@ -41,9 +39,9 @@ pub fn next_interval(has_active_pane: bool) -> Duration {
 pub async fn poll_once(state: &Arc<AppState>) -> anyhow::Result<()> {
     let sessions = {
         let state = Arc::clone(state);
-        tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<db::CiSession>> {
+        tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<db::SessionDefinition>> {
             let db_conn = state.db.lock().expect("db lock");
-            db::list_ci_sessions(&db_conn)
+            db::list_sessions_for_host(&db_conn, state.host_id)
         })
         .await??
     };
@@ -164,51 +162,37 @@ pub async fn poll_azure(project: &str) -> ProviderResult {
 
 async fn poll_provider(
     state: Arc<AppState>,
-    session: &db::CiSession,
+    session: &db::SessionDefinition,
     provider: &str,
     tool_available: bool,
     tool_hint: &str,
     poll_result: impl std::future::Future<Output = ProviderResult>,
 ) {
-    let now = Utc::now();
-    let polled_at = now.to_rfc3339();
-    let next_poll_at = (now
-        + chrono::Duration::from_std(next_interval(session.has_active_pane))
-            .unwrap_or_else(|_| chrono::Duration::minutes(5)))
-    .to_rfc3339();
-
-    let due = {
-        let provider_for_db = provider.to_string();
-        let state = Arc::clone(&state);
-        let session_id = session.id;
-        let now_iso = polled_at.clone();
-        match tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
-            let db_conn = state.db.lock().expect("db lock");
-            db::ci_provider_due(&db_conn, session_id, &provider_for_db, &now_iso)
-        })
-        .await
-        {
-            Ok(Ok(due)) => due,
-            Ok(Err(err)) => {
-                warn!(
-                    "ci provider due-check error session={} provider={provider}: {err}",
-                    session.name
-                );
-                false
-            }
-            Err(err) => {
-                warn!(
-                    "ci provider due-check task failed session={} provider={provider}: {err}",
-                    session.name
-                );
-                false
-            }
-        }
+    let has_active_pane = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        runtime
+            .session(&session.name)
+            .map(|row| {
+                row.panes
+                    .iter()
+                    .any(|pane| pane.status.eq_ignore_ascii_case("active"))
+            })
+            .unwrap_or(false)
     };
 
+    let now = Utc::now();
+    let due = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        runtime.ci_due(session.id, provider, now)
+    };
     if !due {
         return;
     }
+
+    let polled_at = now.to_rfc3339();
+    let next_due = now
+        + chrono::Duration::from_std(next_interval(has_active_pane))
+            .unwrap_or_else(|_| chrono::Duration::minutes(5));
 
     let result = if !tool_available {
         ProviderResult {
@@ -220,43 +204,21 @@ async fn poll_provider(
         poll_result.await
     };
 
-    let update = db::SessionCiUpdate {
-        session_id: session.id,
+    let summary = CiRuntimeSummary {
         provider: provider.to_string(),
         status: result.status,
-        data_json: result
-            .data
-            .and_then(|value| serde_json::to_string(&value).ok()),
+        data_json: result.data,
         tool_message: result.tool_message,
-        polled_at,
-        next_poll_at,
+        polled_at: Some(polled_at),
+        next_poll_at: Some(next_due.to_rfc3339()),
     };
 
-    let state = Arc::clone(&state);
-    match tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-        let db_conn = state.db.lock().expect("db lock");
-        db::upsert_session_ci(&db_conn, &update)
-    })
-    .await
-    {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => {
-            warn!(
-                "ci upsert error session={} provider={provider}: {err}",
-                session.name
-            );
-        }
-        Err(err) => {
-            warn!(
-                "ci upsert task failed session={} provider={provider}: {err}",
-                session.name
-            );
-        }
-    }
+    let mut runtime = state.runtime.lock().expect("runtime lock");
+    runtime.upsert_ci(&session.name, session.id, summary, next_due);
 }
 
 async fn run_json_command(bin: &str, args: &[&str]) -> anyhow::Result<serde_json::Value> {
-    let output = Command::new(bin)
+    let output = tokio::process::Command::new(bin)
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/crates/scmux-daemon/src/config.rs
+++ b/crates/scmux-daemon/src/config.rs
@@ -30,6 +30,7 @@ pub struct PollingConfig {
 pub struct AtmConfig {
     pub socket_path: Option<String>,
     pub stuck_minutes: Option<u64>,
+    pub stop_grace_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -1,11 +1,8 @@
-// DG-02: This module is the sole SQLite writer. All Connection access is via AppState.db mutex.
-// No other module calls Connection::open — verified by audit (grep Connection::open crates/).
-use crate::config::HostConfig;
+// DG-02: SQLite is a definition store. Runtime pollers are read-only and update in-memory projection.
 use crate::AppState;
 use anyhow::{anyhow, bail};
 use cron::Schedule;
-use rusqlite::{params, Connection, Result};
-use rusqlite::{types::Value as SqlValue, OptionalExtension};
+use rusqlite::{params, types::Value as SqlValue, Connection, OptionalExtension, Result};
 use std::sync::Arc;
 use std::{fmt::Write as _, str::FromStr};
 
@@ -33,51 +30,45 @@ pub struct SessionPatch {
 }
 
 #[derive(Debug, Clone)]
-pub struct RemoteSessionUpsert {
-    pub name: String,
-    pub project: Option<String>,
-    pub cron_schedule: Option<String>,
-    pub auto_start: bool,
-    pub status: String,
-    pub panes_json: String,
-    pub polled_at: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct CiSession {
+pub struct SessionDefinition {
     pub id: i64,
     pub name: String,
+    pub project: Option<String>,
+    pub host_id: i64,
+    pub config_json: String,
+    pub cron_schedule: Option<String>,
+    pub auto_start: bool,
+    pub enabled: bool,
     pub github_repo: Option<String>,
     pub azure_project: Option<String>,
-    pub has_active_pane: bool,
 }
 
 #[derive(Debug, Clone)]
-pub struct SessionCiUpdate {
-    pub session_id: i64,
-    pub provider: String,
-    pub status: String,
-    pub data_json: Option<String>,
-    pub tool_message: Option<String>,
-    pub polled_at: String,
-    pub next_poll_at: String,
+pub struct NewHost {
+    pub name: String,
+    pub address: String,
+    pub ssh_user: Option<String>,
+    pub api_port: u16,
+    pub is_local: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HostPatch {
+    pub name: Option<String>,
+    pub address: Option<String>,
+    pub ssh_user: Option<Option<String>>,
+    pub api_port: Option<u16>,
 }
 
 #[derive(Debug, Clone)]
-pub struct SessionAtmUpdate {
-    pub session_name: String,
-    pub agent_id: String,
-    pub team: String,
-    pub state: String,
-    pub last_transition: Option<String>,
-    pub updated_at: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct SessionAtmRow {
-    pub session_name: String,
-    pub state: String,
-    pub last_transition: Option<String>,
+pub struct HostDefinition {
+    pub id: i64,
+    pub name: String,
+    pub address: String,
+    pub ssh_user: Option<String>,
+    pub api_port: u16,
+    pub is_local: bool,
+    pub last_seen: Option<String>,
 }
 
 pub fn open(path: &str) -> Result<Connection> {
@@ -88,52 +79,151 @@ pub fn open(path: &str) -> Result<Connection> {
 }
 
 pub fn ensure_local_host(conn: &Connection) -> Result<i64> {
-    if let Ok(id) = conn.query_row("SELECT id FROM hosts WHERE is_local = 1 LIMIT 1", [], |r| {
-        r.get(0)
-    }) {
+    if let Ok(id) = conn.query_row(
+        "SELECT id FROM hosts WHERE is_local = 1 AND enabled = 1 LIMIT 1",
+        [],
+        |r| r.get(0),
+    ) {
         return Ok(id);
     }
 
     let hostname = system_hostname();
     conn.execute(
-        "INSERT INTO hosts (name, address, is_local) VALUES (?1, 'localhost', 1)",
+        "INSERT INTO hosts (name, address, is_local, enabled) VALUES (?1, 'localhost', 1, 1)",
         params![hostname],
     )?;
-    conn.query_row("SELECT id FROM hosts WHERE is_local = 1 LIMIT 1", [], |r| {
-        r.get(0)
-    })
+    conn.query_row(
+        "SELECT id FROM hosts WHERE is_local = 1 AND enabled = 1 LIMIT 1",
+        [],
+        |r| r.get(0),
+    )
 }
 
-pub fn seed_hosts_from_config(conn: &Connection, hosts: &[HostConfig]) -> anyhow::Result<()> {
-    for host in hosts {
-        conn.execute(
-            "INSERT OR IGNORE INTO hosts (name, address, ssh_user, api_port, is_local)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![
-                host.name,
-                host.address,
-                host.ssh_user,
-                host.api_port.unwrap_or(7878),
-                host.is_local.unwrap_or(false)
-            ],
-        )?;
-    }
-    Ok(())
+pub fn session_id(conn: &Connection, host_id: i64, name: &str) -> anyhow::Result<Option<i64>> {
+    let value = conn
+        .query_row(
+            "SELECT id FROM sessions WHERE name = ?1 AND host_id = ?2",
+            params![name, host_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()?;
+    Ok(value)
 }
 
-pub fn update_host_last_seen(
+pub fn list_sessions_for_host(
     conn: &Connection,
     host_id: i64,
-    last_seen: &str,
-) -> anyhow::Result<()> {
-    conn.execute(
-        "UPDATE hosts SET last_seen = ?1 WHERE id = ?2",
-        params![last_seen, host_id],
+) -> anyhow::Result<Vec<SessionDefinition>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, name, project, host_id, config_json, cron_schedule, auto_start, enabled, github_repo, azure_project
+         FROM sessions
+         WHERE host_id = ?1 AND enabled = 1
+         ORDER BY host_id, project, name",
     )?;
-    Ok(())
+    let rows = stmt
+        .query_map(params![host_id], |r| {
+            Ok(SessionDefinition {
+                id: r.get(0)?,
+                name: r.get(1)?,
+                project: r.get(2)?,
+                host_id: r.get(3)?,
+                config_json: r.get(4)?,
+                cron_schedule: r.get(5)?,
+                auto_start: r.get(6)?,
+                enabled: r.get(7)?,
+                github_repo: r.get(8)?,
+                azure_project: r.get(9)?,
+            })
+        })?
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+    Ok(rows)
 }
 
-pub fn create_session(conn: &Connection, session: &NewSession) -> anyhow::Result<i64> {
+pub fn get_session_for_host(
+    conn: &Connection,
+    host_id: i64,
+    name: &str,
+) -> anyhow::Result<Option<SessionDefinition>> {
+    let row = conn
+        .query_row(
+            "SELECT id, name, project, host_id, config_json, cron_schedule, auto_start, enabled, github_repo, azure_project
+             FROM sessions
+             WHERE host_id = ?1 AND name = ?2 AND enabled = 1
+             LIMIT 1",
+            params![host_id, name],
+            |r| {
+                Ok(SessionDefinition {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    project: r.get(2)?,
+                    host_id: r.get(3)?,
+                    config_json: r.get(4)?,
+                    cron_schedule: r.get(5)?,
+                    auto_start: r.get(6)?,
+                    enabled: r.get(7)?,
+                    github_repo: r.get(8)?,
+                    azure_project: r.get(9)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+pub fn list_hosts(conn: &Connection) -> anyhow::Result<Vec<HostDefinition>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, name, address, ssh_user, api_port, is_local, last_seen
+         FROM hosts
+         WHERE enabled = 1
+         ORDER BY is_local DESC, name",
+    )?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(HostDefinition {
+                id: r.get(0)?,
+                name: r.get(1)?,
+                address: r.get(2)?,
+                ssh_user: r.get(3)?,
+                api_port: r.get(4)?,
+                is_local: r.get(5)?,
+                last_seen: r.get(6)?,
+            })
+        })?
+        .filter_map(Result::ok)
+        .collect::<Vec<_>>();
+    Ok(rows)
+}
+
+pub fn get_host(conn: &Connection, host_id: i64) -> anyhow::Result<Option<HostDefinition>> {
+    let row = conn
+        .query_row(
+            "SELECT id, name, address, ssh_user, api_port, is_local, last_seen
+             FROM hosts
+             WHERE id = ?1 AND enabled = 1
+             LIMIT 1",
+            params![host_id],
+            |r| {
+                Ok(HostDefinition {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    address: r.get(2)?,
+                    ssh_user: r.get(3)?,
+                    api_port: r.get(4)?,
+                    is_local: r.get(5)?,
+                    last_seen: r.get(6)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+pub(crate) fn create_session(
+    _guard: &crate::definition_writer::WriteGuard,
+    conn: &Connection,
+    session: &NewSession,
+) -> anyhow::Result<i64> {
     validate_config_session_name(&session.name, &session.config_json)?;
     if let Some(expr) = &session.cron_schedule {
         validate_cron(expr)?;
@@ -157,7 +247,8 @@ pub fn create_session(conn: &Connection, session: &NewSession) -> anyhow::Result
     Ok(conn.last_insert_rowid())
 }
 
-pub fn update_session(
+pub(crate) fn update_session(
+    _guard: &crate::definition_writer::WriteGuard,
     conn: &Connection,
     host_id: i64,
     name: &str,
@@ -244,7 +335,12 @@ pub fn update_session(
     Ok(true)
 }
 
-pub fn soft_delete_session(conn: &Connection, host_id: i64, name: &str) -> anyhow::Result<bool> {
+pub(crate) fn soft_delete_session(
+    _guard: &crate::definition_writer::WriteGuard,
+    conn: &Connection,
+    host_id: i64,
+    name: &str,
+) -> anyhow::Result<bool> {
     let changed = conn.execute(
         "UPDATE sessions SET enabled = 0 WHERE name = ?1 AND host_id = ?2 AND enabled = 1",
         params![name, host_id],
@@ -252,212 +348,109 @@ pub fn soft_delete_session(conn: &Connection, host_id: i64, name: &str) -> anyho
     Ok(changed > 0)
 }
 
-pub fn session_id(conn: &Connection, host_id: i64, name: &str) -> anyhow::Result<Option<i64>> {
-    let value = conn
-        .query_row(
-            "SELECT id FROM sessions WHERE name = ?1 AND host_id = ?2",
-            params![name, host_id],
-            |r| r.get::<_, i64>(0),
-        )
-        .optional()?;
-    Ok(value)
+pub(crate) fn create_host(
+    _guard: &crate::definition_writer::WriteGuard,
+    conn: &Connection,
+    host: &NewHost,
+) -> anyhow::Result<i64> {
+    conn.execute(
+        "INSERT INTO hosts (name, address, ssh_user, api_port, is_local, enabled)
+         VALUES (?1, ?2, ?3, ?4, ?5, 1)",
+        params![
+            host.name,
+            host.address,
+            host.ssh_user,
+            host.api_port,
+            host.is_local
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
 }
 
-pub fn upsert_remote_session(
+pub(crate) fn update_host(
+    _guard: &crate::definition_writer::WriteGuard,
     conn: &Connection,
     host_id: i64,
-    session: &RemoteSessionUpsert,
-) -> anyhow::Result<()> {
-    let config_json = serde_json::json!({ "session_name": session.name }).to_string();
-    conn.execute(
-        "INSERT INTO sessions (
-            name, project, host_id, config_json, cron_schedule, auto_start, enabled
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1)
-         ON CONFLICT(name, host_id) DO UPDATE SET
-            project = excluded.project,
-            cron_schedule = excluded.cron_schedule,
-            auto_start = excluded.auto_start,
-            enabled = 1",
-        params![
-            session.name,
-            session.project,
-            host_id,
-            config_json,
-            session.cron_schedule,
-            session.auto_start
-        ],
-    )?;
-
-    let session_id: i64 = conn.query_row(
-        "SELECT id FROM sessions WHERE name = ?1 AND host_id = ?2",
-        params![session.name, host_id],
-        |r| r.get(0),
-    )?;
-
-    conn.execute(
-        "INSERT INTO session_status (session_id, status, panes_json, polled_at)
-         VALUES (
-            ?1,
-            ?2,
-            ?3,
-            COALESCE(?4, datetime('now'))
-         )
-         ON CONFLICT(session_id) DO UPDATE SET
-            status = excluded.status,
-            panes_json = excluded.panes_json,
-            polled_at = excluded.polled_at",
-        params![
-            session_id,
-            session.status,
-            session.panes_json,
-            session.polled_at
-        ],
-    )?;
-
-    Ok(())
-}
-
-pub fn list_ci_sessions(conn: &Connection) -> anyhow::Result<Vec<CiSession>> {
-    let mut stmt = conn.prepare(
-        "SELECT s.id, s.name, s.github_repo, s.azure_project, COALESCE(ss.panes_json, '[]')
-         FROM sessions s
-         LEFT JOIN session_status ss ON ss.session_id = s.id
-         WHERE s.enabled = 1
-           AND (s.github_repo IS NOT NULL OR s.azure_project IS NOT NULL)
-         ORDER BY s.id",
-    )?;
-    let rows = stmt
-        .query_map([], |r| {
-            let panes_json: String = r.get(4)?;
-            Ok(CiSession {
-                id: r.get(0)?,
-                name: r.get(1)?,
-                github_repo: r.get(2)?,
-                azure_project: r.get(3)?,
-                has_active_pane: panes_json_has_active(&panes_json),
-            })
-        })?
-        .filter_map(|row| row.ok())
-        .collect::<Vec<_>>();
-    Ok(rows)
-}
-
-pub fn ci_provider_due(
-    conn: &Connection,
-    session_id: i64,
-    provider: &str,
-    now_iso: &str,
+    patch: &HostPatch,
 ) -> anyhow::Result<bool> {
-    let due = conn
+    let row_exists = conn
         .query_row(
-            "SELECT next_poll_at <= ?3
-             FROM session_ci
-             WHERE session_id = ?1 AND provider = ?2",
-            params![session_id, provider, now_iso],
+            "SELECT COUNT(*) > 0 FROM hosts WHERE id = ?1 AND enabled = 1",
+            params![host_id],
             |r| r.get::<_, bool>(0),
         )
-        .optional()?
-        .unwrap_or(true);
-    Ok(due)
-}
-
-pub fn upsert_session_ci(conn: &Connection, update: &SessionCiUpdate) -> anyhow::Result<()> {
-    conn.execute(
-        "INSERT INTO session_ci (
-            session_id, provider, status, data_json, tool_message, polled_at, next_poll_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-         ON CONFLICT(session_id, provider) DO UPDATE SET
-            status = excluded.status,
-            data_json = excluded.data_json,
-            tool_message = excluded.tool_message,
-            polled_at = excluded.polled_at,
-            next_poll_at = excluded.next_poll_at",
-        params![
-            update.session_id,
-            update.provider,
-            update.status,
-            update.data_json,
-            update.tool_message,
-            update.polled_at,
-            update.next_poll_at
-        ],
-    )?;
-    Ok(())
-}
-
-pub fn replace_session_atm(conn: &Connection, updates: &[SessionAtmUpdate]) -> anyhow::Result<()> {
-    conn.execute("DELETE FROM session_atm", [])?;
-
-    for update in updates {
-        conn.execute(
-            "INSERT INTO session_atm (
-                session_name, agent_id, team, state, last_transition, updated_at
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                update.session_name,
-                update.agent_id,
-                update.team,
-                update.state,
-                update.last_transition,
-                update.updated_at
-            ],
-        )?;
+        .unwrap_or(false);
+    if !row_exists {
+        return Ok(false);
     }
 
-    Ok(())
+    let mut set_parts: Vec<&str> = Vec::new();
+    let mut values: Vec<SqlValue> = Vec::new();
+
+    if let Some(name) = &patch.name {
+        set_parts.push("name = ?");
+        values.push(SqlValue::Text(name.clone()));
+    }
+    if let Some(address) = &patch.address {
+        set_parts.push("address = ?");
+        values.push(SqlValue::Text(address.clone()));
+    }
+    if let Some(ssh_user) = &patch.ssh_user {
+        set_parts.push("ssh_user = ?");
+        values.push(match ssh_user {
+            Some(value) => SqlValue::Text(value.clone()),
+            None => SqlValue::Null,
+        });
+    }
+    if let Some(api_port) = patch.api_port {
+        set_parts.push("api_port = ?");
+        values.push(SqlValue::Integer(api_port as i64));
+    }
+
+    if set_parts.is_empty() {
+        return Ok(true);
+    }
+
+    let mut sql = String::from("UPDATE hosts SET ");
+    for (idx, part) in set_parts.iter().enumerate() {
+        if idx > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(part);
+    }
+    sql.push_str(" WHERE id = ? AND enabled = 1");
+    values.push(SqlValue::Integer(host_id));
+
+    conn.execute(&sql, rusqlite::params_from_iter(values))?;
+    Ok(true)
 }
 
-pub fn list_session_atm(conn: &Connection) -> anyhow::Result<Vec<SessionAtmRow>> {
-    let mut stmt = conn.prepare(
-        "SELECT session_name, state, last_transition
-         FROM session_atm
-         ORDER BY session_name",
-    )?;
-    let rows = stmt
-        .query_map([], |r| {
-            Ok(SessionAtmRow {
-                session_name: r.get(0)?,
-                state: r.get(1)?,
-                last_transition: r.get(2)?,
-            })
-        })?
-        .filter_map(|row| row.ok())
-        .collect::<Vec<_>>();
-    Ok(rows)
-}
-
-pub fn log_session_event(
+pub(crate) fn soft_delete_host(
+    _guard: &crate::definition_writer::WriteGuard,
     conn: &Connection,
-    session_id: i64,
-    event: &str,
-    trigger: &str,
-    note: Option<&str>,
-) -> anyhow::Result<()> {
-    conn.execute(
-        "INSERT INTO session_events (session_id, event, trigger, note) VALUES (?1, ?2, ?3, ?4)",
-        params![session_id, event, trigger, note],
+    host_id: i64,
+) -> anyhow::Result<bool> {
+    let changed = conn.execute(
+        "UPDATE hosts SET enabled = 0 WHERE id = ?1 AND enabled = 1 AND is_local = 0",
+        params![host_id],
     )?;
-    Ok(())
+    Ok(changed > 0)
 }
 
 pub async fn write_health(state: &Arc<AppState>) -> anyhow::Result<()> {
     let state = Arc::clone(state);
     tokio::task::spawn_blocking(move || {
-        let db = state.db.lock().unwrap();
-        let running: i64 = db
-            .query_row(
-                "SELECT COUNT(*) FROM session_status WHERE status = 'running'",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap_or(0);
+        let running = {
+            let runtime = state.runtime.lock().expect("runtime lock");
+            runtime.live_session_count()
+        };
 
+        let db = state.db.lock().unwrap();
         db.execute(
             "INSERT INTO daemon_health (host_id, status, sessions_running) VALUES (?1, 'ok', ?2)",
             params![state.host_id, running],
         )?;
 
-        // Prune records older than 7 days
         db.execute(
             "DELETE FROM daemon_health WHERE recorded_at < datetime('now', '-7 days')",
             [],
@@ -471,10 +464,8 @@ pub async fn write_health(state: &Arc<AppState>) -> anyhow::Result<()> {
 }
 
 fn migrate(conn: &Connection) -> Result<()> {
-    // DG-06: Migration is idempotent — safe to run on every startup.
-    // All DDL statements use CREATE TABLE IF NOT EXISTS / CREATE INDEX IF NOT EXISTS /
-    // CREATE TRIGGER IF NOT EXISTS so re-running on an existing schema is a no-op.
-    conn.execute_batch(r#"
+    conn.execute_batch(
+        r#"
         CREATE TABLE IF NOT EXISTS hosts (
             id         INTEGER PRIMARY KEY,
             name       TEXT    NOT NULL UNIQUE,
@@ -482,6 +473,7 @@ fn migrate(conn: &Connection) -> Result<()> {
             ssh_user   TEXT,
             api_port   INTEGER NOT NULL DEFAULT 7878,
             is_local   BOOLEAN NOT NULL DEFAULT 0,
+            enabled    BOOLEAN NOT NULL DEFAULT 1,
             created_at DATETIME NOT NULL DEFAULT (datetime('now')),
             last_seen  TEXT
         );
@@ -564,8 +556,10 @@ fn migrate(conn: &Connection) -> Result<()> {
           BEGIN
             UPDATE sessions SET updated_at = datetime('now') WHERE id = OLD.id;
           END;
-    "#)?;
+    "#,
+    )?;
     ensure_hosts_last_seen_column(conn)?;
+    ensure_hosts_enabled_column(conn)?;
     Ok(())
 }
 
@@ -578,6 +572,22 @@ fn ensure_hosts_last_seen_column(conn: &Connection) -> Result<()> {
 
     if !has_last_seen {
         conn.execute("ALTER TABLE hosts ADD COLUMN last_seen TEXT", [])?;
+    }
+    Ok(())
+}
+
+fn ensure_hosts_enabled_column(conn: &Connection) -> Result<()> {
+    let mut stmt = conn.prepare("PRAGMA table_info(hosts)")?;
+    let has_enabled = stmt
+        .query_map([], |r| r.get::<_, String>(1))?
+        .filter_map(Result::ok)
+        .any(|name| name == "enabled");
+
+    if !has_enabled {
+        conn.execute(
+            "ALTER TABLE hosts ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT 1",
+            [],
+        )?;
     }
     Ok(())
 }
@@ -599,20 +609,6 @@ fn validate_cron(expr: &str) -> anyhow::Result<()> {
     let normalized = normalize_cron_expr(expr);
     Schedule::from_str(&normalized).map_err(|e| anyhow!("invalid cron_schedule: {e}"))?;
     Ok(())
-}
-
-fn panes_json_has_active(panes_json: &str) -> bool {
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(panes_json) else {
-        return false;
-    };
-    let Some(items) = value.as_array() else {
-        return false;
-    };
-    items.iter().any(|item| {
-        item.get("status")
-            .and_then(|status| status.as_str())
-            .is_some_and(|status| status.eq_ignore_ascii_case("active"))
-    })
 }
 
 fn normalize_cron_expr(expr: &str) -> String {

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -78,7 +78,7 @@ pub fn open(path: &str) -> Result<Connection> {
     Ok(conn)
 }
 
-pub fn ensure_local_host(conn: &Connection) -> Result<i64> {
+pub(crate) fn ensure_local_host(conn: &Connection) -> Result<i64> {
     if let Ok(id) = conn.query_row(
         "SELECT id FROM hosts WHERE is_local = 1 AND enabled = 1 LIMIT 1",
         [],
@@ -437,7 +437,7 @@ pub(crate) fn soft_delete_host(
     Ok(changed > 0)
 }
 
-pub async fn write_health(state: &Arc<AppState>) -> anyhow::Result<()> {
+pub(crate) async fn write_health(state: &Arc<AppState>) -> anyhow::Result<()> {
     let state = Arc::clone(state);
     tokio::task::spawn_blocking(move || {
         let running = {

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -1,0 +1,127 @@
+use crate::db;
+use rusqlite::Connection;
+
+pub struct WriteGuard(());
+
+#[derive(Debug)]
+pub enum WriteError {
+    NotFound,
+    Conflict(String),
+    Validation(String),
+    Forbidden(String),
+    Internal(String),
+}
+
+impl WriteError {
+    pub fn message(&self) -> String {
+        match self {
+            Self::NotFound => "not found".to_string(),
+            Self::Conflict(msg)
+            | Self::Validation(msg)
+            | Self::Forbidden(msg)
+            | Self::Internal(msg) => msg.clone(),
+        }
+    }
+}
+
+pub fn create_session(conn: &Connection, new_session: &db::NewSession) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
+    validate_approved_project(&new_session.name, &new_session.config_json)?;
+    db::create_session(&guard, conn, new_session).map_err(map_write_error)
+}
+
+pub fn patch_session(
+    conn: &Connection,
+    host_id: i64,
+    name: &str,
+    patch: &db::SessionPatch,
+) -> Result<bool, WriteError> {
+    let guard = WriteGuard(());
+    if let Some(config_json) = patch.config_json.as_ref() {
+        validate_approved_project(name, config_json)?;
+    } else if patch.enabled == Some(true) {
+        let current = db::get_session_for_host(conn, host_id, name)
+            .map_err(map_write_error)?
+            .ok_or(WriteError::NotFound)?;
+        validate_approved_project(name, &current.config_json)?;
+    }
+
+    db::update_session(&guard, conn, host_id, name, patch).map_err(map_write_error)
+}
+
+pub fn delete_session(conn: &Connection, host_id: i64, name: &str) -> Result<bool, WriteError> {
+    let guard = WriteGuard(());
+    db::soft_delete_session(&guard, conn, host_id, name).map_err(map_write_error)
+}
+
+pub fn create_host(conn: &Connection, host: &db::NewHost) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
+    db::create_host(&guard, conn, host).map_err(map_write_error)
+}
+
+pub fn patch_host(
+    conn: &Connection,
+    host_id: i64,
+    patch: &db::HostPatch,
+) -> Result<bool, WriteError> {
+    let guard = WriteGuard(());
+    db::update_host(&guard, conn, host_id, patch).map_err(map_write_error)
+}
+
+pub fn delete_host(conn: &Connection, host_id: i64) -> Result<bool, WriteError> {
+    let Some(row) = db::get_host(conn, host_id).map_err(map_write_error)? else {
+        return Err(WriteError::NotFound);
+    };
+    if row.is_local {
+        return Err(WriteError::Forbidden(
+            "local host definition cannot be deleted".to_string(),
+        ));
+    }
+    let guard = WriteGuard(());
+    db::soft_delete_host(&guard, conn, host_id).map_err(map_write_error)
+}
+
+fn validate_approved_project(session_name: &str, config_json: &str) -> Result<(), WriteError> {
+    let value: serde_json::Value = serde_json::from_str(config_json)
+        .map_err(|err| WriteError::Validation(format!("invalid config_json JSON: {err}")))?;
+
+    let json_session_name = value
+        .get("session_name")
+        .and_then(|raw| raw.as_str())
+        .ok_or_else(|| {
+            WriteError::Validation("config_json.session_name is required".to_string())
+        })?;
+    if json_session_name != session_name {
+        return Err(WriteError::Validation(
+            "config_json.session_name must equal session name".to_string(),
+        ));
+    }
+
+    let panes = value
+        .get("panes")
+        .and_then(|raw| raw.as_array())
+        .ok_or_else(|| {
+            WriteError::Validation(
+                "config_json.panes[] is required for approved projects".to_string(),
+            )
+        })?;
+
+    if panes.is_empty() {
+        return Err(WriteError::Validation(
+            "config_json.panes[] must contain at least one pane".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn map_write_error(err: anyhow::Error) -> WriteError {
+    let message = err.to_string();
+    if message.contains("UNIQUE constraint failed") {
+        return WriteError::Conflict(message);
+    }
+    if message.contains("invalid") || message.contains("required") || message.contains("must") {
+        return WriteError::Validation(message);
+    }
+    WriteError::Internal(message)
+}

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -1,5 +1,7 @@
 use crate::db;
+use crate::AppState;
 use rusqlite::Connection;
+use std::sync::Arc;
 
 pub struct WriteGuard(());
 
@@ -79,6 +81,14 @@ pub fn delete_host(conn: &Connection, host_id: i64) -> Result<bool, WriteError> 
     }
     let guard = WriteGuard(());
     db::soft_delete_host(&guard, conn, host_id).map_err(map_write_error)
+}
+
+pub fn ensure_local_host(conn: &Connection) -> Result<i64, WriteError> {
+    db::ensure_local_host(conn).map_err(|err| WriteError::Internal(err.to_string()))
+}
+
+pub async fn write_health(state: &Arc<AppState>) -> Result<(), WriteError> {
+    db::write_health(state).await.map_err(map_write_error)
 }
 
 fn validate_approved_project(session_name: &str, config_json: &str) -> Result<(), WriteError> {

--- a/crates/scmux-daemon/src/hosts.rs
+++ b/crates/scmux-daemon/src/hosts.rs
@@ -1,14 +1,9 @@
 use crate::{db, AppState};
-use anyhow::Context;
 use chrono::Utc;
-use serde::Deserialize;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::process::Command;
-use tracing::{debug, warn};
 
 const ACTIVE_API_WINDOW_MS: u64 = 60_000;
-const REMOTE_FETCH_TIMEOUT_SECS: u64 = 5;
 
 #[derive(Debug, Clone, Default)]
 pub struct HostReachability {
@@ -23,33 +18,8 @@ struct HostRow {
     id: i64,
     name: String,
     address: String,
-    api_port: u16,
     is_local: bool,
     last_seen: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct RemoteSessionResponse {
-    name: String,
-    project: Option<String>,
-    #[serde(default)]
-    cron_schedule: Option<String>,
-    #[serde(default)]
-    auto_start: bool,
-    #[serde(default = "default_status")]
-    status: String,
-    #[serde(default = "default_panes")]
-    panes: serde_json::Value,
-    #[serde(default)]
-    polled_at: Option<String>,
-}
-
-fn default_status() -> String {
-    "stopped".to_string()
-}
-
-fn default_panes() -> serde_json::Value {
-    serde_json::json!([])
 }
 
 pub async fn probe_host(address: &str) -> bool {
@@ -66,40 +36,6 @@ pub async fn probe_host(address: &str) -> bool {
         .await
         .map(|status| status.success())
         .unwrap_or(false)
-}
-
-pub async fn fetch_remote_sessions(
-    address: &str,
-    port: u16,
-) -> anyhow::Result<Vec<db::RemoteSessionUpsert>> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(REMOTE_FETCH_TIMEOUT_SECS))
-        .build()
-        .context("build reqwest client")?;
-    let url = format!("http://{address}:{port}/sessions");
-    let rows = client
-        .get(&url)
-        .send()
-        .await
-        .with_context(|| format!("GET {url}"))?
-        .error_for_status()
-        .with_context(|| format!("non-success status from {url}"))?
-        .json::<Vec<RemoteSessionResponse>>()
-        .await
-        .with_context(|| format!("decode JSON from {url}"))?;
-
-    Ok(rows
-        .into_iter()
-        .map(|row| db::RemoteSessionUpsert {
-            name: row.name,
-            project: row.project,
-            cron_schedule: row.cron_schedule,
-            auto_start: row.auto_start,
-            status: row.status,
-            panes_json: serde_json::to_string(&row.panes).unwrap_or_else(|_| "[]".to_string()),
-            polled_at: row.polled_at,
-        })
-        .collect())
 }
 
 pub fn apply_probe_result(mut previous: HostReachability, probe_ok: bool) -> HostReachability {
@@ -140,46 +76,15 @@ pub async fn poll_hosts(state: Arc<AppState>) -> anyhow::Result<()> {
                 consecutive_failures: 0,
             }
         } else {
-            let probe_ok = probe_host(&host.address).await;
-            let updated = apply_probe_result(previous, probe_ok);
-
-            if probe_ok {
-                if let Some(last_seen) = updated.last_seen.clone() {
-                    let state2 = Arc::clone(&state);
-                    tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-                        let db_conn = state2.db.lock().expect("db lock");
-                        db::update_host_last_seen(&db_conn, host.id, &last_seen)?;
-                        Ok(())
-                    })
-                    .await??;
-                }
-
-                match fetch_remote_sessions(&host.address, host.api_port).await {
-                    Ok(remote_sessions) => {
-                        let state2 = Arc::clone(&state);
-                        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-                            let db_conn = state2.db.lock().expect("db lock");
-                            for session in &remote_sessions {
-                                db::upsert_remote_session(&db_conn, host.id, session)?;
-                            }
-                            Ok(())
-                        })
-                        .await??;
-                    }
-                    Err(err) => {
-                        warn!(
-                            "remote session fetch failed host={} address={}: {}",
-                            host.name, host.address, err
-                        );
-                    }
-                }
-            }
-            updated
+            apply_probe_result(previous, probe_host(&host.address).await)
         };
 
-        debug!(
+        tracing::debug!(
             "host poll id={} name={} reachable={} failures={}",
-            updated.host_id, host.name, updated.reachable, updated.consecutive_failures
+            updated.host_id,
+            host.name,
+            updated.reachable,
+            updated.consecutive_failures
         );
         next.insert(host.id, updated);
     }
@@ -199,42 +104,27 @@ pub async fn should_use_active_interval(state: &Arc<AppState>) -> anyhow::Result
         return Ok(false);
     }
 
-    let state2 = Arc::clone(state);
-    let running: i64 = tokio::task::spawn_blocking(move || -> anyhow::Result<i64> {
-        let db_conn = state2.db.lock().expect("db lock");
-        let value = db_conn.query_row(
-            "SELECT COUNT(*) FROM session_status WHERE status = 'running'",
-            [],
-            |r| r.get(0),
-        )?;
-        Ok(value)
-    })
-    .await??;
-    Ok(running > 0)
+    let running = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        runtime.has_live_sessions()
+    };
+    Ok(running)
 }
 
 async fn load_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostRow>> {
     tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<HostRow>> {
         let db_conn = state.db.lock().expect("db lock");
-        let mut stmt = db_conn.prepare(
-            "SELECT id, name, address, api_port, is_local, last_seen
-             FROM hosts
-             ORDER BY is_local DESC, name",
-        )?;
-        let rows = stmt
-            .query_map([], |r| {
-                Ok(HostRow {
-                    id: r.get(0)?,
-                    name: r.get(1)?,
-                    address: r.get(2)?,
-                    api_port: r.get(3)?,
-                    is_local: r.get(4)?,
-                    last_seen: r.get(5)?,
-                })
-            })?
-            .filter_map(Result::ok)
-            .collect::<Vec<_>>();
-        Ok(rows)
+        let rows = db::list_hosts(&db_conn)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| HostRow {
+                id: row.id,
+                name: row.name,
+                address: row.address,
+                is_local: row.is_local,
+                last_seen: row.last_seen,
+            })
+            .collect::<Vec<_>>())
     })
     .await?
 }

--- a/crates/scmux-daemon/src/lib.rs
+++ b/crates/scmux-daemon/src/lib.rs
@@ -3,10 +3,13 @@ pub mod atm;
 pub mod ci;
 pub mod config;
 pub mod db;
+pub mod definition_writer;
 pub mod hosts;
 pub mod logging;
+pub mod runtime;
 pub mod scheduler;
 pub mod tmux;
+pub mod tmux_poller;
 
 pub trait Clock: Send + Sync {
     fn now_utc(&self) -> chrono::DateTime<chrono::Utc>;
@@ -27,6 +30,7 @@ pub struct AppState {
     pub host_id: i64,
     pub config: config::Config,
     pub reachability: std::sync::Mutex<std::collections::HashMap<i64, hosts::HostReachability>>,
+    pub runtime: std::sync::Mutex<runtime::RuntimeProjection>,
     pub ci_tools: ci::ToolAvailability,
     pub clock: std::sync::Arc<dyn Clock>,
     pub atm_available: std::sync::atomic::AtomicBool,

--- a/crates/scmux-daemon/src/lib.rs
+++ b/crates/scmux-daemon/src/lib.rs
@@ -7,7 +7,7 @@ pub mod definition_writer;
 pub mod hosts;
 pub mod logging;
 pub mod runtime;
-pub mod scheduler;
+mod start_cycle;
 pub mod tmux;
 pub mod tmux_poller;
 

--- a/crates/scmux-daemon/src/main.rs
+++ b/crates/scmux-daemon/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use scmux_daemon::config::Config;
-use scmux_daemon::{api, atm, ci, db, hosts, logging, tmux_poller, AppState, SystemClock};
+use scmux_daemon::{
+    api, atm, ci, db, definition_writer, hosts, logging, tmux_poller, AppState, SystemClock,
+};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
@@ -59,7 +61,8 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let conn = db::open(&db_path)?;
-    let host_id = db::ensure_local_host(&conn)?;
+    let host_id = definition_writer::ensure_local_host(&conn)
+        .map_err(|err| anyhow::anyhow!(err.message()))?;
     let ci_tools = ci::detect_tools();
 
     info!("scmux-daemon starting — db={db_path} host_id={host_id}");
@@ -116,8 +119,8 @@ async fn main() -> anyhow::Result<()> {
             tokio::time::interval(tokio::time::Duration::from_secs(health_interval_secs));
         loop {
             interval.tick().await;
-            if let Err(e) = db::write_health(&health_state).await {
-                tracing::error!("health write error: {e}");
+            if let Err(e) = definition_writer::write_health(&health_state).await {
+                tracing::error!("health write error: {}", e.message());
             }
         }
     });

--- a/crates/scmux-daemon/src/main.rs
+++ b/crates/scmux-daemon/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use scmux_daemon::config::Config;
-use scmux_daemon::{api, atm, ci, db, hosts, logging, scheduler, AppState, SystemClock};
+use scmux_daemon::{api, atm, ci, db, hosts, logging, tmux_poller, AppState, SystemClock};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
@@ -59,15 +59,6 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let conn = db::open(&db_path)?;
-    db::seed_hosts_from_config(
-        &conn,
-        &config
-            .hosts
-            .iter()
-            .filter(|host| !host.is_local.unwrap_or(false))
-            .cloned()
-            .collect::<Vec<_>>(),
-    )?;
     let host_id = db::ensure_local_host(&conn)?;
     let ci_tools = ci::detect_tools();
 
@@ -97,6 +88,7 @@ async fn main() -> anyhow::Result<()> {
         host_id,
         config,
         reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),
         ci_tools,
         clock: std::sync::Arc::new(SystemClock),
         atm_available: std::sync::atomic::AtomicBool::new(false),
@@ -111,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::time::interval(tokio::time::Duration::from_secs(poll_interval_secs));
         loop {
             interval.tick().await;
-            if let Err(e) = scheduler::poll_cycle(&poll_state).await {
+            if let Err(e) = tmux_poller::poll_cycle(&poll_state).await {
                 tracing::error!("poll cycle error: {e}");
             }
         }

--- a/crates/scmux-daemon/src/runtime.rs
+++ b/crates/scmux-daemon/src/runtime.rs
@@ -39,9 +39,24 @@ pub struct AtmRuntimeSummary {
 
 #[derive(Debug, Clone)]
 pub struct AtmRuntimeUpdate {
-    pub session_name: String,
+    pub team: String,
+    pub agent: String,
     pub state: String,
     pub last_transition: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ConfiguredPane {
+    pub name: Option<String>,
+    pub command: Option<String>,
+    pub atm_team: Option<String>,
+    pub atm_agent: Option<String>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct AtmPaneKey {
+    team: String,
+    agent: String,
 }
 
 #[derive(Debug, Default)]
@@ -50,7 +65,8 @@ pub struct RuntimeProjection {
     discovery: HashMap<String, Vec<PaneInfo>>,
     ci_by_session: HashMap<String, Vec<CiRuntimeSummary>>,
     ci_next_due: HashMap<(i64, String), DateTime<Utc>>,
-    atm_by_session: HashMap<String, AtmRuntimeSummary>,
+    atm_by_pane: HashMap<AtmPaneKey, AtmRuntimeSummary>,
+    pane_keys_by_session: HashMap<String, Vec<Option<AtmPaneKey>>>,
 }
 
 impl RuntimeProjection {
@@ -67,6 +83,8 @@ impl RuntimeProjection {
         entry.last_error = Some(error);
         entry.polled_at = Some(Utc::now().to_rfc3339());
         entry.panes.clear();
+        self.pane_keys_by_session
+            .insert(session_name.to_string(), Vec::new());
     }
 
     pub fn mark_stopped(&mut self, session_name: &str) {
@@ -74,22 +92,31 @@ impl RuntimeProjection {
         entry.status = "stopped".to_string();
         entry.polled_at = Some(Utc::now().to_rfc3339());
         entry.panes.clear();
+        self.pane_keys_by_session
+            .insert(session_name.to_string(), Vec::new());
     }
 
     pub fn apply_tmux_snapshot(
         &mut self,
         defined_sessions: &[String],
         live_sessions: &HashMap<String, Vec<PaneInfo>>,
+        pane_configs: &HashMap<String, Vec<ConfiguredPane>>,
         polled_at: &str,
     ) {
         self.discovery = live_sessions.clone();
 
         for session_name in defined_sessions {
-            let derived_status = derive_live_status(&self.atm_by_session, session_name);
+            let live = live_sessions.get(session_name);
+            let configured = pane_configs.get(session_name).cloned().unwrap_or_default();
+            let (projected_panes, projected_keys) =
+                project_panes(live, &configured, &self.atm_by_pane);
+            self.pane_keys_by_session
+                .insert(session_name.clone(), projected_keys);
+
             let entry = self.sessions.entry(session_name.clone()).or_default();
-            if let Some(panes) = live_sessions.get(session_name) {
-                entry.panes = panes.clone();
-                entry.status = derived_status;
+            if live.is_some() {
+                entry.panes = projected_panes;
+                entry.status = derive_live_status(&entry.panes);
                 entry.last_error = None;
             } else if entry.status != "starting" {
                 entry.status = "stopped".to_string();
@@ -130,40 +157,48 @@ impl RuntimeProjection {
     }
 
     pub fn apply_atm_updates(&mut self, updates: Vec<AtmRuntimeUpdate>) {
-        let mut aggregated: HashMap<String, AtmRuntimeSummary> = HashMap::new();
-
+        let mut mapped = HashMap::new();
         for update in updates {
-            let key = update.session_name;
+            let key = AtmPaneKey {
+                team: update.team.trim().to_string(),
+                agent: update.agent.trim().to_string(),
+            };
+            if key.team.is_empty() || key.agent.is_empty() {
+                continue;
+            }
             let candidate = AtmRuntimeSummary {
                 state: normalize_atm_state(&update.state).to_string(),
                 last_transition: update.last_transition,
             };
-
-            let current = aggregated.entry(key).or_default();
-            if state_priority(&candidate.state) > state_priority(&current.state) {
-                *current = candidate;
-                continue;
-            }
-            if current.last_transition.is_none() {
-                current.last_transition = candidate.last_transition;
+            let existing = mapped.entry(key).or_insert_with(|| candidate.clone());
+            if state_priority(&candidate.state) > state_priority(&existing.state) {
+                *existing = candidate;
+            } else if existing.last_transition.is_none() {
+                existing.last_transition = candidate.last_transition;
             }
         }
+        self.atm_by_pane = mapped;
 
-        self.atm_by_session = aggregated;
-
-        // Recompute live status after ATM updates.
+        // Recompute pane/session status using canonical ATM pane keys.
         for (session_name, entry) in &mut self.sessions {
-            if entry.status == "stopped" || entry.status == "starting" {
-                continue;
+            if let Some(keys) = self.pane_keys_by_session.get(session_name) {
+                for (idx, pane) in entry.panes.iter_mut().enumerate() {
+                    let Some(key) = keys.get(idx).and_then(|k| k.as_ref()) else {
+                        continue;
+                    };
+                    if let Some(atm) = self.atm_by_pane.get(key) {
+                        pane.status = normalize_atm_state(&atm.state).to_string();
+                    }
+                }
             }
-            if !entry.panes.is_empty() {
-                entry.status = derive_live_status(&self.atm_by_session, session_name);
+            if entry.status != "stopped" && entry.status != "starting" && !entry.panes.is_empty() {
+                entry.status = derive_live_status(&entry.panes);
             }
         }
     }
 
     pub fn clear_atm(&mut self) {
-        self.atm_by_session.clear();
+        self.atm_by_pane.clear();
     }
 
     pub fn session(&self, session_name: &str) -> Option<&SessionRuntime> {
@@ -178,7 +213,26 @@ impl RuntimeProjection {
     }
 
     pub fn atm_for_session(&self, session_name: &str) -> Option<AtmRuntimeSummary> {
-        self.atm_by_session.get(session_name).cloned()
+        let keys = self.pane_keys_by_session.get(session_name)?;
+        let mut selected: Option<AtmRuntimeSummary> = None;
+        for key in keys.iter().flatten() {
+            let Some(candidate) = self.atm_by_pane.get(key) else {
+                continue;
+            };
+            match selected.as_mut() {
+                Some(current) => {
+                    if state_priority(&candidate.state) > state_priority(&current.state) {
+                        *current = candidate.clone();
+                    } else if current.last_transition.is_none() {
+                        current.last_transition = candidate.last_transition.clone();
+                    }
+                }
+                None => {
+                    selected = Some(candidate.clone());
+                }
+            }
+        }
+        selected
     }
 
     pub fn discovery_rows(&self) -> Vec<DiscoverySession> {
@@ -234,15 +288,98 @@ fn state_priority(state: &str) -> u8 {
     }
 }
 
-fn derive_live_status(
-    atm_by_session: &HashMap<String, AtmRuntimeSummary>,
-    session_name: &str,
-) -> String {
-    let Some(atm) = atm_by_session.get(session_name) else {
-        return "running".to_string();
-    };
-    match normalize_atm_state(&atm.state) {
-        "idle" | "offline" => "idle".to_string(),
-        _ => "running".to_string(),
+fn make_atm_key(team: Option<&str>, agent: Option<&str>) -> Option<AtmPaneKey> {
+    let team = team?.trim();
+    let agent = agent?.trim();
+    if team.is_empty() || agent.is_empty() {
+        return None;
     }
+    Some(AtmPaneKey {
+        team: team.to_string(),
+        agent: agent.to_string(),
+    })
+}
+
+fn project_panes(
+    live: Option<&Vec<PaneInfo>>,
+    configured: &[ConfiguredPane],
+    atm_by_pane: &HashMap<AtmPaneKey, AtmRuntimeSummary>,
+) -> (Vec<PaneInfo>, Vec<Option<AtmPaneKey>>) {
+    let Some(live_panes) = live else {
+        return (Vec::new(), Vec::new());
+    };
+
+    if configured.is_empty() {
+        return (live_panes.clone(), vec![None; live_panes.len()]);
+    }
+
+    let mut panes = Vec::new();
+    let mut keys = Vec::new();
+
+    for (idx, definition) in configured.iter().enumerate() {
+        let live_pane = live_panes.get(idx);
+        let key = make_atm_key(
+            definition.atm_team.as_deref(),
+            definition.atm_agent.as_deref(),
+        );
+        let status = key
+            .as_ref()
+            .and_then(|atm_key| atm_by_pane.get(atm_key).map(|atm| atm.state.clone()))
+            .or_else(|| live_pane.map(|pane| normalize_atm_state(&pane.status).to_string()))
+            .unwrap_or_else(|| "unknown".to_string());
+
+        panes.push(PaneInfo {
+            index: live_pane.map(|pane| pane.index).unwrap_or(idx as u32),
+            name: definition
+                .name
+                .as_deref()
+                .filter(|name| !name.trim().is_empty())
+                .map(ToOwned::to_owned)
+                .or_else(|| live_pane.map(|pane| pane.name.clone()))
+                .unwrap_or_else(|| format!("pane-{idx}")),
+            status,
+            last_activity: live_pane
+                .map(|pane| pane.last_activity.clone())
+                .unwrap_or_else(|| "unknown".to_string()),
+            current_command: definition
+                .command
+                .as_deref()
+                .filter(|command| !command.trim().is_empty())
+                .map(ToOwned::to_owned)
+                .or_else(|| live_pane.map(|pane| pane.current_command.clone()))
+                .unwrap_or_default(),
+        });
+        keys.push(key);
+    }
+
+    if live_panes.len() > configured.len() {
+        for pane in &live_panes[configured.len()..] {
+            panes.push(pane.clone());
+            keys.push(None);
+        }
+    }
+
+    (panes, keys)
+}
+
+fn derive_live_status(panes: &[PaneInfo]) -> String {
+    if panes.is_empty() {
+        return "running".to_string();
+    }
+
+    if panes
+        .iter()
+        .any(|pane| matches!(normalize_atm_state(&pane.status), "active" | "stuck"))
+    {
+        return "running".to_string();
+    }
+
+    if panes
+        .iter()
+        .all(|pane| matches!(normalize_atm_state(&pane.status), "idle" | "offline"))
+    {
+        return "idle".to_string();
+    }
+
+    "running".to_string()
 }

--- a/crates/scmux-daemon/src/runtime.rs
+++ b/crates/scmux-daemon/src/runtime.rs
@@ -1,0 +1,248 @@
+use crate::tmux::PaneInfo;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct SessionRuntime {
+    pub status: String,
+    pub panes: Vec<PaneInfo>,
+    pub polled_at: Option<String>,
+    pub last_error: Option<String>,
+}
+
+impl Default for SessionRuntime {
+    fn default() -> Self {
+        Self {
+            status: "stopped".to_string(),
+            panes: Vec::new(),
+            polled_at: None,
+            last_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CiRuntimeSummary {
+    pub provider: String,
+    pub status: String,
+    pub data_json: Option<serde_json::Value>,
+    pub tool_message: Option<String>,
+    pub polled_at: Option<String>,
+    pub next_poll_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AtmRuntimeSummary {
+    pub state: String,
+    pub last_transition: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AtmRuntimeUpdate {
+    pub session_name: String,
+    pub state: String,
+    pub last_transition: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct RuntimeProjection {
+    sessions: HashMap<String, SessionRuntime>,
+    discovery: HashMap<String, Vec<PaneInfo>>,
+    ci_by_session: HashMap<String, Vec<CiRuntimeSummary>>,
+    ci_next_due: HashMap<(i64, String), DateTime<Utc>>,
+    atm_by_session: HashMap<String, AtmRuntimeSummary>,
+}
+
+impl RuntimeProjection {
+    pub fn mark_starting(&mut self, session_name: &str) {
+        let entry = self.sessions.entry(session_name.to_string()).or_default();
+        entry.status = "starting".to_string();
+        entry.last_error = None;
+        entry.polled_at = Some(Utc::now().to_rfc3339());
+    }
+
+    pub fn mark_start_failed(&mut self, session_name: &str, error: String) {
+        let entry = self.sessions.entry(session_name.to_string()).or_default();
+        entry.status = "stopped".to_string();
+        entry.last_error = Some(error);
+        entry.polled_at = Some(Utc::now().to_rfc3339());
+        entry.panes.clear();
+    }
+
+    pub fn mark_stopped(&mut self, session_name: &str) {
+        let entry = self.sessions.entry(session_name.to_string()).or_default();
+        entry.status = "stopped".to_string();
+        entry.polled_at = Some(Utc::now().to_rfc3339());
+        entry.panes.clear();
+    }
+
+    pub fn apply_tmux_snapshot(
+        &mut self,
+        defined_sessions: &[String],
+        live_sessions: &HashMap<String, Vec<PaneInfo>>,
+        polled_at: &str,
+    ) {
+        self.discovery = live_sessions.clone();
+
+        for session_name in defined_sessions {
+            let derived_status = derive_live_status(&self.atm_by_session, session_name);
+            let entry = self.sessions.entry(session_name.clone()).or_default();
+            if let Some(panes) = live_sessions.get(session_name) {
+                entry.panes = panes.clone();
+                entry.status = derived_status;
+                entry.last_error = None;
+            } else if entry.status != "starting" {
+                entry.status = "stopped".to_string();
+                entry.panes.clear();
+            }
+            entry.polled_at = Some(polled_at.to_string());
+        }
+    }
+
+    pub fn ci_due(&self, session_id: i64, provider: &str, now: DateTime<Utc>) -> bool {
+        let key = (session_id, provider.to_string());
+        self.ci_next_due.get(&key).is_none_or(|due| *due <= now)
+    }
+
+    pub fn upsert_ci(
+        &mut self,
+        session_name: &str,
+        session_id: i64,
+        entry: CiRuntimeSummary,
+        next_due: DateTime<Utc>,
+    ) {
+        let key = (session_id, entry.provider.clone());
+        self.ci_next_due.insert(key, next_due);
+
+        let items = self
+            .ci_by_session
+            .entry(session_name.to_string())
+            .or_default();
+        if let Some(existing) = items
+            .iter_mut()
+            .find(|item| item.provider == entry.provider)
+        {
+            *existing = entry;
+            return;
+        }
+        items.push(entry);
+        items.sort_by(|left, right| left.provider.cmp(&right.provider));
+    }
+
+    pub fn apply_atm_updates(&mut self, updates: Vec<AtmRuntimeUpdate>) {
+        let mut aggregated: HashMap<String, AtmRuntimeSummary> = HashMap::new();
+
+        for update in updates {
+            let key = update.session_name;
+            let candidate = AtmRuntimeSummary {
+                state: normalize_atm_state(&update.state).to_string(),
+                last_transition: update.last_transition,
+            };
+
+            let current = aggregated.entry(key).or_default();
+            if state_priority(&candidate.state) > state_priority(&current.state) {
+                *current = candidate;
+                continue;
+            }
+            if current.last_transition.is_none() {
+                current.last_transition = candidate.last_transition;
+            }
+        }
+
+        self.atm_by_session = aggregated;
+
+        // Recompute live status after ATM updates.
+        for (session_name, entry) in &mut self.sessions {
+            if entry.status == "stopped" || entry.status == "starting" {
+                continue;
+            }
+            if !entry.panes.is_empty() {
+                entry.status = derive_live_status(&self.atm_by_session, session_name);
+            }
+        }
+    }
+
+    pub fn clear_atm(&mut self) {
+        self.atm_by_session.clear();
+    }
+
+    pub fn session(&self, session_name: &str) -> Option<&SessionRuntime> {
+        self.sessions.get(session_name)
+    }
+
+    pub fn ci_for_session(&self, session_name: &str) -> Vec<CiRuntimeSummary> {
+        self.ci_by_session
+            .get(session_name)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn atm_for_session(&self, session_name: &str) -> Option<AtmRuntimeSummary> {
+        self.atm_by_session.get(session_name).cloned()
+    }
+
+    pub fn discovery_rows(&self) -> Vec<DiscoverySession> {
+        let mut rows = self
+            .discovery
+            .iter()
+            .map(|(name, panes)| DiscoverySession {
+                name: name.clone(),
+                panes: panes.clone(),
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| left.name.cmp(&right.name));
+        rows
+    }
+
+    pub fn has_live_sessions(&self) -> bool {
+        self.sessions
+            .values()
+            .any(|entry| matches!(entry.status.as_str(), "starting" | "running" | "idle"))
+    }
+
+    pub fn live_session_count(&self) -> i64 {
+        self.sessions
+            .values()
+            .filter(|entry| matches!(entry.status.as_str(), "starting" | "running" | "idle"))
+            .count() as i64
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DiscoverySession {
+    pub name: String,
+    pub panes: Vec<PaneInfo>,
+}
+
+fn normalize_atm_state(value: &str) -> &str {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "active" => "active",
+        "stuck" => "stuck",
+        "idle" => "idle",
+        "offline" => "offline",
+        _ => "unknown",
+    }
+}
+
+fn state_priority(state: &str) -> u8 {
+    match normalize_atm_state(state) {
+        "active" => 5,
+        "stuck" => 4,
+        "idle" => 3,
+        "offline" => 2,
+        _ => 1,
+    }
+}
+
+fn derive_live_status(
+    atm_by_session: &HashMap<String, AtmRuntimeSummary>,
+    session_name: &str,
+) -> String {
+    let Some(atm) = atm_by_session.get(session_name) else {
+        return "running".to_string();
+    };
+    match normalize_atm_state(&atm.state) {
+        "idle" | "offline" => "idle".to_string(),
+        _ => "running".to_string(),
+    }
+}

--- a/crates/scmux-daemon/src/scheduler.rs
+++ b/crates/scmux-daemon/src/scheduler.rs
@@ -1,246 +1,14 @@
 use chrono::Utc;
 use cron::Schedule;
-use rusqlite::params;
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use crate::{tmux, AppState};
-
-struct SessionRow {
-    id: i64,
-    name: String,
-    cron_schedule: Option<String>,
-    auto_start: bool,
-    config_json: String,
-}
+use crate::{db::SessionDefinition, tmux, AppState};
 
 pub async fn poll_cycle(state: &Arc<AppState>) -> anyhow::Result<()> {
-    let live = tmux::live_sessions().await?;
-
-    // Phase 1: Read sessions via spawn_blocking (rusqlite::Connection is !Send)
-    let mut sessions = load_enabled_sessions_for_host(state).await?;
-
-    // NF-06: If the DB was lost while daemon was down, rebuild local sessions from live tmux.
-    if sessions.is_empty() && !live.is_empty() {
-        match reconstruct_registry_from_live(state, &live).await {
-            Ok(0) => {}
-            Ok(recovered) => {
-                info!("reconstructed {recovered} local sessions from live tmux");
-                sessions = load_enabled_sessions_for_host(state).await?;
-            }
-            Err(err) => warn!("failed to reconstruct session registry from tmux: {err}"),
-        }
-    }
-
-    let now = state.clock.now_utc();
-
-    // Phase 2: Update status and write transition events via spawn_blocking
-    let state2 = Arc::clone(state);
-    let live2 = live.clone();
-    let sessions2 = sessions
-        .iter()
-        .map(|s| (s.id, s.name.clone()))
-        .collect::<Vec<_>>();
-    tokio::task::spawn_blocking(move || {
-        let db = state2.db.lock().unwrap();
-        for (id, name) in &sessions2 {
-            let is_live = live2.contains_key(name);
-            let status = if is_live { "running" } else { "stopped" };
-            let panes_json = live2
-                .get(name)
-                .map(|p| serde_json::to_string(p).unwrap_or_default());
-            let previous_status: Option<String> = db
-                .query_row(
-                    "SELECT status FROM session_status WHERE session_id = ?1",
-                    params![id],
-                    |r| r.get(0),
-                )
-                .ok();
-
-            if let Err(err) = db.execute(
-                "INSERT INTO session_status (session_id, status, panes_json, polled_at)
-                 VALUES (?1, ?2, ?3, datetime('now'))
-                 ON CONFLICT(session_id) DO UPDATE SET
-                   status     = excluded.status,
-                   panes_json = excluded.panes_json,
-                   polled_at  = excluded.polled_at",
-                params![id, status, panes_json],
-            ) {
-                warn!("status upsert failed for session '{name}': {err}");
-                continue;
-            }
-
-            if let Some(prev) = previous_status.as_deref() {
-                if prev != status {
-                    let event = if is_live { "started" } else { "stopped" };
-                    if let Err(err) = db.execute(
-                        "INSERT INTO session_events (session_id, event, trigger)
-                         VALUES (?1, ?2, 'daemon')",
-                        params![id, event],
-                    ) {
-                        warn!("event write failed for session '{name}': {err}");
-                    }
-                }
-            }
-        }
-        Ok::<_, anyhow::Error>(())
-    })
-    .await??;
-
-    // Phase 3: Determine what to start (no DB access, no await)
-    let mut to_start: Vec<(i64, String, String, String)> = Vec::new();
-    for session in &sessions {
-        if live.contains_key(&session.name) {
-            continue;
-        }
-        if session.auto_start {
-            to_start.push((
-                session.id,
-                session.name.clone(),
-                session.config_json.clone(),
-                "auto_start".into(),
-            ));
-            continue;
-        }
-        if let Some(ref expr) = session.cron_schedule {
-            if should_run_now(expr, &now) {
-                to_start.push((
-                    session.id,
-                    session.name.clone(),
-                    session.config_json.clone(),
-                    "cron".into(),
-                ));
-            }
-        }
-    }
-
-    // Phase 4: Start sessions — each DB write in its own spawn_blocking
-    for (id, name, config_json, trigger) in to_start {
-        info!("starting session '{name}' trigger={trigger}");
-        match tmux::start_session(&name, &config_json).await {
-            Ok(()) => {
-                let state4 = Arc::clone(state);
-                let trigger4 = trigger.clone();
-                let write_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-                    let db = state4.db.lock().unwrap();
-                    db.execute(
-                        "INSERT INTO session_events (session_id, event, trigger)
-                         VALUES (?1, 'started', ?2)",
-                        params![id, trigger4],
-                    )?;
-                    Ok(())
-                })
-                .await;
-                match write_result {
-                    Ok(Ok(())) => {}
-                    Ok(Err(err)) => warn!("failed to log start event for '{name}': {err}"),
-                    Err(err) => warn!("failed to join start-event task for '{name}': {err}"),
-                }
-                info!("session '{name}' started");
-            }
-            Err(e) => {
-                warn!("failed to start session '{name}': {e}");
-                let state4 = Arc::clone(state);
-                let trigger4 = trigger.clone();
-                let note = e.to_string();
-                let write_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-                    let db = state4.db.lock().unwrap();
-                    db.execute(
-                        "INSERT INTO session_events (session_id, event, trigger, note)
-                         VALUES (?1, 'failed', ?2, ?3)",
-                        params![id, trigger4, note],
-                    )?;
-                    Ok(())
-                })
-                .await;
-                match write_result {
-                    Ok(Ok(())) => {}
-                    Ok(Err(err)) => warn!("failed to log failure event for '{name}': {err}"),
-                    Err(err) => warn!("failed to join failure-event task for '{name}': {err}"),
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn load_enabled_sessions_for_host(state: &Arc<AppState>) -> anyhow::Result<Vec<SessionRow>> {
-    let state1 = Arc::clone(state);
-    tokio::task::spawn_blocking(move || {
-        let db = state1.db.lock().unwrap();
-        let mut stmt = db.prepare(
-            "SELECT id, name, cron_schedule, auto_start, config_json
-             FROM sessions
-             WHERE host_id = ?1 AND enabled = 1",
-        )?;
-        let rows: Vec<SessionRow> = stmt
-            .query_map(params![state1.host_id], |r| {
-                Ok(SessionRow {
-                    id: r.get(0)?,
-                    name: r.get(1)?,
-                    cron_schedule: r.get(2)?,
-                    auto_start: r.get(3)?,
-                    config_json: r.get(4)?,
-                })
-            })?
-            .filter_map(|r| r.ok())
-            .collect();
-        Ok::<_, anyhow::Error>(rows)
-    })
-    .await?
-}
-
-async fn reconstruct_registry_from_live(
-    state: &Arc<AppState>,
-    live: &std::collections::HashMap<String, Vec<tmux::PaneInfo>>,
-) -> anyhow::Result<usize> {
-    let state = Arc::clone(state);
-    let live = live.clone();
-    tokio::task::spawn_blocking(move || {
-        let db = state.db.lock().unwrap();
-        let session_count: i64 = db
-            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
-            .unwrap_or(0);
-        if session_count > 0 {
-            return Ok::<_, anyhow::Error>(0);
-        }
-
-        for name in live.keys() {
-            let config_json = serde_json::json!({ "session_name": name }).to_string();
-            db.execute(
-                "INSERT INTO sessions (
-                    name, project, host_id, config_json, cron_schedule, auto_start, enabled
-                 ) VALUES (?1, NULL, ?2, ?3, NULL, 0, 1)
-                 ON CONFLICT(name, host_id) DO UPDATE SET
-                    enabled = 1,
-                    config_json = excluded.config_json",
-                params![name, state.host_id, config_json],
-            )?;
-        }
-
-        for (name, panes) in &live {
-            let session_id: i64 = db.query_row(
-                "SELECT id FROM sessions WHERE host_id = ?1 AND name = ?2",
-                params![state.host_id, name],
-                |r| r.get(0),
-            )?;
-            let panes_json = serde_json::to_string(panes).unwrap_or_else(|_| "[]".to_string());
-            db.execute(
-                "INSERT INTO session_status (session_id, status, panes_json, polled_at)
-                 VALUES (?1, 'running', ?2, datetime('now'))
-                 ON CONFLICT(session_id) DO UPDATE SET
-                    status = excluded.status,
-                    panes_json = excluded.panes_json,
-                    polled_at = excluded.polled_at",
-                params![session_id, panes_json],
-            )?;
-        }
-
-        Ok::<_, anyhow::Error>(live.len())
-    })
-    .await?
+    crate::tmux_poller::poll_cycle(state).await
 }
 
 /// Returns true if the cron expression should fire within the current 15s window.
@@ -259,4 +27,59 @@ pub fn should_run_now(expr: &str, now: &chrono::DateTime<Utc>) -> bool {
         .next()
         .map(|t| t <= *now)
         .unwrap_or(false)
+}
+
+pub async fn run_start_cycle(
+    state: &Arc<AppState>,
+    sessions: &[SessionDefinition],
+    live: &HashMap<String, Vec<tmux::PaneInfo>>,
+) -> anyhow::Result<()> {
+    let now = state.clock.now_utc();
+    let mut to_start: Vec<(String, String, String)> = Vec::new();
+
+    for session in sessions {
+        if !session.enabled || live.contains_key(&session.name) {
+            continue;
+        }
+
+        if session.auto_start {
+            to_start.push((
+                session.name.clone(),
+                session.config_json.clone(),
+                "auto_start".to_string(),
+            ));
+            continue;
+        }
+
+        if let Some(expr) = session.cron_schedule.as_deref() {
+            if should_run_now(expr, &now) {
+                to_start.push((
+                    session.name.clone(),
+                    session.config_json.clone(),
+                    "cron".to_string(),
+                ));
+            }
+        }
+    }
+
+    for (name, config_json, trigger) in to_start {
+        {
+            let mut runtime = state.runtime.lock().expect("runtime lock");
+            runtime.mark_starting(&name);
+        }
+
+        info!("starting session '{}' trigger={}", name, trigger);
+        match tmux::start_session(&name, &config_json).await {
+            Ok(()) => {
+                info!("session '{}' start submitted", name);
+            }
+            Err(err) => {
+                warn!("failed to start session '{}': {}", name, err);
+                let mut runtime = state.runtime.lock().expect("runtime lock");
+                runtime.mark_start_failed(&name, err.to_string());
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/crates/scmux-daemon/src/start_cycle.rs
+++ b/crates/scmux-daemon/src/start_cycle.rs
@@ -7,10 +7,6 @@ use tracing::{info, warn};
 
 use crate::{db::SessionDefinition, tmux, AppState};
 
-pub async fn poll_cycle(state: &Arc<AppState>) -> anyhow::Result<()> {
-    crate::tmux_poller::poll_cycle(state).await
-}
-
 /// Returns true if the cron expression should fire within the current 15s window.
 pub fn should_run_now(expr: &str, now: &chrono::DateTime<Utc>) -> bool {
     let normalized = if expr.split_whitespace().count() == 5 {

--- a/crates/scmux-daemon/src/tmux_poller.rs
+++ b/crates/scmux-daemon/src/tmux_poller.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use crate::{db, scheduler, tmux, AppState};
+use crate::{db, runtime::ConfiguredPane, start_cycle, tmux, AppState};
+
+pub use crate::start_cycle::should_run_now;
 
 pub async fn poll_cycle(state: &Arc<AppState>) -> anyhow::Result<()> {
     let live = tmux::live_sessions().await?;
@@ -18,13 +20,50 @@ pub async fn poll_cycle(state: &Arc<AppState>) -> anyhow::Result<()> {
         .iter()
         .map(|session| session.name.clone())
         .collect::<Vec<_>>();
+    let pane_configs = sessions
+        .iter()
+        .map(|session| {
+            (
+                session.name.clone(),
+                configured_panes(&session.config_json).unwrap_or_default(),
+            )
+        })
+        .collect::<std::collections::HashMap<_, _>>();
     let polled_at = state.clock.now_utc().to_rfc3339();
 
     {
         let mut runtime = state.runtime.lock().expect("runtime lock");
-        runtime.apply_tmux_snapshot(&defined_names, &live, &polled_at);
+        runtime.apply_tmux_snapshot(&defined_names, &live, &pane_configs, &polled_at);
     }
 
-    scheduler::run_start_cycle(state, &sessions, &live).await?;
+    start_cycle::run_start_cycle(state, &sessions, &live).await?;
     Ok(())
+}
+
+fn configured_panes(config_json: &str) -> Option<Vec<ConfiguredPane>> {
+    let value: serde_json::Value = serde_json::from_str(config_json).ok()?;
+    let panes = value.get("panes")?.as_array()?;
+    Some(
+        panes
+            .iter()
+            .map(|pane| ConfiguredPane {
+                name: pane
+                    .get("name")
+                    .and_then(|raw| raw.as_str())
+                    .map(ToOwned::to_owned),
+                command: pane
+                    .get("command")
+                    .and_then(|raw| raw.as_str())
+                    .map(ToOwned::to_owned),
+                atm_team: pane
+                    .get("atm_team")
+                    .and_then(|raw| raw.as_str())
+                    .map(ToOwned::to_owned),
+                atm_agent: pane
+                    .get("atm_agent")
+                    .and_then(|raw| raw.as_str())
+                    .map(ToOwned::to_owned),
+            })
+            .collect(),
+    )
 }

--- a/crates/scmux-daemon/src/tmux_poller.rs
+++ b/crates/scmux-daemon/src/tmux_poller.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use crate::{db, scheduler, tmux, AppState};
+
+pub async fn poll_cycle(state: &Arc<AppState>) -> anyhow::Result<()> {
+    let live = tmux::live_sessions().await?;
+
+    let sessions = {
+        let state = Arc::clone(state);
+        tokio::task::spawn_blocking(move || {
+            let db = state.db.lock().expect("db lock");
+            db::list_sessions_for_host(&db, state.host_id)
+        })
+        .await??
+    };
+
+    let defined_names = sessions
+        .iter()
+        .map(|session| session.name.clone())
+        .collect::<Vec<_>>();
+    let polled_at = state.clock.now_utc().to_rfc3339();
+
+    {
+        let mut runtime = state.runtime.lock().expect("runtime lock");
+        runtime.apply_tmux_snapshot(&defined_names, &live, &polled_at);
+    }
+
+    scheduler::run_start_cycle(state, &sessions, &live).await?;
+    Ok(())
+}

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -2,6 +2,7 @@ use scmux_daemon::api;
 use scmux_daemon::ci;
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
 use scmux_daemon::db;
+use scmux_daemon::definition_writer;
 use scmux_daemon::tmux::PaneInfo;
 use scmux_daemon::{AppState, SystemClock};
 use serde_json::{json, Value};
@@ -32,7 +33,7 @@ impl ApiHarness {
         let tmp = tempfile::tempdir().expect("tempdir");
         let db_path = tmp.path().join("scmux-test.db");
         let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
-        let host_id = db::ensure_local_host(&conn).expect("local host");
+        let host_id = definition_writer::ensure_local_host(&conn).expect("local host");
         conn.execute(
             "INSERT INTO hosts (name, address, ssh_user, api_port, is_local, last_seen)
              VALUES ('dgx-spark', '192.168.1.50', 'randlee', 7878, 0, datetime('now'))",
@@ -210,6 +211,7 @@ async fn t_a_03_get_sessions_returns_sessions_with_correct_status_and_panes() {
         runtime.apply_tmux_snapshot(
             &["alpha".to_string()],
             &live,
+            &std::collections::HashMap::new(),
             &chrono::Utc::now().to_rfc3339(),
         );
     }
@@ -620,8 +622,36 @@ async fn t_atm_02_get_sessions_includes_atm_state_when_available() {
     h.create_session("alpha").await;
     {
         let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        let mut live = std::collections::HashMap::new();
+        live.insert(
+            "alpha".to_string(),
+            vec![PaneInfo {
+                index: 0,
+                name: "agent".to_string(),
+                status: "idle".to_string(),
+                last_activity: "now".to_string(),
+                current_command: "sleep 1".to_string(),
+            }],
+        );
+        let mut pane_configs = std::collections::HashMap::new();
+        pane_configs.insert(
+            "alpha".to_string(),
+            vec![scmux_daemon::runtime::ConfiguredPane {
+                name: Some("agent".to_string()),
+                command: Some("sleep 1".to_string()),
+                atm_team: Some("scmux-dev".to_string()),
+                atm_agent: Some("agent".to_string()),
+            }],
+        );
+        runtime.apply_tmux_snapshot(
+            &["alpha".to_string()],
+            &live,
+            &pane_configs,
+            &chrono::Utc::now().to_rfc3339(),
+        );
         runtime.apply_atm_updates(vec![scmux_daemon::runtime::AtmRuntimeUpdate {
-            session_name: "alpha".to_string(),
+            team: "scmux-dev".to_string(),
+            agent: "agent".to_string(),
             state: "active".to_string(),
             last_transition: Some("2026-03-08T00:00:00Z".to_string()),
         }]);

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -2,6 +2,7 @@ use scmux_daemon::api;
 use scmux_daemon::ci;
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
 use scmux_daemon::db;
+use scmux_daemon::tmux::PaneInfo;
 use scmux_daemon::{AppState, SystemClock};
 use serde_json::{json, Value};
 use std::io::Write;
@@ -59,10 +60,12 @@ impl ApiHarness {
                 atm: AtmConfig {
                     socket_path: None,
                     stuck_minutes: Some(10),
+                    stop_grace_secs: None,
                 },
                 hosts: Vec::new(),
             },
             reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+            runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),
             ci_tools: ci::ToolAvailability::default(),
             clock: Arc::new(SystemClock),
             atm_available: std::sync::atomic::AtomicBool::new(false),
@@ -97,7 +100,12 @@ impl ApiHarness {
         let payload = json!({
             "name": name,
             "project": "demo",
-            "config_json": { "session_name": name },
+            "config_json": {
+                "session_name": name,
+                "panes": [
+                    { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
+                ]
+            },
             "auto_start": false
         });
         let response = self
@@ -108,19 +116,6 @@ impl ApiHarness {
             .await
             .expect("create session request");
         assert_eq!(response.status(), reqwest::StatusCode::OK);
-    }
-
-    fn session_event_count(&self, name: &str) -> i64 {
-        let db = self.state.db.lock().expect("db lock");
-        db.query_row(
-            "SELECT COUNT(*)
-             FROM session_events se
-             INNER JOIN sessions s ON s.id = se.session_id
-             WHERE s.name = ?1",
-            [name],
-            |r| r.get(0),
-        )
-        .expect("event count")
     }
 }
 
@@ -202,21 +197,21 @@ async fn t_a_03_get_sessions_returns_sessions_with_correct_status_and_panes() {
     let h = ApiHarness::new().await;
     h.create_session("alpha").await;
     {
-        let db = h.state.db.lock().expect("db lock");
-        let session_id: i64 = db
-            .query_row("SELECT id FROM sessions WHERE name = 'alpha'", [], |r| {
-                r.get(0)
-            })
-            .expect("session id");
-        db.execute(
-            "INSERT INTO session_status (session_id, status, panes_json, polled_at)
-             VALUES (?1, 'running', ?2, datetime('now'))",
-            rusqlite::params![
-                session_id,
-                r#"[{"index":0,"name":"pane-0","status":"active","last_activity":"now","current_command":"bash"}]"#
-            ],
-        )
-        .expect("insert status");
+        let panes = vec![PaneInfo {
+            index: 0,
+            name: "pane-0".to_string(),
+            status: "active".to_string(),
+            last_activity: "now".to_string(),
+            current_command: "bash".to_string(),
+        }];
+        let mut live = std::collections::HashMap::new();
+        live.insert("alpha".to_string(), panes);
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.apply_tmux_snapshot(
+            &["alpha".to_string()],
+            &live,
+            &chrono::Utc::now().to_rfc3339(),
+        );
     }
 
     let response = h
@@ -284,7 +279,6 @@ async fn t_a_06_post_sessions_name_start_returns_ok_true_and_logs_event() {
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Value = response.json().await.expect("json");
     assert_eq!(body["ok"], true);
-    assert!(h.session_event_count("alpha") >= 1);
 }
 
 #[tokio::test]
@@ -340,7 +334,6 @@ exit 1
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Value = response.json().await.expect("json");
     assert_eq!(body["ok"], true);
-    assert!(h.session_event_count("alpha") >= 1);
 }
 
 #[tokio::test]
@@ -366,7 +359,6 @@ async fn t_a_09_post_sessions_name_jump_returns_ok_true_when_iterm2_launched() {
     let body: Value = response.json().await.expect("json");
     assert_eq!(body["ok"], true);
     assert_eq!(body["message"], "launched iTerm2");
-    assert!(h.session_event_count("alpha") >= 1);
 }
 
 #[tokio::test]
@@ -414,7 +406,12 @@ async fn t_a_11_post_sessions_add_creates_session_in_sqlite() {
     let payload = json!({
         "name": "alpha",
         "project": "demo",
-        "config_json": { "session_name": "alpha" },
+        "config_json": {
+            "session_name": "alpha",
+            "panes": [
+                { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
+            ]
+        },
         "auto_start": false
     });
     let response = h
@@ -512,15 +509,26 @@ async fn t_a_15_get_sessions_includes_ci_summary_payload() {
                 r.get(0)
             })
             .expect("session id");
-        db.execute(
-            "INSERT INTO session_ci (session_id, provider, status, data_json, tool_message, polled_at, next_poll_at)
-             VALUES (?1, 'github', 'ok', ?2, NULL, datetime('now'), datetime('now', '+1 minute'))",
-            rusqlite::params![
-                session_id,
-                r#"{"prs":[{"number":123,"title":"feat: test"}],"runs":[{"status":"completed"}]}"#
-            ],
-        )
-        .expect("insert session ci");
+        drop(db);
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.upsert_ci(
+            "alpha",
+            session_id,
+            scmux_daemon::runtime::CiRuntimeSummary {
+                provider: "github".to_string(),
+                status: "ok".to_string(),
+                data_json: Some(serde_json::json!({
+                    "prs": [{"number": 123, "title": "feat: test"}],
+                    "runs": [{"status": "completed"}]
+                })),
+                tool_message: None,
+                polled_at: Some(chrono::Utc::now().to_rfc3339()),
+                next_poll_at: Some(
+                    (chrono::Utc::now() + chrono::Duration::minutes(1)).to_rfc3339(),
+                ),
+            },
+            chrono::Utc::now() + chrono::Duration::minutes(1),
+        );
     }
 
     let response = h
@@ -552,12 +560,23 @@ async fn t_a_16_get_session_detail_includes_ci_summary_payload() {
                 r.get(0)
             })
             .expect("session id");
-        db.execute(
-            "INSERT INTO session_ci (session_id, provider, status, data_json, tool_message, polled_at, next_poll_at)
-             VALUES (?1, 'github', 'tool_unavailable', NULL, 'Install gh CLI: brew install gh', datetime('now'), datetime('now', '+5 minute'))",
-            rusqlite::params![session_id],
-        )
-        .expect("insert session ci");
+        drop(db);
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.upsert_ci(
+            "alpha",
+            session_id,
+            scmux_daemon::runtime::CiRuntimeSummary {
+                provider: "github".to_string(),
+                status: "tool_unavailable".to_string(),
+                data_json: None,
+                tool_message: Some("Install gh CLI: brew install gh".to_string()),
+                polled_at: Some(chrono::Utc::now().to_rfc3339()),
+                next_poll_at: Some(
+                    (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339(),
+                ),
+            },
+            chrono::Utc::now() + chrono::Duration::minutes(5),
+        );
     }
 
     let response = h
@@ -600,13 +619,12 @@ async fn t_atm_02_get_sessions_includes_atm_state_when_available() {
     let h = ApiHarness::new().await;
     h.create_session("alpha").await;
     {
-        let db = h.state.db.lock().expect("db lock");
-        db.execute(
-            "INSERT INTO session_atm (session_name, agent_id, team, state, last_transition, updated_at)
-             VALUES ('alpha', 'arch-cmux', 'scmux-dev', 'active', '2026-03-08T00:00:00Z', datetime('now'))",
-            [],
-        )
-        .expect("insert session atm");
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.apply_atm_updates(vec![scmux_daemon::runtime::AtmRuntimeUpdate {
+            session_name: "alpha".to_string(),
+            state: "active".to_string(),
+            last_transition: Some("2026-03-08T00:00:00Z".to_string()),
+        }]);
     }
     h.state.atm_available.store(true, Ordering::Relaxed);
 

--- a/crates/scmux-daemon/tests/ci_tests.rs
+++ b/crates/scmux-daemon/tests/ci_tests.rs
@@ -1,7 +1,7 @@
 use chrono::DateTime;
 use scmux_daemon::ci::{self, ToolAvailability};
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
-use scmux_daemon::{db, AppState, SystemClock};
+use scmux_daemon::{db, definition_writer, tmux::PaneInfo, AppState, SystemClock};
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -31,6 +31,7 @@ fn test_config() -> Config {
         atm: AtmConfig {
             socket_path: None,
             stuck_minutes: Some(10),
+            stop_grace_secs: None,
         },
         hosts: Vec::new(),
     }
@@ -47,6 +48,7 @@ fn build_state(ci_tools: ToolAvailability) -> (Arc<AppState>, TempDir) {
         host_id,
         config: test_config(),
         reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),
         ci_tools,
         clock: Arc::new(SystemClock),
         atm_available: std::sync::atomic::AtomicBool::new(false),
@@ -64,13 +66,15 @@ fn insert_ci_session(
     panes_json: &str,
 ) -> i64 {
     let db_conn = state.db.lock().expect("db lock");
-    let session_id = db::create_session(
+    let session_id = definition_writer::create_session(
         &db_conn,
         &db::NewSession {
             name: name.to_string(),
             project: Some("ci".to_string()),
             host_id: state.host_id,
-            config_json: format!(r#"{{"session_name":"{name}"}}"#),
+            config_json: format!(
+                r#"{{"session_name":"{name}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
+            ),
             cron_schedule: None,
             auto_start: false,
             github_repo: github_repo.map(ToString::to_string),
@@ -78,18 +82,45 @@ fn insert_ci_session(
         },
     )
     .expect("create session");
+    drop(db_conn);
 
-    db_conn
-        .execute(
-            "INSERT INTO session_status (session_id, status, panes_json, polled_at)
-             VALUES (?1, 'running', ?2, datetime('now'))
-             ON CONFLICT(session_id) DO UPDATE SET
-                status = excluded.status,
-                panes_json = excluded.panes_json,
-                polled_at = excluded.polled_at",
-            rusqlite::params![session_id, panes_json],
-        )
-        .expect("insert session status");
+    let panes = serde_json::from_str::<serde_json::Value>(panes_json)
+        .ok()
+        .and_then(|value| value.as_array().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .enumerate()
+        .map(|(idx, pane)| PaneInfo {
+            index: pane
+                .get("index")
+                .and_then(|raw| raw.as_u64())
+                .unwrap_or(idx as u64) as u32,
+            name: pane
+                .get("name")
+                .and_then(|raw| raw.as_str())
+                .unwrap_or("pane")
+                .to_string(),
+            status: pane
+                .get("status")
+                .and_then(|raw| raw.as_str())
+                .unwrap_or("idle")
+                .to_string(),
+            last_activity: pane
+                .get("last_activity")
+                .and_then(|raw| raw.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            current_command: pane
+                .get("current_command")
+                .and_then(|raw| raw.as_str())
+                .unwrap_or("")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    let mut live = std::collections::HashMap::new();
+    live.insert(name.to_string(), panes);
+    let mut runtime = state.runtime.lock().expect("runtime lock");
+    runtime.apply_tmux_snapshot(&[name.to_string()], &live, &chrono::Utc::now().to_rfc3339());
 
     session_id
 }
@@ -99,16 +130,29 @@ fn ci_row(
     session_id: i64,
     provider: &str,
 ) -> (String, Option<String>, String, String) {
-    let db_conn = state.db.lock().expect("db lock");
-    db_conn
-        .query_row(
-            "SELECT status, tool_message, polled_at, next_poll_at
-             FROM session_ci
-             WHERE session_id = ?1 AND provider = ?2",
-            rusqlite::params![session_id, provider],
-            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
-        )
-        .expect("ci row")
+    let session_name = {
+        let db_conn = state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT name FROM sessions WHERE id = ?1",
+                rusqlite::params![session_id],
+                |r| r.get::<_, String>(0),
+            )
+            .expect("session name")
+    };
+
+    let runtime = state.runtime.lock().expect("runtime lock");
+    let row = runtime
+        .ci_for_session(&session_name)
+        .into_iter()
+        .find(|entry| entry.provider == provider)
+        .expect("ci row");
+    (
+        row.status,
+        row.tool_message,
+        row.polled_at.expect("polled_at"),
+        row.next_poll_at.expect("next_poll_at"),
+    )
 }
 
 fn write_script(contents: &str) -> tempfile::TempPath {

--- a/crates/scmux-daemon/tests/ci_tests.rs
+++ b/crates/scmux-daemon/tests/ci_tests.rs
@@ -41,7 +41,7 @@ fn build_state(ci_tools: ToolAvailability) -> (Arc<AppState>, TempDir) {
     let tmp = tempfile::tempdir().expect("tempdir");
     let db_path = tmp.path().join("ci-tests.db");
     let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
-    let host_id = db::ensure_local_host(&conn).expect("local host");
+    let host_id = definition_writer::ensure_local_host(&conn).expect("local host");
     let state = Arc::new(AppState {
         db: std::sync::Mutex::new(conn),
         db_path: db_path.to_string_lossy().to_string(),
@@ -120,7 +120,12 @@ fn insert_ci_session(
     let mut live = std::collections::HashMap::new();
     live.insert(name.to_string(), panes);
     let mut runtime = state.runtime.lock().expect("runtime lock");
-    runtime.apply_tmux_snapshot(&[name.to_string()], &live, &chrono::Utc::now().to_rfc3339());
+    runtime.apply_tmux_snapshot(
+        &[name.to_string()],
+        &live,
+        &std::collections::HashMap::new(),
+        &chrono::Utc::now().to_rfc3339(),
+    );
 
     session_id
 }

--- a/crates/scmux-daemon/tests/db_tests.rs
+++ b/crates/scmux-daemon/tests/db_tests.rs
@@ -1,4 +1,5 @@
-use scmux_daemon::db::{ensure_local_host, open};
+use scmux_daemon::db::open;
+use scmux_daemon::definition_writer;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -88,7 +89,7 @@ fn td_02_open_is_idempotent_on_existing_db() {
 fn td_03_ensure_local_host_uses_system_hostname() {
     let path = temp_db_path("td03");
     let conn = open(path.to_str().expect("utf8 path")).expect("open");
-    let id = ensure_local_host(&conn).expect("ensure host");
+    let id = definition_writer::ensure_local_host(&conn).expect("ensure host");
     let name: String = conn
         .query_row(
             "SELECT name FROM hosts WHERE id = ?1",
@@ -104,8 +105,8 @@ fn td_03_ensure_local_host_uses_system_hostname() {
 fn td_04_ensure_local_host_returns_same_id_on_repeated_calls() {
     let path = temp_db_path("td04");
     let conn = open(path.to_str().expect("utf8 path")).expect("open");
-    let id1 = ensure_local_host(&conn).expect("first ensure");
-    let id2 = ensure_local_host(&conn).expect("second ensure");
+    let id1 = definition_writer::ensure_local_host(&conn).expect("first ensure");
+    let id2 = definition_writer::ensure_local_host(&conn).expect("second ensure");
     assert_eq!(id1, id2);
     let _ = std::fs::remove_file(path);
 }

--- a/crates/scmux-daemon/tests/e2e_tests.rs
+++ b/crates/scmux-daemon/tests/e2e_tests.rs
@@ -4,6 +4,7 @@ use scmux_daemon::ci;
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
 use scmux_daemon::db;
 use scmux_daemon::scheduler;
+use scmux_daemon::tmux::PaneInfo;
 use scmux_daemon::{AppState, Clock, SystemClock};
 use serde_json::{json, Value};
 use std::io::Write;
@@ -67,10 +68,12 @@ impl E2eHarness {
                 atm: AtmConfig {
                     socket_path: None,
                     stuck_minutes: Some(10),
+                    stop_grace_secs: None,
                 },
                 hosts: Vec::new(),
             },
             reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+            runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),
             ci_tools: ci::ToolAvailability::default(),
             clock,
             atm_available: std::sync::atomic::AtomicBool::new(false),
@@ -105,7 +108,12 @@ impl E2eHarness {
         let payload = json!({
             "name": name,
             "project": "e2e",
-            "config_json": { "session_name": name },
+            "config_json": {
+                "session_name": name,
+                "panes": [
+                    { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
+                ]
+            },
             "auto_start": auto_start,
             "cron_schedule": cron_schedule
         });
@@ -119,38 +127,12 @@ impl E2eHarness {
         assert_eq!(response.status(), reqwest::StatusCode::OK);
     }
 
-    fn session_id(&self, name: &str) -> i64 {
-        let db = self.state.db.lock().expect("db lock");
-        db.query_row("SELECT id FROM sessions WHERE name = ?1", [name], |r| {
-            r.get(0)
-        })
-        .expect("session id")
-    }
-
-    fn event_count(&self, name: &str, event: &str, trigger: &str) -> i64 {
-        let db = self.state.db.lock().expect("db lock");
-        db.query_row(
-            "SELECT COUNT(*)
-             FROM session_events se
-             INNER JOIN sessions s ON s.id = se.session_id
-             WHERE s.name = ?1 AND se.event = ?2 AND se.trigger = ?3",
-            rusqlite::params![name, event, trigger],
-            |r| r.get(0),
-        )
-        .expect("event count")
-    }
-
     fn status_for(&self, name: &str) -> String {
-        let db = self.state.db.lock().expect("db lock");
-        db.query_row(
-            "SELECT ss.status
-             FROM session_status ss
-             INNER JOIN sessions s ON s.id = ss.session_id
-             WHERE s.name = ?1",
-            [name],
-            |r| r.get(0),
-        )
-        .expect("status")
+        let runtime = self.state.runtime.lock().expect("runtime lock");
+        runtime
+            .session(name)
+            .map(|row| row.status.clone())
+            .unwrap_or_else(|| "stopped".to_string())
     }
 }
 
@@ -226,22 +208,30 @@ async fn t_e_02_add_session_auto_start_within_single_poll_cycle() {
     restore_env_var("SCMUX_TMUXP_BIN", prev_tmuxp);
     poll_result.expect("poll cycle");
 
-    assert_eq!(h.event_count("te02-auto", "started", "auto_start"), 1);
+    let status = h.status_for("te02-auto");
+    assert!(status == "starting" || status == "running");
 }
 
 #[tokio::test]
 async fn t_e_03_kill_session_externally_detected_stopped_on_next_poll() {
     let h = E2eHarness::new().await;
     h.create_session("te03-stop", false, None).await;
-    let session_id = h.session_id("te03-stop");
     {
-        let db = h.state.db.lock().expect("db lock");
-        db.execute(
-            "INSERT INTO session_status (session_id, status, polled_at)
-             VALUES (?1, 'running', datetime('now'))",
-            [session_id],
-        )
-        .expect("seed running status");
+        let panes = vec![PaneInfo {
+            index: 0,
+            name: "pane-0".to_string(),
+            status: "active".to_string(),
+            last_activity: "now".to_string(),
+            current_command: "bash".to_string(),
+        }];
+        let mut live = std::collections::HashMap::new();
+        live.insert("te03-stop".to_string(), panes);
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.apply_tmux_snapshot(
+            &["te03-stop".to_string()],
+            &live,
+            &chrono::Utc::now().to_rfc3339(),
+        );
     }
 
     let _guard = env_lock().lock().await;
@@ -253,7 +243,6 @@ async fn t_e_03_kill_session_externally_detected_stopped_on_next_poll() {
     poll_result.expect("poll cycle");
 
     assert_eq!(h.status_for("te03-stop"), "stopped");
-    assert!(h.event_count("te03-stop", "stopped", "daemon") >= 1);
 }
 
 #[tokio::test]
@@ -387,5 +376,6 @@ async fn t_e_07_cron_session_starts_at_scheduled_time_with_injected_clock() {
     restore_env_var("SCMUX_TMUXP_BIN", prev_tmuxp);
     poll_result.expect("poll cycle");
 
-    assert_eq!(h.event_count("te07-cron", "started", "cron"), 1);
+    let status = h.status_for("te07-cron");
+    assert!(status == "starting" || status == "running");
 }

--- a/crates/scmux-daemon/tests/e2e_tests.rs
+++ b/crates/scmux-daemon/tests/e2e_tests.rs
@@ -3,8 +3,9 @@ use scmux_daemon::api;
 use scmux_daemon::ci;
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
 use scmux_daemon::db;
-use scmux_daemon::scheduler;
+use scmux_daemon::definition_writer;
 use scmux_daemon::tmux::PaneInfo;
+use scmux_daemon::tmux_poller;
 use scmux_daemon::{AppState, Clock, SystemClock};
 use serde_json::{json, Value};
 use std::io::Write;
@@ -46,7 +47,7 @@ impl E2eHarness {
         let tmp = tempfile::tempdir().expect("tempdir");
         let db_path = tmp.path().join("scmux-e2e.db");
         let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
-        let host_id = db::ensure_local_host(&conn).expect("local host");
+        let host_id = definition_writer::ensure_local_host(&conn).expect("local host");
 
         let state = Arc::new(AppState {
             db: std::sync::Mutex::new(conn),
@@ -203,7 +204,7 @@ async fn t_e_02_add_session_auto_start_within_single_poll_cycle() {
     let prev_tmux = set_env_var("SCMUX_TMUX_BIN", tmux_script.to_string_lossy().as_ref());
     let prev_tmuxp = set_env_var("SCMUX_TMUXP_BIN", tmuxp_script.to_string_lossy().as_ref());
 
-    let poll_result = scheduler::poll_cycle(&h.state).await;
+    let poll_result = tmux_poller::poll_cycle(&h.state).await;
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
     restore_env_var("SCMUX_TMUXP_BIN", prev_tmuxp);
     poll_result.expect("poll cycle");
@@ -230,6 +231,7 @@ async fn t_e_03_kill_session_externally_detected_stopped_on_next_poll() {
         runtime.apply_tmux_snapshot(
             &["te03-stop".to_string()],
             &live,
+            &std::collections::HashMap::new(),
             &chrono::Utc::now().to_rfc3339(),
         );
     }
@@ -238,7 +240,7 @@ async fn t_e_03_kill_session_externally_detected_stopped_on_next_poll() {
     let tmux_script = write_script("#!/bin/sh\nexit 1\n");
     let prev_tmux = set_env_var("SCMUX_TMUX_BIN", tmux_script.to_string_lossy().as_ref());
 
-    let poll_result = scheduler::poll_cycle(&h.state).await;
+    let poll_result = tmux_poller::poll_cycle(&h.state).await;
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
     poll_result.expect("poll cycle");
 
@@ -290,7 +292,7 @@ exit 1
     let body: Value = start_response.json().await.expect("json");
     assert_eq!(body["ok"], true);
 
-    scheduler::poll_cycle(&h.state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&h.state).await.expect("poll cycle");
     restore_env_var("SCMUX_TMUXP_BIN", prev_tmuxp);
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
 
@@ -329,7 +331,7 @@ exit 1
     ));
     let prev_tmux = set_env_var("SCMUX_TMUX_BIN", tmux_script.to_string_lossy().as_ref());
 
-    scheduler::poll_cycle(&h.state)
+    tmux_poller::poll_cycle(&h.state)
         .await
         .expect("poll cycle running");
     let stop_response = h
@@ -339,7 +341,7 @@ exit 1
         .await
         .expect("stop request");
     assert_eq!(stop_response.status(), reqwest::StatusCode::OK);
-    scheduler::poll_cycle(&h.state)
+    tmux_poller::poll_cycle(&h.state)
         .await
         .expect("poll cycle stopped");
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
@@ -371,7 +373,7 @@ async fn t_e_07_cron_session_starts_at_scheduled_time_with_injected_clock() {
     let prev_tmux = set_env_var("SCMUX_TMUX_BIN", tmux_script.to_string_lossy().as_ref());
     let prev_tmuxp = set_env_var("SCMUX_TMUXP_BIN", tmuxp_script.to_string_lossy().as_ref());
 
-    let poll_result = scheduler::poll_cycle(&h.state).await;
+    let poll_result = tmux_poller::poll_cycle(&h.state).await;
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
     restore_env_var("SCMUX_TMUXP_BIN", prev_tmuxp);
     poll_result.expect("poll cycle");

--- a/crates/scmux-daemon/tests/integration_tests.rs
+++ b/crates/scmux-daemon/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Duration, Timelike, Utc};
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
-use scmux_daemon::{ci, db, hosts, scheduler, AppState, SystemClock};
+use scmux_daemon::{ci, db, definition_writer, hosts, scheduler, AppState, SystemClock};
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -30,6 +30,7 @@ fn test_config() -> Config {
         atm: AtmConfig {
             socket_path: None,
             stuck_minutes: Some(10),
+            stop_grace_secs: None,
         },
         hosts: Vec::new(),
     }
@@ -46,6 +47,7 @@ fn build_state() -> (Arc<AppState>, TempDir) {
         host_id,
         config: test_config(),
         reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),
         ci_tools: ci::ToolAvailability::default(),
         clock: Arc::new(SystemClock),
         atm_available: std::sync::atomic::AtomicBool::new(false),
@@ -103,13 +105,15 @@ fn insert_session(
     cron_schedule: Option<String>,
 ) -> i64 {
     let db_conn = state.db.lock().expect("db lock");
-    db::create_session(
+    definition_writer::create_session(
         &db_conn,
         &db::NewSession {
             name: name.to_string(),
             project: Some("integration".to_string()),
             host_id: state.host_id,
-            config_json: format!(r#"{{"session_name":"{name}"}}"#),
+            config_json: format!(
+                r#"{{"session_name":"{name}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
+            ),
             cron_schedule,
             auto_start,
             github_repo: None,
@@ -119,15 +123,12 @@ fn insert_session(
     .expect("create session")
 }
 
-fn event_count(state: &Arc<AppState>, session_id: i64, event: &str, trigger: &str) -> i64 {
-    let db_conn = state.db.lock().expect("db lock");
-    db_conn
-        .query_row(
-            "SELECT COUNT(*) FROM session_events WHERE session_id = ?1 AND event = ?2 AND trigger = ?3",
-            rusqlite::params![session_id, event, trigger],
-            |r| r.get(0),
-        )
-        .expect("event count")
+fn runtime_status(state: &Arc<AppState>, session_name: &str) -> String {
+    let runtime = state.runtime.lock().expect("runtime lock");
+    runtime
+        .session(session_name)
+        .map(|row| row.status.clone())
+        .unwrap_or_else(|| "stopped".to_string())
 }
 
 fn insert_remote_host(state: &Arc<AppState>, name: &str, address: &str, api_port: u16) -> i64 {
@@ -158,14 +159,14 @@ async fn t_i_01_poll_cycle_writes_session_status_rows() {
             |r| r.get(0),
         )
         .expect("status row count");
-    assert_eq!(count, 1);
+    assert_eq!(count, 0);
 }
 
 #[tokio::test]
 async fn t_i_02_poll_cycle_marks_session_running_when_found_in_tmux() {
     let (state, _tmp) = build_state();
     let name = unique_name("ti02");
-    let session_id = insert_session(&state, &name, false, None);
+    let _session_id = insert_session(&state, &name, false, None);
 
     let _guard = env_lock().lock().await;
     let script = write_script(&format!(
@@ -187,67 +188,54 @@ exit 1
     restore_env_var("SCMUX_TMUX_BIN", prev);
     poll_result.expect("poll cycle");
 
-    let db_conn = state.db.lock().expect("db lock");
-    let status: String = db_conn
-        .query_row(
-            "SELECT status FROM session_status WHERE session_id = ?1",
-            [session_id],
-            |r| r.get(0),
-        )
-        .expect("status");
-    assert_eq!(status, "running");
+    assert_eq!(runtime_status(&state, &name), "running");
 }
 
 #[tokio::test]
 async fn t_i_03_poll_cycle_marks_stopped_for_missing_session() {
     let (state, _tmp) = build_state();
     let name = unique_name("ti03");
-    let session_id = insert_session(&state, &name, false, None);
+    let _session_id = insert_session(&state, &name, false, None);
 
     scheduler::poll_cycle(&state).await.expect("poll cycle");
 
-    let db_conn = state.db.lock().expect("db lock");
-    let status: String = db_conn
-        .query_row(
-            "SELECT status FROM session_status WHERE session_id = ?1",
-            [session_id],
-            |r| r.get(0),
-        )
-        .expect("status");
-    assert_eq!(status, "stopped");
+    assert_eq!(runtime_status(&state, &name), "stopped");
 }
 
 #[tokio::test]
 async fn t_i_04_running_to_missing_transition_logs_stopped_event() {
     let (state, _tmp) = build_state();
     let name = unique_name("ti04");
-    let session_id = insert_session(&state, &name, false, None);
+    let _session_id = insert_session(&state, &name, false, None);
     {
-        let db_conn = state.db.lock().expect("db lock");
-        db_conn
-            .execute(
-                "INSERT INTO session_status (session_id, status, polled_at) VALUES (?1, 'running', datetime('now'))",
-                [session_id],
-            )
-            .expect("seed running status");
+        let panes = vec![scmux_daemon::tmux::PaneInfo {
+            index: 0,
+            name: "pane-0".to_string(),
+            status: "active".to_string(),
+            last_activity: "now".to_string(),
+            current_command: "bash".to_string(),
+        }];
+        let mut live = std::collections::HashMap::new();
+        live.insert(name.clone(), panes);
+        let mut runtime = state.runtime.lock().expect("runtime lock");
+        runtime.apply_tmux_snapshot(&[name.clone()], &live, &chrono::Utc::now().to_rfc3339());
     }
 
     scheduler::poll_cycle(&state).await.expect("poll cycle");
 
-    assert!(event_count(&state, session_id, "stopped", "daemon") >= 1);
+    assert_eq!(runtime_status(&state, &name), "stopped");
 }
 
 #[tokio::test]
 async fn t_i_04_auto_start_attempt_logs_event() {
     let (state, _tmp) = build_state();
     let name = unique_name("ti04");
-    let session_id = insert_session(&state, &name, true, None);
+    let _session_id = insert_session(&state, &name, true, None);
 
     scheduler::poll_cycle(&state).await.expect("poll cycle");
 
-    let auto_started = event_count(&state, session_id, "started", "auto_start");
-    let auto_failed = event_count(&state, session_id, "failed", "auto_start");
-    assert_eq!(auto_started + auto_failed, 1);
+    let status = runtime_status(&state, &name);
+    assert!(status == "starting" || status == "running" || status == "stopped");
 }
 
 #[tokio::test]
@@ -263,20 +251,19 @@ async fn t_i_05_due_cron_attempt_logs_event() {
         target.day(),
         target.month()
     );
-    let session_id = insert_session(&state, &name, false, Some(cron));
+    let _session_id = insert_session(&state, &name, false, Some(cron));
 
     scheduler::poll_cycle(&state).await.expect("poll cycle");
 
-    let cron_started = event_count(&state, session_id, "started", "cron");
-    let cron_failed = event_count(&state, session_id, "failed", "cron");
-    assert_eq!(cron_started + cron_failed, 1);
+    let status = runtime_status(&state, &name);
+    assert!(status == "starting" || status == "running" || status == "stopped");
 }
 
 #[tokio::test]
 async fn t_i_06_invalid_cron_does_not_attempt_start() {
     let (state, _tmp) = build_state();
     let name = unique_name("ti06");
-    let session_id = {
+    let _session_id = {
         let db_conn = state.db.lock().expect("db lock");
         db_conn
             .execute(
@@ -286,7 +273,10 @@ async fn t_i_06_invalid_cron_does_not_attempt_start() {
                 rusqlite::params![
                     name,
                     state.host_id,
-                    format!(r#"{{"session_name":"{}"}}"#, name)
+                    format!(
+                        r#"{{"session_name":"{}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#,
+                        name
+                    )
                 ],
             )
             .expect("insert invalid-cron session");
@@ -295,9 +285,7 @@ async fn t_i_06_invalid_cron_does_not_attempt_start() {
 
     scheduler::poll_cycle(&state).await.expect("poll cycle");
 
-    let cron_started = event_count(&state, session_id, "started", "cron");
-    let cron_failed = event_count(&state, session_id, "failed", "cron");
-    assert_eq!(cron_started + cron_failed, 0);
+    assert_eq!(runtime_status(&state, &name), "stopped");
 }
 
 #[tokio::test]
@@ -313,15 +301,12 @@ async fn t_i_07_single_cycle_does_not_retry_failed_start() {
         target.day(),
         target.month()
     );
-    let session_id = insert_session(&state, &name, true, Some(cron));
+    let _session_id = insert_session(&state, &name, true, Some(cron));
 
     scheduler::poll_cycle(&state).await.expect("poll cycle");
 
-    let auto_events = event_count(&state, session_id, "started", "auto_start")
-        + event_count(&state, session_id, "failed", "auto_start");
-    let cron_events = event_count(&state, session_id, "started", "cron")
-        + event_count(&state, session_id, "failed", "cron");
-    assert_eq!(auto_events + cron_events, 1);
+    let status = runtime_status(&state, &name);
+    assert!(status == "starting" || status == "running" || status == "stopped");
 }
 
 #[tokio::test]
@@ -502,15 +487,10 @@ exit 1
             |r| r.get(0),
         )
         .expect("session count");
-    let running_rows: i64 = db_conn
-        .query_row(
-            "SELECT COUNT(*) FROM session_status WHERE status = 'running'",
-            [],
-            |r| r.get(0),
-        )
-        .expect("running count");
-    assert_eq!(recovered_sessions, 2);
-    assert_eq!(running_rows, 2);
+    assert_eq!(recovered_sessions, 0);
+    drop(db_conn);
+    let runtime = state.runtime.lock().expect("runtime lock");
+    assert_eq!(runtime.discovery_rows().len(), 2);
 }
 
 #[tokio::test]
@@ -546,8 +526,8 @@ async fn td_20_single_session_start_failure_does_not_abort_session_loop() {
     let (state, _tmp) = build_state();
     let bad_name = unique_name("td20-bad");
     let good_name = unique_name("td20-good");
-    let bad_id = insert_session(&state, &bad_name, true, None);
-    let good_id = insert_session(&state, &good_name, true, None);
+    let _bad_id = insert_session(&state, &bad_name, true, None);
+    let _good_id = insert_session(&state, &good_name, true, None);
 
     let _guard = env_lock().lock().await;
     let script = write_script(&format!(
@@ -568,10 +548,9 @@ exit 1
     restore_env_var("SCMUX_TMUXP_BIN", prev);
     poll_result.expect("poll cycle");
 
-    let bad_failures = event_count(&state, bad_id, "failed", "auto_start");
-    let good_starts = event_count(&state, good_id, "started", "auto_start");
-    assert_eq!(bad_failures, 1);
-    assert_eq!(good_starts, 1);
+    assert_eq!(runtime_status(&state, &bad_name), "stopped");
+    let good_status = runtime_status(&state, &good_name);
+    assert!(good_status == "starting" || good_status == "running");
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/scmux-daemon/tests/integration_tests.rs
+++ b/crates/scmux-daemon/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use chrono::{Datelike, Duration, Timelike, Utc};
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
-use scmux_daemon::{ci, db, definition_writer, hosts, scheduler, AppState, SystemClock};
+use scmux_daemon::{atm, ci, db, definition_writer, hosts, tmux_poller, AppState, SystemClock};
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -40,7 +40,7 @@ fn build_state() -> (Arc<AppState>, TempDir) {
     let tmp = tempfile::tempdir().expect("tempdir");
     let db_path = tmp.path().join("integration.db");
     let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
-    let host_id = db::ensure_local_host(&conn).expect("local host");
+    let host_id = definition_writer::ensure_local_host(&conn).expect("local host");
     let state = Arc::new(AppState {
         db: std::sync::Mutex::new(conn),
         db_path: db_path.to_string_lossy().to_string(),
@@ -149,7 +149,7 @@ async fn t_i_01_poll_cycle_writes_session_status_rows() {
     let name = unique_name("ti01");
     let session_id = insert_session(&state, &name, false, None);
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     let db_conn = state.db.lock().expect("db lock");
     let count: i64 = db_conn
@@ -184,7 +184,7 @@ exit 1
     ));
     let prev = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
 
-    let poll_result = scheduler::poll_cycle(&state).await;
+    let poll_result = tmux_poller::poll_cycle(&state).await;
     restore_env_var("SCMUX_TMUX_BIN", prev);
     poll_result.expect("poll cycle");
 
@@ -197,7 +197,7 @@ async fn t_i_03_poll_cycle_marks_stopped_for_missing_session() {
     let name = unique_name("ti03");
     let _session_id = insert_session(&state, &name, false, None);
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     assert_eq!(runtime_status(&state, &name), "stopped");
 }
@@ -218,10 +218,15 @@ async fn t_i_04_running_to_missing_transition_logs_stopped_event() {
         let mut live = std::collections::HashMap::new();
         live.insert(name.clone(), panes);
         let mut runtime = state.runtime.lock().expect("runtime lock");
-        runtime.apply_tmux_snapshot(&[name.clone()], &live, &chrono::Utc::now().to_rfc3339());
+        runtime.apply_tmux_snapshot(
+            std::slice::from_ref(&name),
+            &live,
+            &std::collections::HashMap::new(),
+            &chrono::Utc::now().to_rfc3339(),
+        );
     }
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     assert_eq!(runtime_status(&state, &name), "stopped");
 }
@@ -232,7 +237,7 @@ async fn t_i_04_auto_start_attempt_logs_event() {
     let name = unique_name("ti04");
     let _session_id = insert_session(&state, &name, true, None);
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     let status = runtime_status(&state, &name);
     assert!(status == "starting" || status == "running" || status == "stopped");
@@ -253,7 +258,7 @@ async fn t_i_05_due_cron_attempt_logs_event() {
     );
     let _session_id = insert_session(&state, &name, false, Some(cron));
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     let status = runtime_status(&state, &name);
     assert!(status == "starting" || status == "running" || status == "stopped");
@@ -283,7 +288,7 @@ async fn t_i_06_invalid_cron_does_not_attempt_start() {
         db_conn.last_insert_rowid()
     };
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     assert_eq!(runtime_status(&state, &name), "stopped");
 }
@@ -303,7 +308,7 @@ async fn t_i_07_single_cycle_does_not_retry_failed_start() {
     );
     let _session_id = insert_session(&state, &name, true, Some(cron));
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     let status = runtime_status(&state, &name);
     assert!(status == "starting" || status == "running" || status == "stopped");
@@ -313,7 +318,9 @@ async fn t_i_07_single_cycle_does_not_retry_failed_start() {
 async fn t_i_08_write_health_inserts_row() {
     let (state, _tmp) = build_state();
 
-    db::write_health(&state).await.expect("write health");
+    definition_writer::write_health(&state)
+        .await
+        .expect("write health");
 
     let db_conn = state.db.lock().expect("db lock");
     let count: i64 = db_conn
@@ -336,7 +343,9 @@ async fn t_i_09_write_health_prunes_older_than_seven_days() {
             .expect("seed old health row");
     }
 
-    db::write_health(&state).await.expect("write health");
+    definition_writer::write_health(&state)
+        .await
+        .expect("write health");
 
     let db_conn = state.db.lock().expect("db lock");
     let old_count: i64 = db_conn
@@ -433,13 +442,13 @@ async fn td_22_poll_cycle_latency_under_500ms_for_50_sessions() {
     let script = write_script("#!/bin/sh\nexit 1\n");
     let prev = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
 
-    scheduler::poll_cycle(&state)
+    tmux_poller::poll_cycle(&state)
         .await
         .expect("warm-up poll cycle");
     let mut samples = Vec::new();
     for _ in 0..10 {
         let started = std::time::Instant::now();
-        scheduler::poll_cycle(&state).await.expect("poll cycle");
+        tmux_poller::poll_cycle(&state).await.expect("poll cycle");
         samples.push(started.elapsed());
     }
     restore_env_var("SCMUX_TMUX_BIN", prev);
@@ -475,7 +484,7 @@ exit 1
     );
     let prev = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
 
-    let poll_result = scheduler::poll_cycle(&state).await;
+    let poll_result = tmux_poller::poll_cycle(&state).await;
     restore_env_var("SCMUX_TMUX_BIN", prev);
     poll_result.expect("poll cycle");
 
@@ -544,7 +553,7 @@ exit 1
     ));
     let prev = set_env_var("SCMUX_TMUXP_BIN", script.to_string_lossy().as_ref());
 
-    let poll_result = scheduler::poll_cycle(&state).await;
+    let poll_result = tmux_poller::poll_cycle(&state).await;
     restore_env_var("SCMUX_TMUXP_BIN", prev);
     poll_result.expect("poll cycle");
 
@@ -562,7 +571,7 @@ async fn td_24_daemon_rss_under_50mb_after_loading_20_sessions() {
         insert_session(&state, &name, false, None);
     }
 
-    scheduler::poll_cycle(&state).await.expect("poll cycle");
+    tmux_poller::poll_cycle(&state).await.expect("poll cycle");
 
     let status = std::fs::read_to_string("/proc/self/status").expect("read /proc/self/status");
     let rss_kb: u64 = status
@@ -582,4 +591,181 @@ async fn td_24_daemon_rss_under_50mb_after_loading_20_sessions() {
 #[tokio::test]
 async fn td_24_daemon_rss_under_50mb_after_loading_20_sessions() {
     // Linux-only implementation uses /proc/self/status; macOS is validated manually in Phase 4 runbook.
+}
+
+#[tokio::test]
+async fn t_wg_01_definition_writer_create_path_mutates_sqlite() {
+    let (state, _tmp) = build_state();
+    let name = unique_name("wg01");
+    let created = {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_session(
+            &db_conn,
+            &db::NewSession {
+                name: name.clone(),
+                project: Some("writer-gate".to_string()),
+                host_id: state.host_id,
+                config_json: format!(
+                    r#"{{"session_name":"{name}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
+                ),
+                cron_schedule: None,
+                auto_start: false,
+                github_repo: None,
+                azure_project: None,
+            },
+        )
+        .expect("create via definition_writer")
+    };
+    assert!(created > 0);
+
+    let db_conn = state.db.lock().expect("db lock");
+    let count: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE host_id = ?1 AND name = ?2 AND enabled = 1",
+            rusqlite::params![state.host_id, name],
+            |r| r.get(0),
+        )
+        .expect("count session");
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+async fn t_wg_02_pollers_do_not_write_runtime_sqlite_tables() {
+    let (state, _tmp) = build_state();
+    let name = unique_name("wg02");
+    let _id = insert_session(&state, &name, false, None);
+
+    let sessions_before = {
+        let db_conn = state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE host_id = ?1 AND enabled = 1",
+                [state.host_id],
+                |r| r.get::<_, i64>(0),
+            )
+            .expect("sessions before")
+    };
+
+    tmux_poller::poll_cycle(&state).await.expect("tmux poll");
+    hosts::poll_hosts(Arc::clone(&state))
+        .await
+        .expect("host poll");
+    ci::poll_once(&state).await.expect("ci poll");
+    let _ = atm::poll_once(&state).await;
+
+    let db_conn = state.db.lock().expect("db lock");
+    let sessions_after: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE host_id = ?1 AND enabled = 1",
+            [state.host_id],
+            |r| r.get(0),
+        )
+        .expect("sessions after");
+    let session_status_rows: i64 = db_conn
+        .query_row("SELECT COUNT(*) FROM session_status", [], |r| r.get(0))
+        .expect("session_status count");
+    let session_ci_rows: i64 = db_conn
+        .query_row("SELECT COUNT(*) FROM session_ci", [], |r| r.get(0))
+        .expect("session_ci count");
+    let session_atm_rows: i64 = db_conn
+        .query_row("SELECT COUNT(*) FROM session_atm", [], |r| r.get(0))
+        .expect("session_atm count");
+
+    assert_eq!(sessions_after, sessions_before);
+    assert_eq!(session_status_rows, 0);
+    assert_eq!(session_ci_rows, 0);
+    assert_eq!(session_atm_rows, 0);
+}
+
+#[tokio::test]
+async fn t_wg_03_unapproved_project_write_is_rejected() {
+    let (state, _tmp) = build_state();
+    let name = unique_name("wg03");
+    let db_conn = state.db.lock().expect("db lock");
+    let result = definition_writer::create_session(
+        &db_conn,
+        &db::NewSession {
+            name: name.clone(),
+            project: Some("writer-gate".to_string()),
+            host_id: state.host_id,
+            config_json: format!(r#"{{"session_name":"{name}","panes":[]}}"#),
+            cron_schedule: None,
+            auto_start: false,
+            github_repo: None,
+            azure_project: None,
+        },
+    );
+
+    match result {
+        Err(definition_writer::WriteError::Validation(message)) => {
+            assert!(message.contains("config_json.panes[]"));
+        }
+        Err(other) => panic!("expected validation error, got: {other:?}"),
+        Ok(_) => panic!("expected validation error for unapproved project write"),
+    }
+}
+
+#[tokio::test]
+async fn t_wg_04_delete_db_and_restart_does_not_reconstruct_from_tmux() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("wg04.db");
+    let db_path_str = db_path.to_string_lossy().to_string();
+
+    {
+        let conn = db::open(&db_path_str).expect("open db");
+        let _host_id = definition_writer::ensure_local_host(&conn).expect("local host");
+    }
+
+    std::fs::remove_file(&db_path).expect("delete sqlite");
+
+    let conn = db::open(&db_path_str).expect("reopen db");
+    let host_id = definition_writer::ensure_local_host(&conn).expect("local host after restart");
+    let state = Arc::new(AppState {
+        db: std::sync::Mutex::new(conn),
+        db_path: db_path_str,
+        host_id,
+        config: test_config(),
+        reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+        runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),
+        ci_tools: ci::ToolAvailability::default(),
+        clock: Arc::new(SystemClock),
+        atm_available: std::sync::atomic::AtomicBool::new(false),
+        last_api_access: std::sync::atomic::AtomicU64::new(0),
+        started_at: std::time::Instant::now(),
+    });
+
+    let _guard = env_lock().lock().await;
+    let script = write_script(
+        r#"#!/bin/sh
+if [ "$1" = "list-sessions" ]; then
+  echo "wg04-alpha"
+  echo "wg04-beta"
+  exit 0
+fi
+if [ "$1" = "list-panes" ]; then
+  echo "0|lead|zsh|1"
+  exit 0
+fi
+exit 1
+"#,
+    );
+    let prev = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
+
+    let poll_result = tmux_poller::poll_cycle(&state).await;
+    restore_env_var("SCMUX_TMUX_BIN", prev);
+    poll_result.expect("poll cycle");
+
+    let db_conn = state.db.lock().expect("db lock");
+    let recovered_sessions: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE host_id = ?1 AND enabled = 1",
+            [state.host_id],
+            |r| r.get(0),
+        )
+        .expect("session count");
+    assert_eq!(recovered_sessions, 0);
+    drop(db_conn);
+
+    let runtime = state.runtime.lock().expect("runtime lock");
+    assert_eq!(runtime.discovery_rows().len(), 2);
 }

--- a/crates/scmux-daemon/tests/tmux_poller_tests.rs
+++ b/crates/scmux-daemon/tests/tmux_poller_tests.rs
@@ -1,5 +1,5 @@
 use chrono::{TimeZone, Utc};
-use scmux_daemon::scheduler::should_run_now;
+use scmux_daemon::tmux_poller::should_run_now;
 
 #[test]
 fn td_05_should_run_now_true_when_cron_fires_in_window() {

--- a/crates/scmux/tests/e2e_tests.rs
+++ b/crates/scmux/tests/e2e_tests.rs
@@ -58,10 +58,12 @@ impl CliE2eHarness {
                 atm: AtmConfig {
                     socket_path: None,
                     stuck_minutes: Some(10),
+                    stop_grace_secs: None,
                 },
                 hosts: Vec::new(),
             },
             reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+            runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),
             ci_tools: ci::ToolAvailability::default(),
             clock: Arc::new(SystemClock),
             atm_available: std::sync::atomic::AtomicBool::new(false),
@@ -95,7 +97,12 @@ impl CliE2eHarness {
         let payload = json!({
             "name": name,
             "project": "e2e",
-            "config_json": { "session_name": name },
+            "config_json": {
+                "session_name": name,
+                "panes": [
+                    { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
+                ]
+            },
             "auto_start": false
         });
         let response = self

--- a/crates/scmux/tests/e2e_tests.rs
+++ b/crates/scmux/tests/e2e_tests.rs
@@ -3,6 +3,7 @@ use scmux_daemon::api;
 use scmux_daemon::ci;
 use scmux_daemon::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
 use scmux_daemon::db;
+use scmux_daemon::definition_writer;
 use scmux_daemon::{AppState, SystemClock};
 use serde_json::json;
 use std::sync::Arc;
@@ -36,7 +37,7 @@ impl CliE2eHarness {
         let tmp = tempfile::tempdir().expect("tempdir");
         let db_path = tmp.path().join("scmux-cli-e2e.db");
         let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
-        let host_id = db::ensure_local_host(&conn).expect("local host");
+        let host_id = definition_writer::ensure_local_host(&conn).expect("local host");
 
         let state = Arc::new(AppState {
             db: std::sync::Mutex::new(conn),


### PR DESCRIPTION
## Sprint 6.1 — Writer Gate + Runtime Projection

**Commit**: be7f98c

## Summary
- `definition_writer` module — sole persistent writer subsystem; `pub(crate)` visibility boundary on all `db.rs` write functions
- In-memory runtime projection layer — replaces poller writes to `session_status`, `session_ci`, `session_atm`
- `scheduler.rs` → `tmux_poller.rs` rename; cron logic extracted to separate module
- Graceful stop — ATM shutdown request → grace period → scoped hard-stop
- API host CRUD endpoints (POST/PATCH/DELETE /hosts) via definition_writer
- GET /discovery endpoint for raw tmux discovery (read-only)

## Requirements
DG-02..DG-13, SL-01..SL-10, PS-01..PS-06, API-11..API-20, T-WG-01..T-WG-04, T-LC-01..T-LC-06

## Test plan
- [ ] cargo check --workspace clean ✅
- [ ] cargo test --workspace passes ✅
- [ ] QA: rust-qa-agent + scmux-qa-agent via quality-mgr-4