### PR TITLE
P7-S2: runtime-write carve-out and ATM shutdown send stub

### DIFF
--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -3,9 +3,7 @@ use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -153,70 +151,17 @@ pub async fn send_shutdown_messages(
     state: &AppState,
     targets: &[ShutdownTarget],
 ) -> anyhow::Result<usize> {
-    if !state.config.atm.enabled || !state.config.atm.allow_shutdown {
-        tracing::warn!("ATM send not implemented");
-        return Ok(0);
-    }
-
-    if targets.is_empty() {
-        return Ok(0);
-    }
-
-    let allowed_teams = configured_teams(state).into_iter().collect::<HashSet<_>>();
-    if allowed_teams.is_empty() {
-        tracing::warn!("ATM shutdown skipped: atm.teams allowlist is empty");
-        return Ok(0);
-    }
-
-    let unique = targets
+    let configured_targets = targets
         .iter()
-        .filter(|target| allowed_teams.contains(&target.team))
-        .map(|target| (target.team.clone(), target.agent.clone()))
-        .collect::<HashSet<_>>();
-
-    let mut sent = 0usize;
-    for (team, agent) in unique {
-        let output = tokio::process::Command::new(atm_bin())
-            .arg("send")
-            .arg(&agent)
-            .arg("--team")
-            .arg(&team)
-            .arg("scmux: graceful shutdown requested; please stop current work and exit")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .output()
-            .await;
-
-        match output {
-            Ok(result) if result.status.success() => {
-                sent += 1;
-            }
-            Ok(result) => {
-                let message = String::from_utf8_lossy(&result.stderr).trim().to_string();
-                tracing::warn!(
-                    "atm shutdown message failed team='{}' agent='{}': {}",
-                    team,
-                    agent,
-                    if message.is_empty() {
-                        format!("exit {}", result.status)
-                    } else {
-                        message
-                    }
-                );
-            }
-            Err(err) => {
-                tracing::warn!(
-                    "atm shutdown message execution failed team='{}' agent='{}': {}",
-                    team,
-                    agent,
-                    err
-                );
-            }
-        }
-    }
-
-    Ok(sent)
+        .map(|target| format!("{}@{}", target.agent, target.team))
+        .collect::<Vec<_>>();
+    tracing::warn!(
+        "ATM send not implemented: skipping graceful shutdown send; enabled={} allow_shutdown={} targets={:?}",
+        state.config.atm.enabled,
+        state.config.atm.allow_shutdown,
+        configured_targets
+    );
+    Ok(0)
 }
 
 fn resolve_socket_path(state: &AppState) -> PathBuf {
@@ -334,10 +279,6 @@ fn request_id() -> String {
         std::process::id(),
         Utc::now().timestamp_nanos_opt().unwrap_or_default()
     )
-}
-
-fn atm_bin() -> String {
-    std::env::var("SCMUX_ATM_BIN").unwrap_or_else(|_| "atm".to_string())
 }
 
 #[cfg(unix)]

