### PR TITLE
P6 final cleanup: API JSON errors, runtime prune, legacy removal

### DIFF
--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -254,7 +254,9 @@ async fn touch_last_api_access(
     next.run(request).await
 }
 
-async fn health(State(state): State<Arc<AppState>>) -> Result<Json<HealthResponse>, StatusCode> {
+async fn health(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<HealthResponse>, (StatusCode, Json<ErrorResponse>)> {
     let uptime_secs = state.started_at.elapsed().as_secs();
     let db_path = state.db_path.clone();
     let host_id = state.host_id;
@@ -280,11 +282,13 @@ async fn health(State(state): State<Arc<AppState>>) -> Result<Json<HealthRespons
         Ok(Ok(value)) => value,
         Ok(Err(err)) => {
             tracing::warn!("health query failed: {err}");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            return Err(internal_error("failed to query session count".to_string()));
         }
         Err(err) => {
             tracing::warn!("health join error: {err}");
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            return Err(internal_error(
+                "failed to join health query task".to_string(),
+            ));
         }
     };
 
@@ -310,7 +314,7 @@ async fn health(State(state): State<Arc<AppState>>) -> Result<Json<HealthRespons
 
 async fn list_sessions(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<Vec<SessionSummary>>, StatusCode> {
+) -> Result<Json<Vec<SessionSummary>>, (StatusCode, Json<ErrorResponse>)> {
     let session_rows = {
         let state = Arc::clone(&state);
         let joined = tokio::task::spawn_blocking(move || {
@@ -323,11 +327,15 @@ async fn list_sessions(
             Ok(Ok(rows)) => rows,
             Ok(Err(err)) => {
                 tracing::warn!("list_sessions DB error: {err}");
-                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                return Err(internal_error(
+                    "failed to read session definitions".to_string(),
+                ));
             }
             Err(err) => {
                 tracing::warn!("list_sessions join error: {err}");
-                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                return Err(internal_error(
+                    "failed to join list_sessions task".to_string(),
+                ));
             }
         }
     };
@@ -373,7 +381,7 @@ async fn list_sessions(
 async fn get_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
-) -> Result<Json<SessionDetail>, StatusCode> {
+) -> Result<Json<SessionDetail>, (StatusCode, Json<ErrorResponse>)> {
     let row = {
         let state = Arc::clone(&state);
         let name = name.clone();
@@ -382,10 +390,19 @@ async fn get_session(
             db::get_session_for_host(&db, state.host_id, &name)
         })
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        result.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| internal_error("failed to join get_session read task".to_string()))?;
+        result.map_err(|_| internal_error("failed to read session definition".to_string()))?
     }
-    .ok_or(StatusCode::NOT_FOUND)?;
+    .ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("session '{name}' not found"),
+            }),
+        )
+    })?;
 
     let config_json = serde_json::from_str(&row.config_json).unwrap_or(serde_json::json!({}));
     let atm_available = state.atm_available.load(Ordering::Relaxed);
@@ -602,7 +619,7 @@ async fn start_session(
 async fn stop_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
-) -> Result<Json<ActionResponse>, StatusCode> {
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
     let definition = {
         let state = Arc::clone(&state);
         let name = name.clone();
@@ -611,10 +628,19 @@ async fn stop_session(
             db::get_session_for_host(&db_conn, state.host_id, &name)
         })
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        result.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .map_err(|_| internal_error("failed to join stop_session read task".to_string()))?;
+        result.map_err(|_| internal_error("failed to read session definition".to_string()))?
     }
-    .ok_or(StatusCode::NOT_FOUND)?;
+    .ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("session '{name}' not found"),
+            }),
+        )
+    })?;
 
     let targets = extract_shutdown_targets(&definition.config_json);
     if let Err(err) = atm::send_shutdown_messages(state.as_ref(), &targets).await {
@@ -662,7 +688,7 @@ async fn jump_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
     Json(req): Json<JumpRequest>,
-) -> Result<Json<ActionResponse>, StatusCode> {
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
     let host_id = req.host_id.unwrap_or(state.host_id);
     let state2 = Arc::clone(&state);
     let name2 = name.clone();
@@ -673,11 +699,30 @@ async fn jump_session(
         Ok::<_, anyhow::Error>((session, host))
     })
     .await
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    .map_err(|_| internal_error("failed to join jump_session read task".to_string()))?
+    .map_err(|_| internal_error("failed to read jump target definition".to_string()))?;
 
-    let (_session, host) = session_data;
-    let host = host.ok_or(StatusCode::NOT_FOUND)?;
+    let (session, host) = session_data;
+    if session.is_none() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("session '{name}' not found"),
+            }),
+        ));
+    }
+    let host = host.ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("host '{host_id}' not found"),
+            }),
+        )
+    })?;
 
     let terminal = req
         .terminal
