### PR TITLE
P7-S3: definition schema + editor backend APIs

### DIFF
--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -3,9 +3,10 @@ use axum::{
     http::{header, StatusCode},
     middleware::{from_fn_with_state, Next},
     response::{IntoResponse, Json, Response},
-    routing::{get, post},
+    routing::{delete, get, post},
     Router,
 };
+use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -40,6 +41,20 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/sessions/:name/start", post(start_session))
         .route("/sessions/:name/stop", post(stop_session))
         .route("/sessions/:name/jump", post(jump_session))
+        .route("/editor/armadas", post(create_armada))
+        .route("/editor/armadas/:id", axum::routing::patch(patch_armada))
+        .route("/editor/fleets", post(create_fleet))
+        .route("/editor/fleets/:id", axum::routing::patch(patch_fleet))
+        .route("/editor/flotillas", post(create_flotilla))
+        .route(
+            "/editor/flotillas/:id",
+            axum::routing::patch(patch_flotilla),
+        )
+        .route("/editor/crews", post(create_crew_bundle))
+        .route("/editor/crews/:id", axum::routing::patch(patch_crew_bundle))
+        .route("/editor/crews/:id/clone", post(clone_crew_bundle))
+        .route("/editor/crew-refs/:id/move", post(move_crew_ref))
+        .route("/editor/crew-refs/:id", delete(unlink_crew_ref))
         .layer(CorsLayer::permissive())
         .layer(from_fn_with_state(middleware_state, touch_last_api_access))
         .with_state(state)