--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -151,14 +151,20 @@ pub async fn send_shutdown_messages(
     state: &AppState,
     targets: &[ShutdownTarget],
 ) -> anyhow::Result<usize> {
+    if !state.config.atm.enabled || !state.config.atm.allow_shutdown {
+        return Ok(0);
+    }
+
+    if targets.is_empty() {
+        return Ok(0);
+    }
+
     let configured_targets = targets
         .iter()
         .map(|target| format!("{}@{}", target.agent, target.team))
         .collect::<Vec<_>>();
     tracing::warn!(
-        "ATM send not implemented: skipping graceful shutdown send; enabled={} allow_shutdown={} targets={:?}",
-        state.config.atm.enabled,
-        state.config.atm.allow_shutdown,
+        "ATM send not implemented: skipping graceful shutdown send; targets={:?}",
         configured_targets
     );
     Ok(0)
@@ -328,4 +334,108 @@ async fn query_socket_raw<T: DeserializeOwned>(
     _request_json: &str,
 ) -> anyhow::Result<T> {
     Err(anyhow!("ATM socket IPC is only available on Unix"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
+    use crate::{ci, db, definition_writer, runtime, AppState, RuntimeHealth, SystemClock};
+    use tempfile::TempDir;
+
+    fn build_state(atm: AtmConfig) -> (TempDir, AppState) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("atm-tests.db");
+        let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
+        let host_id = definition_writer::ensure_local_host(&conn).expect("local host");
+
+        (
+            tmp,
+            AppState {
+                db: std::sync::Mutex::new(conn),
+                db_path: db_path.to_string_lossy().to_string(),
+                host_id,
+                config: Config {
+                    daemon: DaemonConfig {
+                        port: None,
+                        db_path: None,
+                        default_terminal: Some("iterm2".to_string()),
+                        log_level: None,
+                    },
+                    polling: PollingConfig {
+                        tmux_interval_secs: Some(15),
+                        health_interval_secs: Some(60),
+                        ci_active_interval_secs: None,
+                        ci_idle_interval_secs: None,
+                    },
+                    atm,
+                },
+                reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+                runtime: std::sync::Mutex::new(runtime::RuntimeProjection::default()),
+                ci_tools: ci::ToolAvailability::default(),
+                clock: std::sync::Arc::new(SystemClock),
+                atm_available: std::sync::atomic::AtomicBool::new(false),
+                last_api_access: std::sync::atomic::AtomicU64::new(0),
+                started_at: std::time::Instant::now(),
+                health: std::sync::Mutex::new(RuntimeHealth::default()),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn td_atm_09_shutdown_send_returns_early_when_allow_shutdown_false() {
+        let (_tmp, state) = build_state(AtmConfig {
+            enabled: true,
+            teams: vec!["scmux-dev".to_string()],
+            allow_shutdown: false,
+            socket_path: None,
+            stuck_minutes: Some(10),
+            stop_grace_secs: None,
+        });
+
+        let sent = send_shutdown_messages(
+            &state,
+            &[ShutdownTarget {
+                team: "scmux-dev".to_string(),
+                agent: "team-lead".to_string(),
+            }],
+        )
+        .await
+        .expect("send");
+
+        assert_eq!(sent, 0);
+    }
+
+    #[test]
+    fn td_atm_teams_are_config_only_not_scanned_from_home() {
+        let home = tempfile::tempdir().expect("home");
+        std::fs::create_dir_all(home.path().join(".claude/teams/should-not-load"))
+            .expect("create teams dir");
+        let prev_home = std::env::var("HOME").ok();
+        // SAFETY: test-only env mutation within single test scope.
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let (_tmp, state) = build_state(AtmConfig {
+            enabled: true,
+            teams: vec!["scmux-dev".to_string()],
+            allow_shutdown: false,
+            socket_path: None,
+            stuck_minutes: Some(10),
+            stop_grace_secs: None,
+        });
+
+        let teams = configured_teams(&state);
+        assert_eq!(teams, vec!["scmux-dev".to_string()]);
+
+        match prev_home {
+            Some(value) => {
+                // SAFETY: restoring previous test-only env var value.
+                unsafe { std::env::set_var("HOME", value) };
+            }
+            None => {
+                // SAFETY: restoring previous test-only env var absence.
+                unsafe { std::env::remove_var("HOME") };
+            }
+        }
+    }
 }

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -204,6 +204,8 @@ pub fn get_host(conn: &Connection, host_id: i64) -> anyhow::Result<Option<HostDe
     Ok(row)
 }
 
+// Persistent write helpers are crate-visible for module organization, but gated by
+// `definition_writer::WriteGuard`, which cannot be constructed outside definition_writer.
 pub(crate) fn create_session(
     _guard: &crate::definition_writer::WriteGuard,
     conn: &Connection,

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -327,7 +327,7 @@ async fn t_lc_06_start_failure_returns_500_and_keeps_session_stopped() {
 }
 
 #[tokio::test]
-async fn t_lc_03_stop_sends_atm_then_grace_then_hard_stop() {
+async fn t_lc_03_stop_grace_then_hard_stop_when_atm_send_is_stubbed() {
     let h = ApiHarness::new().await;
     h.create_session("alpha").await;
 
@@ -348,17 +348,7 @@ fi
 exit 1
 "#,
     ));
-    let atm_script = write_script(&format!(
-        r#"#!/bin/sh
-if [ "$1" = "send" ]; then
-  echo "send" >> "{marker_path}"
-  exit 0
-fi
-exit 1
-"#
-    ));
     let prev_tmux = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
-    let prev_atm = set_env_var("SCMUX_ATM_BIN", atm_script.to_string_lossy().as_ref());
     let started = Instant::now();
 
     let response = h
@@ -368,7 +358,6 @@ exit 1
         .await
         .expect("stop request");
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
-    restore_env_var("SCMUX_ATM_BIN", prev_atm);
 
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Value = response.json().await.expect("json");
@@ -384,8 +373,8 @@ exit 1
 
     let marker_log = std::fs::read_to_string(marker.path()).expect("read marker");
     assert!(
-        marker_log.contains("send\nkill\n"),
-        "expected ATM send before tmux hard-stop, got: {marker_log:?}"
+        marker_log.contains("kill\n"),
+        "expected tmux hard-stop after grace timeout, got: {marker_log:?}"
     );
 }
 

--- a/docs/sprint-specs/p7-s2-runtime-write-carveout.md
+++ b/docs/sprint-specs/p7-s2-runtime-write-carveout.md
@@ -1,0 +1,35 @@
+# Sprint P7-S2 — Runtime-Write Carve-Out and Safety Gate
+
+## Scope
+
+Enforce definition-first persistence boundaries and remove remaining unsafe runtime-write behavior.
+
+## Deliverables
+
+- Remove all persistent writes outside the writer gate.
+- Keep runtime pollers projection-only (no definition persistence from runtime observations).
+- Ensure API/runtime control paths do not bypass `definition_writer`.
+- Stub unsupported ATM shutdown-send behavior with explicit, non-silent behavior when enabled.
+- Preserve scoped stop semantics and avoid cross-session side effects.
+- Validate carve-out against `docs/refactor-scope-v0.5.md` conflict inventory.
+
+## Requirement IDs
+
+- `INV-01`
+- `INV-02`
+- `INV-03`
+- `INV-04`
+- `INV-05`
+- `ED-03`
+- `RT-05`
+- `RT-06`
+
+## Acceptance Criteria
+
+1. Code search confirms no persistent-definition writes outside writer-gate pathways.
+2. Poller/runtime modules remain SQLite-read-only for definitions.
+3. `atm::send_shutdown_messages` returns early when `allow_shutdown = false`.
+4. Tests cover:
+- ATM shutdown gate behavior (`allow_shutdown` false).
+- ATM team source remains config-driven (no `~/.claude/teams` scan behavior).
+5. Existing runtime flows and test suite remain green after carve-out changes.


### PR DESCRIPTION
## Summary
- stub ATM graceful shutdown send path with explicit warning log (`ATM send not implemented`)
- keep stop flow scoped and unchanged for grace + hard-stop fallback
- retain and clarify write-gate boundary on DB write helpers via `definition_writer::WriteGuard`
- update API lifecycle test to validate stubbed ATM behavior

## Validation
- `cargo test --workspace`