@@ -688,7 +733,12 @@ async fn jump_session(
         HostTarget::Local
     } else {
         HostTarget::Remote {
-            user: host.ssh_user.ok_or(StatusCode::BAD_REQUEST)?,
+            user: host.ssh_user.ok_or_else(|| {
+                bad_request(
+                    "invalid_host",
+                    format!("host '{}' is missing ssh_user", host.name),
+                )
+            })?,
             host: host.address,
         }
     };
@@ -802,10 +852,10 @@ async fn delete_host(
 
 async fn get_dashboard_config(
     State(state): State<Arc<AppState>>,
-) -> Result<Json<DashboardConfigResponse>, StatusCode> {
+) -> Result<Json<DashboardConfigResponse>, (StatusCode, Json<ErrorResponse>)> {
     let hosts = fetch_hosts(Arc::clone(&state))
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(|_| internal_error("failed to read hosts for dashboard config".to_string()))?;
     Ok(Json(DashboardConfigResponse {
         hosts,
         default_terminal: state

--- a/crates/scmux-daemon/src/config.rs
+++ b/crates/scmux-daemon/src/config.rs
@@ -7,7 +7,6 @@ pub struct Config {
     pub daemon: DaemonConfig,
     pub polling: PollingConfig,
     pub atm: AtmConfig,
-    pub hosts: Vec<HostConfig>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -37,15 +36,6 @@ pub struct AtmConfig {
     pub socket_path: Option<String>,
     pub stuck_minutes: Option<u64>,
     pub stop_grace_secs: Option<u64>,
-}
-
-#[derive(Debug, Deserialize, Clone)]
-pub struct HostConfig {
-    pub name: String,
-    pub address: String,
-    pub ssh_user: Option<String>,
-    pub api_port: Option<u16>,
-    pub is_local: Option<bool>,
 }
 
 /// Loads config from TOML. Missing file is not an error and returns defaults.

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -97,17 +97,6 @@ pub(crate) fn ensure_local_host(conn: &Connection) -> Result<i64> {
     )
 }
 
-pub fn session_id(conn: &Connection, host_id: i64, name: &str) -> anyhow::Result<Option<i64>> {
-    let value = conn
-        .query_row(
-            "SELECT id FROM sessions WHERE name = ?1 AND host_id = ?2",
-            params![name, host_id],
-            |r| r.get::<_, i64>(0),
-        )
-        .optional()?;
-    Ok(value)
-}
-
 pub fn list_sessions_for_host(
     conn: &Connection,
     host_id: i64,
@@ -462,18 +451,8 @@ fn migrate(conn: &Connection) -> Result<()> {
             UNIQUE (name, host_id)
         );
 
-        CREATE TABLE IF NOT EXISTS session_events (
-            id         INTEGER PRIMARY KEY,
-            session_id INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-            event      TEXT    NOT NULL,
-            trigger    TEXT    NOT NULL,
-            note       TEXT,
-            occurred_at DATETIME NOT NULL DEFAULT (datetime('now'))
-        );
-
         CREATE INDEX IF NOT EXISTS idx_sessions_host    ON sessions (host_id);
         CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions (project);
-        CREATE INDEX IF NOT EXISTS idx_session_events_session ON session_events (session_id, occurred_at);
 
         CREATE TRIGGER IF NOT EXISTS sessions_updated_at
           AFTER UPDATE ON sessions
@@ -486,10 +465,12 @@ fn migrate(conn: &Connection) -> Result<()> {
         DROP TABLE IF EXISTS session_ci;
         DROP TABLE IF EXISTS session_atm;
         DROP TABLE IF EXISTS daemon_health;
+        DROP TABLE IF EXISTS session_events;
 
         DROP INDEX IF EXISTS idx_session_ci_session;
         DROP INDEX IF EXISTS idx_session_ci_next_poll;
         DROP INDEX IF EXISTS idx_session_atm_session_name;
+        DROP INDEX IF EXISTS idx_session_events_session;
     "#,
     )?;
     ensure_hosts_last_seen_column(conn)?;

--- a/crates/scmux-daemon/src/runtime.rs
+++ b/crates/scmux-daemon/src/runtime.rs
@@ -1,6 +1,6 @@
 use crate::tmux::PaneInfo;
 use chrono::{DateTime, Utc};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone)]
 pub struct SessionRuntime {
@@ -104,6 +104,14 @@ impl RuntimeProjection {
         polled_at: &str,
     ) {
         self.discovery = live_sessions.clone();
+        let defined = defined_sessions
+            .iter()
+            .cloned()
+            .collect::<HashSet<String>>();
+        self.sessions.retain(|name, _| defined.contains(name));
+        self.pane_keys_by_session
+            .retain(|name, _| defined.contains(name));
+        self.ci_by_session.retain(|name, _| defined.contains(name));
 
         for session_name in defined_sessions {
             let live = live_sessions.get(session_name);

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -66,7 +66,6 @@ impl ApiHarness {
                     stuck_minutes: Some(10),
                     stop_grace_secs: Some(1),
                 },
-                hosts: Vec::new(),
             },
             reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
             runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),

--- a/crates/scmux-daemon/tests/ci_tests.rs
+++ b/crates/scmux-daemon/tests/ci_tests.rs
@@ -36,7 +36,6 @@ fn test_config() -> Config {
             stuck_minutes: Some(10),
             stop_grace_secs: None,
         },
-        hosts: Vec::new(),
     }
 }
 
@@ -121,11 +120,23 @@ fn insert_ci_session(
                 .to_string(),
         })
         .collect::<Vec<_>>();
-    let mut live = std::collections::HashMap::new();
-    live.insert(name.to_string(), panes);
+    let defined_names = {
+        let db_conn = state.db.lock().expect("db lock");
+        db::list_sessions_for_host(&db_conn, state.host_id)
+            .expect("list sessions")
+            .into_iter()
+            .map(|session| session.name)
+            .collect::<Vec<_>>()
+    };
     let mut runtime = state.runtime.lock().expect("runtime lock");
+    let mut live = runtime
+        .discovery_rows()
+        .into_iter()
+        .map(|row| (row.name, row.panes))
+        .collect::<std::collections::HashMap<_, _>>();
+    live.insert(name.to_string(), panes);
     runtime.apply_tmux_snapshot(
-        &[name.to_string()],
+        &defined_names,
         &live,
         &std::collections::HashMap::new(),
         &chrono::Utc::now().to_rfc3339(),

--- a/crates/scmux-daemon/tests/db_tests.rs
+++ b/crates/scmux-daemon/tests/db_tests.rs
@@ -46,7 +46,7 @@ fn td_02_open_is_idempotent_on_existing_db() {
     let _ = open(path.to_str().expect("utf8 path")).expect("first open");
     let conn = open(path.to_str().expect("utf8 path")).expect("second open");
 
-    for table in &["hosts", "sessions", "session_events"] {
+    for table in &["hosts", "sessions"] {
         let count: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",

--- a/crates/scmux-daemon/tests/e2e_tests.rs
+++ b/crates/scmux-daemon/tests/e2e_tests.rs
@@ -74,7 +74,6 @@ impl E2eHarness {
                     stuck_minutes: Some(10),
                     stop_grace_secs: None,
                 },
-                hosts: Vec::new(),
             },
             reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
             runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),

--- a/crates/scmux-daemon/tests/integration_tests.rs
+++ b/crates/scmux-daemon/tests/integration_tests.rs
@@ -35,7 +35,6 @@ fn test_config() -> Config {
             stuck_minutes: Some(10),
             stop_grace_secs: None,
         },
-        hosts: Vec::new(),
     }
 }
 

--- a/crates/scmux/src/lib.rs
+++ b/crates/scmux/src/lib.rs
@@ -52,48 +52,6 @@ pub enum Command {
         #[command(subcommand)]
         command: HostCommand,
     },
-    /// Register a new session
-    Add {
-        #[arg(long)]
-        name: String,
-        #[arg(long)]
-        project: Option<String>,
-        #[arg(long)]
-        config: String,
-        #[arg(long)]
-        cron: Option<String>,
-        #[arg(long)]
-        auto_start: bool,
-        #[arg(long)]
-        host_id: Option<i64>,
-        #[arg(long)]
-        github_repo: Option<String>,
-        #[arg(long)]
-        azure_project: Option<String>,
-    },
-    /// Edit a session
-    Edit {
-        name: String,
-        #[arg(long)]
-        project: Option<String>,
-        #[arg(long)]
-        config: Option<String>,
-        #[arg(long)]
-        cron: Option<String>,
-        /// Set auto-start behavior. Supports `--auto-start` and `--auto-start=false`.
-        #[arg(long, num_args = 0..=1, default_missing_value = "true")]
-        auto_start: Option<bool>,
-        #[arg(long)]
-        github_repo: Option<String>,
-        #[arg(long)]
-        azure_project: Option<String>,
-    },
-    /// Disable a session
-    Disable { name: String },
-    /// Enable a session
-    Enable { name: String },
-    /// Remove a session
-    Remove { name: String },
     /// List hosts
     Hosts,
     /// Daemon subcommands

--- a/crates/scmux/src/main.rs
+++ b/crates/scmux/src/main.rs
@@ -68,63 +68,6 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         Command::Host { command } => {
             handle_host_command(&client, command).await?;
         }
-        Command::Add {
-            name,
-            project,
-            config,
-            cron,
-            auto_start,
-            host_id,
-            github_repo,
-            azure_project,
-        } => {
-            handle_session_command(
-                &client,
-                SessionCommand::Add {
-                    name,
-                    project,
-                    config,
-                    cron,
-                    auto_start,
-                    host_id,
-                    github_repo,
-                    azure_project,
-                },
-            )
-            .await?;
-        }
-        Command::Edit {
-            name,
-            project,
-            config,
-            cron,
-            auto_start,
-            github_repo,
-            azure_project,
-        } => {
-            handle_session_command(
-                &client,
-                SessionCommand::Edit {
-                    name,
-                    project,
-                    config,
-                    cron,
-                    auto_start,
-                    github_repo,
-                    azure_project,
-                },
-            )
-            .await?;
-        }
-        Command::Disable { name } => {
-            handle_session_command(&client, SessionCommand::Disable { name }).await?;
-        }
-        Command::Enable { name } => {
-            handle_session_command(&client, SessionCommand::Enable { name }).await?;
-        }
-        Command::Remove { name } => {
-            handle_session_command(&client, SessionCommand::Remove { name }).await?;
-        }
         Command::Hosts => {
             let hosts = client.list_hosts().await.map_err(map_client_error)?;
             output::print_hosts(&hosts);

--- a/crates/scmux/tests/cli_tests.rs
+++ b/crates/scmux/tests/cli_tests.rs
@@ -49,38 +49,6 @@ fn td_c_02_parse_daemon_status_command() {
 }
 
 #[test]
-fn td_c_03_parse_add_command() {
-    let cli = Cli::try_parse_from([
-        "scmux",
-        "add",
-        "--name",
-        "alpha",
-        "--project",
-        "demo",
-        "--config",
-        "alpha.json",
-        "--auto-start",
-    ])
-    .expect("parse add command");
-
-    match cli.command {
-        Command::Add {
-            name,
-            project,
-            config,
-            auto_start,
-            ..
-        } => {
-            assert_eq!(name, "alpha");
-            assert_eq!(project.as_deref(), Some("demo"));
-            assert_eq!(config, "alpha.json");
-            assert!(auto_start);
-        }
-        other => panic!("expected add command, got {other:?}"),
-    }
-}
-
-#[test]
 fn td_c_04_host_resolution_uses_default_when_no_env_or_flag() {
     let _guard = env_lock().lock().expect("env lock");
     let prev = std::env::var("SCMUX_HOST").ok();
@@ -115,28 +83,6 @@ fn td_c_06_host_resolution_flag_overrides_env() {
 
     restore_env_var("SCMUX_HOST", prev);
     assert_eq!(resolved, "http://127.0.0.1:8800");
-}
-
-#[test]
-fn td_c_07_parse_edit_auto_start_false() {
-    let cli = Cli::try_parse_from(["scmux", "edit", "alpha", "--auto-start=false"])
-        .expect("parse edit auto-start false");
-
-    match cli.command {
-        Command::Edit { auto_start, .. } => assert_eq!(auto_start, Some(false)),
-        other => panic!("expected edit command, got {other:?}"),
-    }
-}
-
-#[test]
-fn td_c_08_parse_edit_auto_start_true_without_value() {
-    let cli = Cli::try_parse_from(["scmux", "edit", "alpha", "--auto-start"])
-        .expect("parse edit auto-start true");
-
-    match cli.command {
-        Command::Edit { auto_start, .. } => assert_eq!(auto_start, Some(true)),
-        other => panic!("expected edit command, got {other:?}"),
-    }
 }
 
 #[test]

--- a/crates/scmux/tests/e2e_tests.rs
+++ b/crates/scmux/tests/e2e_tests.rs
@@ -64,7 +64,6 @@ impl CliE2eHarness {
                     stuck_minutes: Some(10),
                     stop_grace_secs: None,
                 },
-                hosts: Vec::new(),
             },
             reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
             runtime: std::sync::Mutex::new(scmux_daemon::runtime::RuntimeProjection::default()),


### PR DESCRIPTION
## Summary
- wrap API error paths in structured JSON for health/sessions/session detail/stop/jump/dashboard-config handlers
- prune removed/disabled sessions from RuntimeProjection during tmux snapshot application
- remove duplicate legacy CLI write commands (top-level add/edit/disable/enable/remove)
- remove unused legacy DB/config surfaces (session_events table + session_id helper, Config.hosts/HostConfig)
- update tests to match cleanup and runtime-prune behavior

## Validation
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