@@ -176,6 +191,101 @@ struct PatchHostRequest {
     address: Option<String>,
     ssh_user: Option<Option<String>>,
     api_port: Option<u16>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateArmadaRequest {
+    name: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchArmadaRequest {
+    name: Option<String>,
+    description: Option<Option<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateFleetRequest {
+    armada_id: i64,
+    name: String,
+    color: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchFleetRequest {
+    armada_id: Option<i64>,
+    name: Option<String>,
+    color: Option<Option<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateFlotillaRequest {
+    fleet_id: i64,
+    name: String,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchFlotillaRequest {
+    fleet_id: Option<i64>,
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CrewMemberPayload {
+    member_id: String,
+    role: String,
+    ai_provider: String,
+    model: String,
+    startup_prompts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CrewVariantPayload {
+    host_id: i64,
+    repo_url: Option<String>,
+    branch_ref: Option<String>,
+    root_path: String,
+    config_json: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CrewPlacementPayload {
+    armada_id: i64,
+    fleet_id: i64,
+    flotilla_id: Option<i64>,
+    alias_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateCrewBundleRequest {
+    crew_name: String,
+    crew_ulid: String,
+    members: Vec<CrewMemberPayload>,
+    variants: Vec<CrewVariantPayload>,
+    placement: CrewPlacementPayload,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchCrewBundleRequest {
+    crew_ulid: Option<String>,
+    members: Option<Vec<CrewMemberPayload>>,
+    variants: Option<Vec<CrewVariantPayload>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CloneCrewBundleRequest {
+    crew_name: String,
+    crew_ulid: String,
+    placement: CrewPlacementPayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct MoveCrewRefRequest {
+    armada_id: i64,
+    fleet_id: i64,
+    flotilla_id: Option<i64>,
+    alias_name: Option<Option<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -850,6 +960,381 @@ async fn delete_host(
     }
 }
 
+async fn create_armada(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateArmadaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let armada = definition_writer::NewArmada {
+        name: req.name.clone(),
+        description: req.description,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_armada(&db_conn, &armada)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_armada task".to_string()))?;
+
+    match result {
+        Ok(id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("armada '{id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_armada(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchArmadaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::ArmadaPatch {
+        name: req.name,
+        description: req.description,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_armada(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_armada task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("armada '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("armada '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn create_fleet(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateFleetRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let fleet = definition_writer::NewFleet {
+        armada_id: req.armada_id,
+        name: req.name.clone(),
+        color: req.color,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_fleet(&db_conn, &fleet)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_fleet task".to_string()))?;
+
+    match result {
+        Ok(id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("fleet '{id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_fleet(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchFleetRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::FleetPatch {
+        armada_id: req.armada_id,
+        name: req.name,
+        color: req.color,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_fleet(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_fleet task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("fleet '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("fleet '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn create_flotilla(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateFlotillaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let flotilla = definition_writer::NewFlotilla {
+        fleet_id: req.fleet_id,
+        name: req.name.clone(),
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_flotilla(&db_conn, &flotilla)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_flotilla task".to_string()))?;
+
+    match result {
+        Ok(id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("flotilla '{id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_flotilla(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchFlotillaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::FlotillaPatch {
+        fleet_id: req.fleet_id,
+        name: req.name,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_flotilla(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_flotilla task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("flotilla '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("flotilla '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn create_crew_bundle(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateCrewBundleRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let members = req
+        .members
+        .iter()
+        .map(map_member_payload)
+        .collect::<Result<Vec<_>, _>>()?;
+    let variants = req
+        .variants
+        .iter()
+        .map(map_variant_payload)
+        .collect::<Result<Vec<_>, _>>()?;
+    let placement = map_placement_payload(&req.placement);
+
+    let bundle = definition_writer::NewCrewBundle {
+        crew_name: req.crew_name,
+        crew_ulid: req.crew_ulid,
+        members,
+        variants,
+        placement,
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_crew_bundle(&db_conn, &bundle)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_crew_bundle task".to_string()))?;
+
+    match result {
+        Ok(crew_id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew '{crew_id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_crew_bundle(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchCrewBundleRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let editing_roster = req.members.is_some() || req.variants.is_some();
+    if editing_roster {
+        if let Some(crew_name) = fetch_crew_name(Arc::clone(&state), id).await? {
+            let live = tmux::live_sessions().await.unwrap_or_default();
+            if live.contains_key(&crew_name) {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        ok: false,
+                        code: "running_edit_forbidden".to_string(),
+                        message: "running crew roster/prompt edits are not allowed".to_string(),
+                    }),
+                ));
+            }
+        }
+    }
+
+    let members = req
+        .members
+        .as_ref()
+        .map(|items| {
+            items
+                .iter()
+                .map(map_member_payload)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+    let variants = req
+        .variants
+        .as_ref()
+        .map(|items| {
+            items
+                .iter()
+                .map(map_variant_payload)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+
+    let patch = definition_writer::CrewBundlePatch {
+        crew_ulid: req.crew_ulid,
+        members,
+        variants,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_crew_bundle(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_crew_bundle task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("crew '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn clone_crew_bundle(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<CloneCrewBundleRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let request = definition_writer::CloneCrewRequest {
+        crew_name: req.crew_name,
+        crew_ulid: req.crew_ulid,
+        placement: map_placement_payload(&req.placement),
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::clone_crew(&db_conn, id, &request)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join clone_crew_bundle task".to_string()))?;
+
+    match result {
+        Ok(new_id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew cloned to '{new_id}'"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn move_crew_ref(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<MoveCrewRefRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::MoveCrewRefPatch {
+        armada_id: req.armada_id,
+        fleet_id: req.fleet_id,
+        flotilla_id: req.flotilla_id,
+        alias_name: req.alias_name,
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::move_crew_ref(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join move_crew_ref task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew ref '{id}' moved"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("crew ref '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn unlink_crew_ref(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::unlink_crew_ref(&db_conn, id)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join unlink_crew_ref task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew ref '{id}' unlinked"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("crew ref '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
 async fn get_dashboard_config(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<DashboardConfigResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -984,6 +1469,77 @@ fn extract_shutdown_targets(config_json: &str) -> Vec<ShutdownTarget> {
             })
         })
         .collect::<Vec<_>>()
+}
+
+fn map_member_payload(
+    payload: &CrewMemberPayload,
+) -> Result<definition_writer::CrewMemberInput, (StatusCode, Json<ErrorResponse>)> {
+    let startup_prompts_json = serde_json::to_string(&payload.startup_prompts).map_err(|_| {
+        bad_request(
+            "invalid_startup_prompts",
+            "startup_prompts could not be serialized".to_string(),
+        )
+    })?;
+
+    Ok(definition_writer::CrewMemberInput {
+        member_id: payload.member_id.clone(),
+        role: payload.role.clone(),
+        ai_provider: payload.ai_provider.clone(),
+        model: payload.model.clone(),
+        startup_prompts_json,
+    })
+}
+
+fn map_variant_payload(
+    payload: &CrewVariantPayload,
+) -> Result<definition_writer::CrewVariantInput, (StatusCode, Json<ErrorResponse>)> {
+    let config_json = payload
+        .config_json
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|_| {
+            bad_request(
+                "invalid_variant_config",
+                "invalid variant config_json".to_string(),
+            )
+        })?;
+
+    Ok(definition_writer::CrewVariantInput {
+        host_id: payload.host_id,
+        repo_url: payload.repo_url.clone(),
+        branch_ref: payload.branch_ref.clone(),
+        root_path: payload.root_path.clone(),
+        config_json,
+    })
+}
+
+fn map_placement_payload(payload: &CrewPlacementPayload) -> definition_writer::CrewPlacementInput {
+    definition_writer::CrewPlacementInput {
+        armada_id: payload.armada_id,
+        fleet_id: payload.fleet_id,
+        flotilla_id: payload.flotilla_id,
+        alias_name: payload.alias_name.clone(),
+    }
+}
+
+async fn fetch_crew_name(
+    state: Arc<AppState>,
+    crew_id: i64,
+) -> Result<Option<String>, (StatusCode, Json<ErrorResponse>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT crew_name FROM crews WHERE id = ?1",
+                rusqlite::params![crew_id],
+                |r| r.get::<_, String>(0),
+            )
+            .optional()
+    })
+    .await
+    .map_err(|_| internal_error("failed to join fetch_crew_name task".to_string()))?;
+    result.map_err(|_| internal_error("failed to read crew name".to_string()))
 }
 
 fn map_write_error(err: definition_writer::WriteError) -> (StatusCode, Json<ErrorResponse>) {

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -41,6 +41,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/sessions/:name/start", post(start_session))
         .route("/sessions/:name/stop", post(stop_session))
         .route("/sessions/:name/jump", post(jump_session))
+        .route("/editor/state", get(get_editor_state))
         .route("/editor/armadas", post(create_armada))
         .route("/editor/armadas/:id", axum::routing::patch(patch_armada))
         .route("/editor/fleets", post(create_fleet))
@@ -286,6 +287,56 @@ struct MoveCrewRefRequest {
     fleet_id: i64,
     flotilla_id: Option<i64>,
     alias_name: Option<Option<String>>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorStateResponse {
+    armadas: Vec<EditorArmada>,
+    fleets: Vec<EditorFleet>,
+    flotillas: Vec<EditorFlotilla>,
+    crews: Vec<EditorCrew>,
+    crew_refs: Vec<EditorCrewRef>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorArmada {
+    id: i64,
+    name: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorFleet {
+    id: i64,
+    armada_id: i64,
+    name: String,
+    color: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorFlotilla {
+    id: i64,
+    fleet_id: i64,
+    name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorCrew {
+    id: i64,
+    crew_name: String,
+    crew_ulid: String,
+    member_count: i64,
+    variant_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorCrewRef {
+    id: i64,
+    crew_id: i64,
+    armada_id: i64,
+    fleet_id: i64,
+    flotilla_id: Option<i64>,
+    alias_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1332,6 +1383,109 @@ async fn unlink_crew_ref(
             }),
         )),
         Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn get_editor_state(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<EditorStateResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let result = tokio::task::spawn_blocking(move || -> anyhow::Result<EditorStateResponse> {
+        let db_conn = state.db.lock().expect("db lock");
+
+        let armadas = {
+            let mut stmt =
+                db_conn.prepare("SELECT id, name, description FROM armadas ORDER BY name")?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorArmada {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    description: r.get(2)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let fleets = {
+            let mut stmt =
+                db_conn.prepare("SELECT id, armada_id, name, color FROM fleets ORDER BY name")?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorFleet {
+                    id: r.get(0)?,
+                    armada_id: r.get(1)?,
+                    name: r.get(2)?,
+                    color: r.get(3)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let flotillas = {
+            let mut stmt = db_conn.prepare("SELECT id, fleet_id, name FROM flotillas ORDER BY name")?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorFlotilla {
+                    id: r.get(0)?,
+                    fleet_id: r.get(1)?,
+                    name: r.get(2)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let crews = {
+            let mut stmt = db_conn.prepare(
+                "SELECT c.id, c.crew_name, c.crew_ulid,
+                        (SELECT COUNT(*) FROM crew_members cm WHERE cm.crew_id = c.id) AS member_count,
+                        (SELECT COUNT(*) FROM crew_variants cv WHERE cv.crew_id = c.id) AS variant_count
+                 FROM crews c
+                 ORDER BY c.crew_name",
+            )?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorCrew {
+                    id: r.get(0)?,
+                    crew_name: r.get(1)?,
+                    crew_ulid: r.get(2)?,
+                    member_count: r.get(3)?,
+                    variant_count: r.get(4)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let crew_refs = {
+            let mut stmt = db_conn.prepare(
+                "SELECT id, crew_id, armada_id, fleet_id, flotilla_id, alias_name
+                 FROM crew_refs
+                 ORDER BY armada_id, fleet_id, id",
+            )?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorCrewRef {
+                    id: r.get(0)?,
+                    crew_id: r.get(1)?,
+                    armada_id: r.get(2)?,
+                    fleet_id: r.get(3)?,
+                    flotilla_id: r.get(4)?,
+                    alias_name: r.get(5)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        Ok(EditorStateResponse {
+            armadas,
+            fleets,
+            flotillas,
+            crews,
+            crew_refs,
+        })
+    })
+    .await
+    .map_err(|_| internal_error("failed to join get_editor_state task".to_string()))?;
+
+    match result {
+        Ok(body) => Ok(Json(body)),
+        Err(err) => Err(internal_error(format!(
+            "failed to load editor state: {err}"
+        ))),
     }
 }
 

--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -3,9 +3,7 @@ use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -153,70 +151,17 @@ pub async fn send_shutdown_messages(
     state: &AppState,
     targets: &[ShutdownTarget],
 ) -> anyhow::Result<usize> {
-    if !state.config.atm.enabled || !state.config.atm.allow_shutdown {
-        tracing::warn!("ATM send not implemented");
-        return Ok(0);
-    }
-
-    if targets.is_empty() {
-        return Ok(0);
-    }
-
-    let allowed_teams = configured_teams(state).into_iter().collect::<HashSet<_>>();
-    if allowed_teams.is_empty() {
-        tracing::warn!("ATM shutdown skipped: atm.teams allowlist is empty");
-        return Ok(0);
-    }
-
-    let unique = targets
+    let configured_targets = targets
         .iter()
-        .filter(|target| allowed_teams.contains(&target.team))
-        .map(|target| (target.team.clone(), target.agent.clone()))
-        .collect::<HashSet<_>>();
-
-    let mut sent = 0usize;
-    for (team, agent) in unique {
-        let output = tokio::process::Command::new(atm_bin())
-            .arg("send")
-            .arg(&agent)
-            .arg("--team")
-            .arg(&team)
-            .arg("scmux: graceful shutdown requested; please stop current work and exit")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .output()
-            .await;
-
-        match output {
-            Ok(result) if result.status.success() => {
-                sent += 1;
-            }
-            Ok(result) => {
-                let message = String::from_utf8_lossy(&result.stderr).trim().to_string();
-                tracing::warn!(
-                    "atm shutdown message failed team='{}' agent='{}': {}",
-                    team,
-                    agent,
-                    if message.is_empty() {
-                        format!("exit {}", result.status)
-                    } else {
-                        message
-                    }
-                );
-            }
-            Err(err) => {
-                tracing::warn!(
-                    "atm shutdown message execution failed team='{}' agent='{}': {}",
-                    team,
-                    agent,
-                    err
-                );
-            }
-        }
-    }
-
-    Ok(sent)
+        .map(|target| format!("{}@{}", target.agent, target.team))
+        .collect::<Vec<_>>();
+    tracing::warn!(
+        "ATM send not implemented: skipping graceful shutdown send; enabled={} allow_shutdown={} targets={:?}",
+        state.config.atm.enabled,
+        state.config.atm.allow_shutdown,
+        configured_targets
+    );
+    Ok(0)
 }
 
 fn resolve_socket_path(state: &AppState) -> PathBuf {
@@ -334,10 +279,6 @@ fn request_id() -> String {
         std::process::id(),
         Utc::now().timestamp_nanos_opt().unwrap_or_default()
     )
-}
-
-fn atm_bin() -> String {
-    std::env::var("SCMUX_ATM_BIN").unwrap_or_else(|_| "atm".to_string())
 }
 
 #[cfg(unix)]

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -204,6 +204,8 @@ pub fn get_host(conn: &Connection, host_id: i64) -> anyhow::Result<Option<HostDe
     Ok(row)
 }
 
+// Persistent write helpers are crate-visible for module organization, but gated by
+// `definition_writer::WriteGuard`, which cannot be constructed outside definition_writer.
 pub(crate) fn create_session(
     _guard: &crate::definition_writer::WriteGuard,
     conn: &Connection,

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -463,6 +463,80 @@ fn migrate(conn: &Connection) -> Result<()> {
             UPDATE sessions SET updated_at = datetime('now') WHERE id = OLD.id;
           END;
 
+        CREATE TABLE IF NOT EXISTS armadas (
+            id          INTEGER PRIMARY KEY,
+            name        TEXT NOT NULL UNIQUE,
+            description TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS fleets (
+            id          INTEGER PRIMARY KEY,
+            armada_id   INTEGER NOT NULL REFERENCES armadas(id) ON DELETE CASCADE,
+            name        TEXT NOT NULL,
+            color       TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (armada_id, name)
+        );
+
+        CREATE TABLE IF NOT EXISTS flotillas (
+            id          INTEGER PRIMARY KEY,
+            fleet_id    INTEGER NOT NULL REFERENCES fleets(id) ON DELETE CASCADE,
+            name        TEXT NOT NULL,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (fleet_id, name)
+        );
+
+        CREATE TABLE IF NOT EXISTS crews (
+            id          INTEGER PRIMARY KEY,
+            crew_name   TEXT NOT NULL UNIQUE,
+            crew_ulid   TEXT NOT NULL UNIQUE,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS crew_members (
+            id                   INTEGER PRIMARY KEY,
+            crew_id              INTEGER NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
+            member_id            TEXT NOT NULL,
+            role                 TEXT NOT NULL,
+            ai_provider          TEXT NOT NULL,
+            model                TEXT NOT NULL,
+            startup_prompts_json TEXT NOT NULL,
+            created_at           DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (crew_id, member_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS crew_variants (
+            id          INTEGER PRIMARY KEY,
+            crew_id     INTEGER NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
+            host_id     INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+            repo_url    TEXT,
+            branch_ref  TEXT,
+            root_path   TEXT NOT NULL,
+            config_json TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (crew_id, host_id, repo_url, branch_ref, root_path)
+        );
+
+        CREATE TABLE IF NOT EXISTS crew_refs (
+            id          INTEGER PRIMARY KEY,
+            crew_id     INTEGER NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
+            armada_id   INTEGER NOT NULL REFERENCES armadas(id) ON DELETE CASCADE,
+            fleet_id    INTEGER NOT NULL REFERENCES fleets(id) ON DELETE CASCADE,
+            flotilla_id INTEGER REFERENCES flotillas(id) ON DELETE SET NULL,
+            alias_name  TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_fleets_armada         ON fleets (armada_id);
+        CREATE INDEX IF NOT EXISTS idx_flotillas_fleet       ON flotillas (fleet_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_members_crew     ON crew_members (crew_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_variants_crew    ON crew_variants (crew_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_crew        ON crew_refs (crew_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_armada      ON crew_refs (armada_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_fleet       ON crew_refs (fleet_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_flotilla    ON crew_refs (flotilla_id);
+
         DROP TABLE IF EXISTS session_status;
         DROP TABLE IF EXISTS session_ci;
         DROP TABLE IF EXISTS session_atm;

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -1,5 +1,5 @@
 use crate::db;
-use rusqlite::Connection;
+use rusqlite::{params, types::Value as SqlValue, Connection, OptionalExtension};
 
 pub struct WriteGuard(());
 
@@ -22,6 +22,101 @@ impl WriteError {
             | Self::Internal(msg) => msg.clone(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewArmada {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ArmadaPatch {
+    pub name: Option<String>,
+    pub description: Option<Option<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewFleet {
+    pub armada_id: i64,
+    pub name: String,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FleetPatch {
+    pub armada_id: Option<i64>,
+    pub name: Option<String>,
+    pub color: Option<Option<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewFlotilla {
+    pub fleet_id: i64,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FlotillaPatch {
+    pub fleet_id: Option<i64>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrewMemberInput {
+    pub member_id: String,
+    pub role: String,
+    pub ai_provider: String,
+    pub model: String,
+    pub startup_prompts_json: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrewVariantInput {
+    pub host_id: i64,
+    pub repo_url: Option<String>,
+    pub branch_ref: Option<String>,
+    pub root_path: String,
+    pub config_json: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrewPlacementInput {
+    pub armada_id: i64,
+    pub fleet_id: i64,
+    pub flotilla_id: Option<i64>,
+    pub alias_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewCrewBundle {
+    pub crew_name: String,
+    pub crew_ulid: String,
+    pub members: Vec<CrewMemberInput>,
+    pub variants: Vec<CrewVariantInput>,
+    pub placement: CrewPlacementInput,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CrewBundlePatch {
+    pub crew_ulid: Option<String>,
+    pub members: Option<Vec<CrewMemberInput>>,
+    pub variants: Option<Vec<CrewVariantInput>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloneCrewRequest {
+    pub crew_name: String,
+    pub crew_ulid: String,
+    pub placement: CrewPlacementInput,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MoveCrewRefPatch {
+    pub armada_id: i64,
+    pub fleet_id: i64,
+    pub flotilla_id: Option<i64>,
+    pub alias_name: Option<Option<String>>,
 }
 
 pub fn create_session(conn: &Connection, new_session: &db::NewSession) -> Result<i64, WriteError> {
@@ -85,6 +180,563 @@ pub fn ensure_local_host(conn: &Connection) -> Result<i64, WriteError> {
     db::ensure_local_host(conn).map_err(|err| WriteError::Internal(err.to_string()))
 }
 
+pub fn create_armada(conn: &Connection, armada: &NewArmada) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
+        params![armada.name, armada.description],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn patch_armada(
+    conn: &Connection,
+    armada_id: i64,
+    patch: &ArmadaPatch,
+) -> Result<bool, WriteError> {
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM armadas WHERE id = ?1",
+            params![armada_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    let mut set_parts: Vec<&str> = Vec::new();
+    let mut values: Vec<SqlValue> = Vec::new();
+    if let Some(name) = &patch.name {
+        set_parts.push("name = ?");
+        values.push(SqlValue::Text(name.clone()));
+    }
+    if let Some(description) = &patch.description {
+        set_parts.push("description = ?");
+        values.push(match description {
+            Some(value) => SqlValue::Text(value.clone()),
+            None => SqlValue::Null,
+        });
+    }
+    if set_parts.is_empty() {
+        return Ok(true);
+    }
+
+    let mut sql = String::from("UPDATE armadas SET ");
+    for (idx, part) in set_parts.iter().enumerate() {
+        if idx > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(part);
+    }
+    sql.push_str(" WHERE id = ?");
+    values.push(SqlValue::Integer(armada_id));
+
+    conn.execute(&sql, rusqlite::params_from_iter(values))
+        .map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn create_fleet(conn: &Connection, fleet: &NewFleet) -> Result<i64, WriteError> {
+    ensure_armada_exists(conn, fleet.armada_id)?;
+    conn.execute(
+        "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
+        params![fleet.armada_id, fleet.name, fleet.color],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn patch_fleet(
+    conn: &Connection,
+    fleet_id: i64,
+    patch: &FleetPatch,
+) -> Result<bool, WriteError> {
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM fleets WHERE id = ?1",
+            params![fleet_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    if let Some(armada_id) = patch.armada_id {
+        ensure_armada_exists(conn, armada_id)?;
+    }
+
+    let mut set_parts: Vec<&str> = Vec::new();
+    let mut values: Vec<SqlValue> = Vec::new();
+    if let Some(armada_id) = patch.armada_id {
+        set_parts.push("armada_id = ?");
+        values.push(SqlValue::Integer(armada_id));
+    }
+    if let Some(name) = &patch.name {
+        set_parts.push("name = ?");
+        values.push(SqlValue::Text(name.clone()));
+    }
+    if let Some(color) = &patch.color {
+        set_parts.push("color = ?");
+        values.push(match color {
+            Some(value) => SqlValue::Text(value.clone()),
+            None => SqlValue::Null,
+        });
+    }
+    if set_parts.is_empty() {
+        return Ok(true);
+    }
+
+    let mut sql = String::from("UPDATE fleets SET ");
+    for (idx, part) in set_parts.iter().enumerate() {
+        if idx > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(part);
+    }
+    sql.push_str(" WHERE id = ?");
+    values.push(SqlValue::Integer(fleet_id));
+
+    conn.execute(&sql, rusqlite::params_from_iter(values))
+        .map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn create_flotilla(conn: &Connection, flotilla: &NewFlotilla) -> Result<i64, WriteError> {
+    ensure_fleet_exists(conn, flotilla.fleet_id)?;
+    conn.execute(
+        "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
+        params![flotilla.fleet_id, flotilla.name],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn patch_flotilla(
+    conn: &Connection,
+    flotilla_id: i64,
+    patch: &FlotillaPatch,
+) -> Result<bool, WriteError> {
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM flotillas WHERE id = ?1",
+            params![flotilla_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    if let Some(fleet_id) = patch.fleet_id {
+        ensure_fleet_exists(conn, fleet_id)?;
+    }
+
+    let mut set_parts: Vec<&str> = Vec::new();
+    let mut values: Vec<SqlValue> = Vec::new();
+    if let Some(fleet_id) = patch.fleet_id {
+        set_parts.push("fleet_id = ?");
+        values.push(SqlValue::Integer(fleet_id));
+    }
+    if let Some(name) = &patch.name {
+        set_parts.push("name = ?");
+        values.push(SqlValue::Text(name.clone()));
+    }
+    if set_parts.is_empty() {
+        return Ok(true);
+    }
+
+    let mut sql = String::from("UPDATE flotillas SET ");
+    for (idx, part) in set_parts.iter().enumerate() {
+        if idx > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(part);
+    }
+    sql.push_str(" WHERE id = ?");
+    values.push(SqlValue::Integer(flotilla_id));
+
+    conn.execute(&sql, rusqlite::params_from_iter(values))
+        .map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn create_crew_bundle(conn: &Connection, bundle: &NewCrewBundle) -> Result<i64, WriteError> {
+    validate_captain_count(&bundle.members)?;
+
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    validate_placement(&tx, &bundle.placement)?;
+
+    tx.execute(
+        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
+        params![bundle.crew_name, bundle.crew_ulid],
+    )
+    .map_err(map_write_error)?;
+    let crew_id = tx.last_insert_rowid();
+
+    insert_members(&tx, crew_id, &bundle.members)?;
+    insert_variants(&tx, crew_id, &bundle.variants)?;
+
+    tx.execute(
+        "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            crew_id,
+            bundle.placement.armada_id,
+            bundle.placement.fleet_id,
+            bundle.placement.flotilla_id,
+            bundle.placement.alias_name
+        ],
+    )
+    .map_err(map_write_error)?;
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(crew_id)
+}
+
+pub fn patch_crew_bundle(
+    conn: &Connection,
+    crew_id: i64,
+    patch: &CrewBundlePatch,
+) -> Result<bool, WriteError> {
+    if let Some(members) = patch.members.as_ref() {
+        validate_captain_count(members)?;
+    }
+
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let exists: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM crews WHERE id = ?1",
+            params![crew_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    if let Some(crew_ulid) = patch.crew_ulid.as_ref() {
+        tx.execute(
+            "UPDATE crews SET crew_ulid = ?1 WHERE id = ?2",
+            params![crew_ulid, crew_id],
+        )
+        .map_err(map_write_error)?;
+    }
+
+    if let Some(members) = patch.members.as_ref() {
+        tx.execute(
+            "DELETE FROM crew_members WHERE crew_id = ?1",
+            params![crew_id],
+        )
+        .map_err(map_write_error)?;
+        insert_members(&tx, crew_id, members)?;
+    }
+
+    if let Some(variants) = patch.variants.as_ref() {
+        tx.execute(
+            "DELETE FROM crew_variants WHERE crew_id = ?1",
+            params![crew_id],
+        )
+        .map_err(map_write_error)?;
+        insert_variants(&tx, crew_id, variants)?;
+    }
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn clone_crew(
+    conn: &Connection,
+    source_crew_id: i64,
+    request: &CloneCrewRequest,
+) -> Result<i64, WriteError> {
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+
+    let source_exists: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM crews WHERE id = ?1",
+            params![source_crew_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if source_exists.is_none() {
+        return Err(WriteError::NotFound);
+    }
+
+    validate_placement(&tx, &request.placement)?;
+
+    tx.execute(
+        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
+        params![request.crew_name, request.crew_ulid],
+    )
+    .map_err(map_write_error)?;
+    let new_crew_id = tx.last_insert_rowid();
+
+    tx.execute(
+        "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
+         SELECT ?1, member_id, role, ai_provider, model, startup_prompts_json
+         FROM crew_members WHERE crew_id = ?2",
+        params![new_crew_id, source_crew_id],
+    )
+    .map_err(map_write_error)?;
+
+    tx.execute(
+        "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
+         SELECT ?1, host_id, repo_url, branch_ref, root_path, config_json
+         FROM crew_variants WHERE crew_id = ?2",
+        params![new_crew_id, source_crew_id],
+    )
+    .map_err(map_write_error)?;
+
+    tx.execute(
+        "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            new_crew_id,
+            request.placement.armada_id,
+            request.placement.fleet_id,
+            request.placement.flotilla_id,
+            request.placement.alias_name
+        ],
+    )
+    .map_err(map_write_error)?;
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(new_crew_id)
+}
+
+pub fn move_crew_ref(
+    conn: &Connection,
+    ref_id: i64,
+    patch: &MoveCrewRefPatch,
+) -> Result<bool, WriteError> {
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let exists: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM crew_refs WHERE id = ?1",
+            params![ref_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    let placement = CrewPlacementInput {
+        armada_id: patch.armada_id,
+        fleet_id: patch.fleet_id,
+        flotilla_id: patch.flotilla_id,
+        alias_name: None,
+    };
+    validate_placement(&tx, &placement)?;
+
+    if let Some(alias_name) = patch.alias_name.as_ref() {
+        tx.execute(
+            "UPDATE crew_refs
+             SET armada_id = ?1, fleet_id = ?2, flotilla_id = ?3, alias_name = ?4
+             WHERE id = ?5",
+            params![
+                patch.armada_id,
+                patch.fleet_id,
+                patch.flotilla_id,
+                alias_name,
+                ref_id
+            ],
+        )
+        .map_err(map_write_error)?;
+    } else {
+        tx.execute(
+            "UPDATE crew_refs
+             SET armada_id = ?1, fleet_id = ?2, flotilla_id = ?3
+             WHERE id = ?4",
+            params![patch.armada_id, patch.fleet_id, patch.flotilla_id, ref_id],
+        )
+        .map_err(map_write_error)?;
+    }
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn unlink_crew_ref(conn: &Connection, ref_id: i64) -> Result<bool, WriteError> {
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let crew_id: Option<i64> = tx
+        .query_row(
+            "SELECT crew_id FROM crew_refs WHERE id = ?1",
+            params![ref_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    let Some(crew_id) = crew_id else {
+        return Ok(false);
+    };
+
+    tx.execute("DELETE FROM crew_refs WHERE id = ?1", params![ref_id])
+        .map_err(map_write_error)?;
+
+    let remaining_refs: i64 = tx
+        .query_row(
+            "SELECT COUNT(*) FROM crew_refs WHERE crew_id = ?1",
+            params![crew_id],
+            |r| r.get(0),
+        )
+        .map_err(map_write_error)?;
+
+    if remaining_refs == 0 {
+        tx.execute("DELETE FROM crews WHERE id = ?1", params![crew_id])
+            .map_err(map_write_error)?;
+    }
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(true)
+}
+
+fn insert_members(
+    tx: &rusqlite::Transaction<'_>,
+    crew_id: i64,
+    members: &[CrewMemberInput],
+) -> Result<(), WriteError> {
+    for member in members {
+        tx.execute(
+            "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                crew_id,
+                member.member_id,
+                member.role,
+                member.ai_provider,
+                member.model,
+                member.startup_prompts_json
+            ],
+        )
+        .map_err(map_write_error)?;
+    }
+    Ok(())
+}
+
+fn insert_variants(
+    tx: &rusqlite::Transaction<'_>,
+    crew_id: i64,
+    variants: &[CrewVariantInput],
+) -> Result<(), WriteError> {
+    for variant in variants {
+        tx.execute(
+            "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                crew_id,
+                variant.host_id,
+                variant.repo_url,
+                variant.branch_ref,
+                variant.root_path,
+                variant.config_json
+            ],
+        )
+        .map_err(map_write_error)?;
+    }
+    Ok(())
+}
+
+fn validate_placement(
+    tx: &rusqlite::Transaction<'_>,
+    placement: &CrewPlacementInput,
+) -> Result<(), WriteError> {
+    let fleet_armada: Option<i64> = tx
+        .query_row(
+            "SELECT armada_id FROM fleets WHERE id = ?1",
+            params![placement.fleet_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+
+    let Some(fleet_armada) = fleet_armada else {
+        return Err(WriteError::Validation(
+            "fleet_id does not exist".to_string(),
+        ));
+    };
+
+    if fleet_armada != placement.armada_id {
+        return Err(WriteError::Validation(
+            "fleet_id must belong to armada_id".to_string(),
+        ));
+    }
+
+    if let Some(flotilla_id) = placement.flotilla_id {
+        let flotilla_fleet: Option<i64> = tx
+            .query_row(
+                "SELECT fleet_id FROM flotillas WHERE id = ?1",
+                params![flotilla_id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(map_write_error)?;
+
+        let Some(flotilla_fleet) = flotilla_fleet else {
+            return Err(WriteError::Validation(
+                "flotilla_id does not exist".to_string(),
+            ));
+        };
+
+        if flotilla_fleet != placement.fleet_id {
+            return Err(WriteError::Validation(
+                "flotilla_id must belong to fleet_id".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_armada_exists(conn: &Connection, armada_id: i64) -> Result<(), WriteError> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM armadas WHERE id = ?1",
+            params![armada_id],
+            |r| r.get(0),
+        )
+        .map_err(map_write_error)?;
+    if !exists {
+        return Err(WriteError::NotFound);
+    }
+    Ok(())
+}
+
+fn ensure_fleet_exists(conn: &Connection, fleet_id: i64) -> Result<(), WriteError> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM fleets WHERE id = ?1",
+            params![fleet_id],
+            |r| r.get(0),
+        )
+        .map_err(map_write_error)?;
+    if !exists {
+        return Err(WriteError::NotFound);
+    }
+    Ok(())
+}
+
+fn validate_captain_count(members: &[CrewMemberInput]) -> Result<(), WriteError> {
+    let captain_count = members
+        .iter()
+        .filter(|member| member.role.trim().eq_ignore_ascii_case("captain"))
+        .count();
+    if captain_count != 1 {
+        return Err(WriteError::Validation(
+            "crew must have exactly one captain".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_approved_project(session_name: &str, config_json: &str) -> Result<(), WriteError> {
     let value: serde_json::Value = serde_json::from_str(config_json)
         .map_err(|err| WriteError::Validation(format!("invalid config_json JSON: {err}")))?;
@@ -123,10 +775,13 @@ fn validate_approved_project(session_name: &str, config_json: &str) -> Result<()
     Ok(())
 }
 
-fn map_write_error(err: anyhow::Error) -> WriteError {
+fn map_write_error(err: impl std::fmt::Display) -> WriteError {
     let message = err.to_string();
     if message.contains("UNIQUE constraint failed") {
         return WriteError::Conflict(message);
+    }
+    if message.contains("FOREIGN KEY constraint failed") {
+        return WriteError::Validation(message);
     }
     if message.contains("invalid") || message.contains("required") || message.contains("must") {
         return WriteError::Validation(message);

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -181,12 +181,8 @@ pub fn ensure_local_host(conn: &Connection) -> Result<i64, WriteError> {
 }
 
 pub fn create_armada(conn: &Connection, armada: &NewArmada) -> Result<i64, WriteError> {
-    conn.execute(
-        "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
-        params![armada.name, armada.description],
-    )
-    .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    let guard = WriteGuard(());
+    write_armada(&guard, conn, armada)
 }
 
 pub fn patch_armada(
@@ -239,13 +235,9 @@ pub fn patch_armada(
 }
 
 pub fn create_fleet(conn: &Connection, fleet: &NewFleet) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
     ensure_armada_exists(conn, fleet.armada_id)?;
-    conn.execute(
-        "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
-        params![fleet.armada_id, fleet.name, fleet.color],
-    )
-    .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    write_fleet(&guard, conn, fleet)
 }
 
 pub fn patch_fleet(
@@ -306,13 +298,9 @@ pub fn patch_fleet(
 }
 
 pub fn create_flotilla(conn: &Connection, flotilla: &NewFlotilla) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
     ensure_fleet_exists(conn, flotilla.fleet_id)?;
-    conn.execute(
-        "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
-        params![flotilla.fleet_id, flotilla.name],
-    )
-    .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    write_flotilla(&guard, conn, flotilla)
 }
 
 pub fn patch_flotilla(
@@ -366,20 +354,16 @@ pub fn patch_flotilla(
 }
 
 pub fn create_crew_bundle(conn: &Connection, bundle: &NewCrewBundle) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
     validate_captain_count(&bundle.members)?;
 
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
     validate_placement(&tx, &bundle.placement)?;
 
-    tx.execute(
-        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
-        params![bundle.crew_name, bundle.crew_ulid],
-    )
-    .map_err(map_write_error)?;
-    let crew_id = tx.last_insert_rowid();
+    let crew_id = write_crew(&guard, &tx, &bundle.crew_name, &bundle.crew_ulid)?;
 
-    insert_members(&tx, crew_id, &bundle.members)?;
-    insert_variants(&tx, crew_id, &bundle.variants)?;
+    insert_members(&guard, &tx, crew_id, &bundle.members)?;
+    insert_variants(&guard, &tx, crew_id, &bundle.variants)?;
 
     tx.execute(
         "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
@@ -403,6 +387,7 @@ pub fn patch_crew_bundle(
     crew_id: i64,
     patch: &CrewBundlePatch,
 ) -> Result<bool, WriteError> {
+    let guard = WriteGuard(());
     if let Some(members) = patch.members.as_ref() {
         validate_captain_count(members)?;
     }
@@ -434,7 +419,7 @@ pub fn patch_crew_bundle(
             params![crew_id],
         )
         .map_err(map_write_error)?;
-        insert_members(&tx, crew_id, members)?;
+        insert_members(&guard, &tx, crew_id, members)?;
     }
 
     if let Some(variants) = patch.variants.as_ref() {
@@ -443,7 +428,7 @@ pub fn patch_crew_bundle(
             params![crew_id],
         )
         .map_err(map_write_error)?;
-        insert_variants(&tx, crew_id, variants)?;
+        insert_variants(&guard, &tx, crew_id, variants)?;
     }
 
     tx.commit().map_err(map_write_error)?;
@@ -455,6 +440,7 @@ pub fn clone_crew(
     source_crew_id: i64,
     request: &CloneCrewRequest,
 ) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
 
     let source_exists: Option<i64> = tx
@@ -471,28 +457,61 @@ pub fn clone_crew(
 
     validate_placement(&tx, &request.placement)?;
 
-    tx.execute(
-        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
-        params![request.crew_name, request.crew_ulid],
-    )
-    .map_err(map_write_error)?;
-    let new_crew_id = tx.last_insert_rowid();
+    let new_crew_id = write_crew(&guard, &tx, &request.crew_name, &request.crew_ulid)?;
 
-    tx.execute(
-        "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
-         SELECT ?1, member_id, role, ai_provider, model, startup_prompts_json
-         FROM crew_members WHERE crew_id = ?2",
-        params![new_crew_id, source_crew_id],
-    )
-    .map_err(map_write_error)?;
+    let source_members = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT member_id, role, ai_provider, model, startup_prompts_json
+                 FROM crew_members
+                 WHERE crew_id = ?1",
+            )
+            .map_err(map_write_error)?;
+        let mapped = stmt
+            .query_map(params![source_crew_id], |r| {
+                Ok(CrewMemberInput {
+                    member_id: r.get(0)?,
+                    role: r.get(1)?,
+                    ai_provider: r.get(2)?,
+                    model: r.get(3)?,
+                    startup_prompts_json: r.get(4)?,
+                })
+            })
+            .map_err(map_write_error)?;
+        mapped
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_write_error)?
+    };
+    for member in &source_members {
+        write_crew_member(&guard, &tx, new_crew_id, member)?;
+    }
 
-    tx.execute(
-        "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
-         SELECT ?1, host_id, repo_url, branch_ref, root_path, config_json
-         FROM crew_variants WHERE crew_id = ?2",
-        params![new_crew_id, source_crew_id],
-    )
-    .map_err(map_write_error)?;
+    let source_variants = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT host_id, repo_url, branch_ref, root_path, config_json
+                 FROM crew_variants
+                 WHERE crew_id = ?1",
+            )
+            .map_err(map_write_error)?;
+        let mapped = stmt
+            .query_map(params![source_crew_id], |r| {
+                Ok(CrewVariantInput {
+                    host_id: r.get(0)?,
+                    repo_url: r.get(1)?,
+                    branch_ref: r.get(2)?,
+                    root_path: r.get(3)?,
+                    config_json: r.get(4)?,
+                })
+            })
+            .map_err(map_write_error)?;
+        mapped
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_write_error)?
+    };
+    for variant in &source_variants {
+        write_crew_variant(&guard, &tx, new_crew_id, variant)?;
+    }
 
     tx.execute(
         "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
@@ -600,48 +619,123 @@ pub fn unlink_crew_ref(conn: &Connection, ref_id: i64) -> Result<bool, WriteErro
 }
 
 fn insert_members(
+    guard: &WriteGuard,
     tx: &rusqlite::Transaction<'_>,
     crew_id: i64,
     members: &[CrewMemberInput],
 ) -> Result<(), WriteError> {
     for member in members {
-        tx.execute(
-            "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                crew_id,
-                member.member_id,
-                member.role,
-                member.ai_provider,
-                member.model,
-                member.startup_prompts_json
-            ],
-        )
-        .map_err(map_write_error)?;
+        write_crew_member(guard, tx, crew_id, member)?;
     }
     Ok(())
 }
 
 fn insert_variants(
+    guard: &WriteGuard,
     tx: &rusqlite::Transaction<'_>,
     crew_id: i64,
     variants: &[CrewVariantInput],
 ) -> Result<(), WriteError> {
     for variant in variants {
-        tx.execute(
-            "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![
-                crew_id,
-                variant.host_id,
-                variant.repo_url,
-                variant.branch_ref,
-                variant.root_path,
-                variant.config_json
-            ],
-        )
-        .map_err(map_write_error)?;
+        write_crew_variant(guard, tx, crew_id, variant)?;
     }
+    Ok(())
+}
+
+fn write_armada(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    armada: &NewArmada,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
+        params![armada.name, armada.description],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_fleet(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    fleet: &NewFleet,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
+        params![fleet.armada_id, fleet.name, fleet.color],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_flotilla(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    flotilla: &NewFlotilla,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
+        params![flotilla.fleet_id, flotilla.name],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_crew(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    crew_name: &str,
+    crew_ulid: &str,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
+        params![crew_name, crew_ulid],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_crew_member(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    crew_id: i64,
+    member: &CrewMemberInput,
+) -> Result<(), WriteError> {
+    conn.execute(
+        "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            crew_id,
+            member.member_id,
+            member.role,
+            member.ai_provider,
+            member.model,
+            member.startup_prompts_json
+        ],
+    )
+    .map_err(map_write_error)?;
+    Ok(())
+}
+
+fn write_crew_variant(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    crew_id: i64,
+    variant: &CrewVariantInput,
+) -> Result<(), WriteError> {
+    conn.execute(
+        "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            crew_id,
+            variant.host_id,
+            variant.repo_url,
+            variant.branch_ref,
+            variant.root_path,
+            variant.config_json
+        ],
+    )
+    .map_err(map_write_error)?;
     Ok(())
 }
 

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -190,6 +190,7 @@ pub fn patch_armada(
     armada_id: i64,
     patch: &ArmadaPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM armadas WHERE id = ?1",
@@ -245,6 +246,7 @@ pub fn patch_fleet(
     fleet_id: i64,
     patch: &FleetPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM fleets WHERE id = ?1",
@@ -308,6 +310,7 @@ pub fn patch_flotilla(
     flotilla_id: i64,
     patch: &FlotillaPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM flotillas WHERE id = ?1",
@@ -535,6 +538,7 @@ pub fn move_crew_ref(
     ref_id: i64,
     patch: &MoveCrewRefPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
     let exists: Option<i64> = tx
         .query_row(

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -121,6 +121,66 @@ impl ApiHarness {
             .expect("create session request");
         assert_eq!(response.status(), reqwest::StatusCode::OK);
     }
+
+    async fn create_armada(&self, name: &str) -> i64 {
+        let response = self
+            .client
+            .post(format!("{}/editor/armadas", self.base_url))
+            .json(&json!({ "name": name }))
+            .send()
+            .await
+            .expect("create armada request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let db_conn = self.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM armadas WHERE name = ?1",
+                rusqlite::params![name],
+                |r| r.get(0),
+            )
+            .expect("armada id")
+    }
+
+    async fn create_fleet(&self, armada_id: i64, name: &str) -> i64 {
+        let response = self
+            .client
+            .post(format!("{}/editor/fleets", self.base_url))
+            .json(&json!({ "armada_id": armada_id, "name": name }))
+            .send()
+            .await
+            .expect("create fleet request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let db_conn = self.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM fleets WHERE armada_id = ?1 AND name = ?2",
+                rusqlite::params![armada_id, name],
+                |r| r.get(0),
+            )
+            .expect("fleet id")
+    }
+
+    async fn create_flotilla(&self, fleet_id: i64, name: &str) -> i64 {
+        let response = self
+            .client
+            .post(format!("{}/editor/flotillas", self.base_url))
+            .json(&json!({ "fleet_id": fleet_id, "name": name }))
+            .send()
+            .await
+            .expect("create flotilla request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let db_conn = self.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM flotillas WHERE fleet_id = ?1 AND name = ?2",
+                rusqlite::params![fleet_id, name],
+                |r| r.get(0),
+            )
+            .expect("flotilla id")
+    }
 }
 
 impl Drop for ApiHarness {
@@ -376,6 +436,375 @@ exit 1
         marker_log.contains("kill\n"),
         "expected tmux hard-stop after grace timeout, got: {marker_log:?}"
     );
+}
+
+#[tokio::test]
+async fn t_ed_01_create_editor_hierarchy_and_crew_bundle() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Work Dev").await;
+    let fleet_id = h.create_fleet(armada_id, "Core").await;
+    let flotilla_id = h.create_flotilla(fleet_id, "Backend").await;
+
+    let response = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-alpha",
+            "crew_ulid": "01JCREWALPHA00000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["prompts/arch-startup.md", "prompts/pm-startup.md"]
+                },
+                {
+                    "member_id": "arch-cmux",
+                    "role": "mate",
+                    "ai_provider": "codex",
+                    "model": "codex-high",
+                    "startup_prompts": ["prompts/arch-cmux-startup.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "repo_url": "git@github.com:randlee/scmux.git",
+                    "branch_ref": "feature/demo",
+                    "root_path": "/tmp/scmux",
+                    "config_json": { "session_name": "crew-alpha" }
+                }
+            ],
+            "placement": {
+                "armada_id": armada_id,
+                "fleet_id": fleet_id,
+                "flotilla_id": flotilla_id
+            }
+        }))
+        .send()
+        .await
+        .expect("create crew bundle");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let db_conn = h.state.db.lock().expect("db lock");
+    let crews: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crews WHERE crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("crew count");
+    let members: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_members cm JOIN crews c ON c.id = cm.crew_id WHERE c.crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("member count");
+    let variants: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_variants cv JOIN crews c ON c.id = cv.crew_id WHERE c.crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("variant count");
+    let refs_count: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_refs cr JOIN crews c ON c.id = cr.crew_id WHERE c.crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("ref count");
+
+    assert_eq!(crews, 1);
+    assert_eq!(members, 2);
+    assert_eq!(variants, 1);
+    assert_eq!(refs_count, 1);
+}
+
+#[tokio::test]
+async fn t_ed_02_clone_move_and_unlink_crew_ref_with_reference_count_delete() {
+    let h = ApiHarness::new().await;
+    let armada_a = h.create_armada("A").await;
+    let fleet_a = h.create_fleet(armada_a, "Fleet-A").await;
+    let armada_b = h.create_armada("B").await;
+    let fleet_b = h.create_fleet(armada_b, "Fleet-B").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-src",
+            "crew_ulid": "01JCREWSRC0000000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": "/tmp/crew-src"
+                }
+            ],
+            "placement": { "armada_id": armada_a, "fleet_id": fleet_a }
+        }))
+        .send()
+        .await
+        .expect("create source crew");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let (source_crew_id, source_ref_id): (i64, i64) = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT c.id, r.id FROM crews c JOIN crew_refs r ON r.crew_id = c.id WHERE c.crew_name = 'crew-src' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("source ids")
+    };
+
+    let clone = h
+        .client
+        .post(format!(
+            "{}/editor/crews/{}/clone",
+            h.base_url, source_crew_id
+        ))
+        .json(&json!({
+            "crew_name": "crew-clone",
+            "crew_ulid": "01JCREWCLONE00000000000000",
+            "placement": { "armada_id": armada_b, "fleet_id": fleet_b }
+        }))
+        .send()
+        .await
+        .expect("clone crew");
+    assert_eq!(clone.status(), reqwest::StatusCode::OK);
+
+    let move_ref = h
+        .client
+        .post(format!(
+            "{}/editor/crew-refs/{}/move",
+            h.base_url, source_ref_id
+        ))
+        .json(&json!({
+            "armada_id": armada_b,
+            "fleet_id": fleet_b
+        }))
+        .send()
+        .await
+        .expect("move crew ref");
+    assert_eq!(move_ref.status(), reqwest::StatusCode::OK);
+
+    let unlink = h
+        .client
+        .delete(format!("{}/editor/crew-refs/{}", h.base_url, source_ref_id))
+        .send()
+        .await
+        .expect("unlink crew ref");
+    assert_eq!(unlink.status(), reqwest::StatusCode::OK);
+
+    let db_conn = h.state.db.lock().expect("db lock");
+    let source_exists: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crews WHERE id = ?1",
+            rusqlite::params![source_crew_id],
+            |r| r.get(0),
+        )
+        .expect("source exists count");
+    let clone_exists: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crews WHERE crew_name = 'crew-clone'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("clone exists count");
+    assert_eq!(source_exists, 0);
+    assert_eq!(clone_exists, 1);
+}
+
+#[tokio::test]
+async fn t_ed_03_running_crew_blocks_roster_patch() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Run").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-running",
+            "crew_ulid": "01JCREWRUN000000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": "/tmp/crew-running"
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-running");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-running'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+
+    let _guard = env_lock().lock().await;
+    let script = write_script(
+        r#"#!/bin/sh
+if [ "$1" = "list-sessions" ]; then
+  echo "crew-running"
+  exit 0
+fi
+if [ "$1" = "list-panes" ]; then
+  exit 0
+fi
+exit 1
+"#,
+    );
+    let prev_tmux = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
+    let response = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["updated.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("patch running crew");
+    restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
+
+    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["code"], "running_edit_forbidden");
+}
+
+#[tokio::test]
+async fn t_ed_04_invalid_roster_patch_is_atomic() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Atomic").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-atomic",
+            "crew_ulid": "01JCREWATOMIC000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                },
+                {
+                    "member_id": "arch-cmux",
+                    "role": "mate",
+                    "ai_provider": "codex",
+                    "model": "codex-high",
+                    "startup_prompts": ["b.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": "/tmp/crew-atomic"
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-atomic");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-atomic'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+
+    let before_count: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT COUNT(*) FROM crew_members WHERE crew_id = ?1",
+                rusqlite::params![crew_id],
+                |r| r.get(0),
+            )
+            .expect("before count")
+    };
+    assert_eq!(before_count, 2);
+
+    let response = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "members": [
+                {
+                    "member_id": "arch-cmux",
+                    "role": "mate",
+                    "ai_provider": "codex",
+                    "model": "codex-high",
+                    "startup_prompts": ["only-mate.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("invalid patch request");
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let after_count: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT COUNT(*) FROM crew_members WHERE crew_id = ?1",
+                rusqlite::params![crew_id],
+                |r| r.get(0),
+            )
+            .expect("after count")
+    };
+    assert_eq!(after_count, 2);
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -327,7 +327,7 @@ async fn t_lc_06_start_failure_returns_500_and_keeps_session_stopped() {
 }
 
 #[tokio::test]
-async fn t_lc_03_stop_sends_atm_then_grace_then_hard_stop() {
+async fn t_lc_03_stop_grace_then_hard_stop_when_atm_send_is_stubbed() {
     let h = ApiHarness::new().await;
     h.create_session("alpha").await;
 
@@ -348,17 +348,7 @@ fi
 exit 1
 "#,
     ));
-    let atm_script = write_script(&format!(
-        r#"#!/bin/sh
-if [ "$1" = "send" ]; then
-  echo "send" >> "{marker_path}"
-  exit 0
-fi
-exit 1
-"#
-    ));
     let prev_tmux = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
-    let prev_atm = set_env_var("SCMUX_ATM_BIN", atm_script.to_string_lossy().as_ref());
     let started = Instant::now();
 
     let response = h
@@ -368,7 +358,6 @@ exit 1
         .await
         .expect("stop request");
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
-    restore_env_var("SCMUX_ATM_BIN", prev_atm);
 
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Value = response.json().await.expect("json");
@@ -384,8 +373,8 @@ exit 1
 
     let marker_log = std::fs::read_to_string(marker.path()).expect("read marker");
     assert!(
-        marker_log.contains("send\nkill\n"),
-        "expected ATM send before tmux hard-stop, got: {marker_log:?}"
+        marker_log.contains("kill\n"),
+        "expected tmux hard-stop after grace timeout, got: {marker_log:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- add persisted editor hierarchy schema in SQLite: `armadas`, `fleets`, `flotillas`, `crews`, `crew_members`, `crew_variants`, `crew_refs`
- implement writer-gate backend APIs for create/edit/clone/move/unlink across hierarchy
- enforce atomic roster/variant edits with transaction boundaries and reference-counted delete semantics on unlink
- enforce running-edit restriction: roster/prompt edits are blocked when the crew session is live
- add API integration tests for hierarchy creation, clone/move/unlink behavior, running-edit policy, and atomic failure behavior

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
