### PR TITLE
Phase 7: Armada/Fleet/Flotilla/Crew architecture (v0.6.0)

### DIFF
--- a/crates/scmux-daemon/assets/dashboard.js
+++ b/crates/scmux-daemon/assets/dashboard.js
@@ -1,4 +1,4 @@
-const { useEffect, useMemo, useState } = React;
+const { useState, useEffect, useMemo } = React;
 
 const PROJECT_COLORS = {
   "radiant-p3": "#3b82f6",
@@ -50,6 +50,7 @@ const STATUS_DOT = {
 };
 const DEFAULT_BASE_URL = "http://localhost:7878";
 const DEFAULT_POLL_MS = 15_000;
+const FLOTILLA_V1_ENABLED = false;
 function daemonBaseUrl() {
   if (typeof window === "undefined") {
     return DEFAULT_BASE_URL;
@@ -895,6 +896,729 @@ function DiscoveryView({
     colSpan: 4
   }, "no panes reported")))))));
 }
+function makeCrewUlid() {
+  return `01J${Date.now().toString(36).toUpperCase()}${Math.random().toString(36).slice(2, 12).toUpperCase()}`;
+}
+function OrganizationEditorModal({
+  baseUrl,
+  open,
+  onClose,
+  onSaved
+}) {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
+  const [state, setState] = useState({
+    armadas: [],
+    fleets: [],
+    flotillas: [],
+    crews: [],
+    crew_refs: []
+  });
+  const [armadaName, setArmadaName] = useState("");
+  const [fleetName, setFleetName] = useState("");
+  const [fleetColor, setFleetColor] = useState("#3b82f6");
+  const [newCrewName, setNewCrewName] = useState("");
+  const [newCrewUlid, setNewCrewUlid] = useState(makeCrewUlid());
+  const [captainModel, setCaptainModel] = useState("claude-opus");
+  const [mateModel, setMateModel] = useState("codex-high");
+  const [newRootPath, setNewRootPath] = useState("/tmp/scmux");
+  const [selectedArmadaId, setSelectedArmadaId] = useState(null);
+  const [selectedFleetId, setSelectedFleetId] = useState(null);
+  const [selectedFlotillaId, setSelectedFlotillaId] = useState(null);
+  const loadState = async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const response = await fetch(`${baseUrl}/editor/state`);
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || `HTTP ${response.status}`);
+      }
+      setState({
+        armadas: Array.isArray(body.armadas) ? body.armadas : [],
+        fleets: Array.isArray(body.fleets) ? body.fleets : [],
+        flotillas: Array.isArray(body.flotillas) ? body.flotillas : [],
+        crews: Array.isArray(body.crews) ? body.crews : [],
+        crew_refs: Array.isArray(body.crew_refs) ? body.crew_refs : []
+      });
+    } catch (error) {
+      setErrorMessage(`Failed to load editor state: ${String(error)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    loadState();
+  }, [open]);
+  useEffect(() => {
+    if (!selectedArmadaId && state.armadas.length) {
+      setSelectedArmadaId(state.armadas[0].id);
+    }
+  }, [state.armadas, selectedArmadaId]);
+  useEffect(() => {
+    const fleetsForArmada = state.fleets.filter(fleet => fleet.armada_id === selectedArmadaId);
+    if (!fleetsForArmada.length) {
+      setSelectedFleetId(null);
+      return;
+    }
+    if (!fleetsForArmada.some(fleet => fleet.id === selectedFleetId)) {
+      setSelectedFleetId(fleetsForArmada[0].id);
+    }
+  }, [state.fleets, selectedArmadaId, selectedFleetId]);
+  useEffect(() => {
+    const flotillasForFleet = state.flotillas.filter(item => item.fleet_id === selectedFleetId);
+    if (!flotillasForFleet.length) {
+      setSelectedFlotillaId(null);
+      return;
+    }
+    if (!flotillasForFleet.some(item => item.id === selectedFlotillaId)) {
+      setSelectedFlotillaId(flotillasForFleet[0].id);
+    }
+  }, [state.flotillas, selectedFleetId, selectedFlotillaId]);
+  if (!open) {
+    return null;
+  }
+  const fleetsForSelectedArmada = state.fleets.filter(fleet => fleet.armada_id === selectedArmadaId);
+  const flotillasForSelectedFleet = state.flotillas.filter(item => item.fleet_id === selectedFleetId);
+  const hasPlacement = Number.isFinite(selectedArmadaId) && Number.isFinite(selectedFleetId);
+  const submitJson = async (url, method, payload, successText) => {
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || body.code || `HTTP ${response.status}`);
+      }
+      setSuccessMessage(successText || body.message || "Saved");
+      await loadState();
+      if (onSaved) {
+        onSaved(successText || body.message || "Saved");
+      }
+      return true;
+    } catch (error) {
+      setErrorMessage(String(error));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+  const createArmada = async () => {
+    if (!armadaName.trim()) {
+      setErrorMessage("Armada name is required.");
+      return;
+    }
+    const ok = await submitJson(`${baseUrl}/editor/armadas`, "POST", {
+      name: armadaName.trim()
+    }, `Armada created: ${armadaName.trim()}`);
+    if (ok) {
+      setArmadaName("");
+    }
+  };
+  const cloneArmada = async (armadaId, sourceName) => {
+    const copyName = `${sourceName}-clone`;
+    await submitJson(`${baseUrl}/editor/armadas/${armadaId}/clone`, "POST", {
+      name: copyName
+    }, `Cloned armada to ${copyName}`);
+  };
+  const createFleet = async () => {
+    if (!fleetName.trim()) {
+      setErrorMessage("Fleet name is required.");
+      return;
+    }
+    if (!selectedArmadaId) {
+      setErrorMessage("Create/select an Armada before creating a Fleet.");
+      return;
+    }
+    const ok = await submitJson(`${baseUrl}/editor/fleets`, "POST", {
+      armada_id: selectedArmadaId,
+      name: fleetName.trim(),
+      color: fleetColor
+    }, `Fleet created: ${fleetName.trim()}`);
+    if (ok) {
+      setFleetName("");
+    }
+  };
+  const cloneFleet = async (fleetId, sourceName, sourceArmadaId, sourceColor) => {
+    const copyName = `${sourceName}-clone`;
+    await submitJson(`${baseUrl}/editor/fleets/${fleetId}/clone`, "POST", {
+      armada_id: selectedArmadaId || sourceArmadaId,
+      name: copyName,
+      color: sourceColor || null
+    }, `Cloned fleet to ${copyName}`);
+  };
+  const createCrew = async () => {
+    if (!newCrewName.trim()) {
+      setErrorMessage("Crew name is required.");
+      return;
+    }
+    if (!hasPlacement) {
+      setErrorMessage("Crew placement is unresolved. Select Armada and Fleet.");
+      return;
+    }
+    const payload = {
+      crew_name: newCrewName.trim(),
+      crew_ulid: newCrewUlid.trim() || makeCrewUlid(),
+      members: [{
+        member_id: "team-lead",
+        role: "captain",
+        ai_provider: "claude",
+        model: captainModel.trim() || "claude-opus",
+        startup_prompts: ["prompts/arch-startup.md", "prompts/pm-startup.md"]
+      }, {
+        member_id: "arch-cmux",
+        role: "mate",
+        ai_provider: "codex",
+        model: mateModel.trim() || "codex-high",
+        startup_prompts: ["prompts/arch-cmux-startup.md"]
+      }],
+      variants: [{
+        host_id: 1,
+        root_path: newRootPath.trim() || "/tmp/scmux"
+      }],
+      placement: {
+        armada_id: selectedArmadaId,
+        fleet_id: selectedFleetId,
+        flotilla_id: FLOTILLA_V1_ENABLED ? selectedFlotillaId : null
+      }
+    };
+    const ok = await submitJson(`${baseUrl}/editor/crews`, "POST", payload, `Crew created: ${newCrewName.trim()}`);
+    if (ok) {
+      setNewCrewName("");
+      setNewCrewUlid(makeCrewUlid());
+    }
+  };
+  const moveRef = async (refRow, nextArmadaId, nextFleetId) => {
+    if (!nextArmadaId || !nextFleetId) {
+      setErrorMessage("Move requires target armada and fleet.");
+      return;
+    }
+    await submitJson(`${baseUrl}/editor/crew-refs/${refRow.id}/move`, "POST", {
+      armada_id: Number(nextArmadaId),
+      fleet_id: Number(nextFleetId),
+      flotilla_id: null
+    }, `Moved crew ref ${refRow.id}`);
+  };
+  const cloneCrew = async (crewId, crewName) => {
+    const copyName = `${crewName}-clone`;
+    await submitJson(`${baseUrl}/editor/crews/${crewId}/clone`, "POST", {
+      crew_name: copyName,
+      crew_ulid: makeCrewUlid(),
+      placement: {
+        armada_id: selectedArmadaId,
+        fleet_id: selectedFleetId,
+        flotilla_id: FLOTILLA_V1_ENABLED ? selectedFlotillaId : null
+      }
+    }, `Cloned crew to ${copyName}`);
+  };
+  const unlinkRef = async refId => {
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      const response = await fetch(`${baseUrl}/editor/crew-refs/${refId}`, {
+        method: "DELETE"
+      });
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || `HTTP ${response.status}`);
+      }
+      setSuccessMessage(body.message || `Unlinked ref ${refId}`);
+      await loadState();
+      if (onSaved) {
+        onSaved(body.message || `Unlinked ref ${refId}`);
+      }
+    } catch (error) {
+      setErrorMessage(String(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: "fixed",
+      inset: 0,
+      background: "rgba(0,0,0,0.8)",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      zIndex: 230
+    },
+    onClick: onClose
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      width: "min(1100px, 96vw)",
+      maxHeight: "92vh",
+      overflowY: "auto",
+      background: "#0d1117",
+      border: "1px solid #1e2535",
+      borderRadius: 10,
+      padding: 16,
+      display: "grid",
+      gap: 14
+    },
+    onClick: event => event.stopPropagation()
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center"
+    }
+  }, /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 10,
+      color: "#475569",
+      letterSpacing: "0.1em"
+    }
+  }, "ORGANIZATION EDITOR"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      color: "#cbd5e1"
+    }
+  }, "Armada / Fleet", FLOTILLA_V1_ENABLED ? " / Flotilla" : "", " / Crew")), /*#__PURE__*/React.createElement("button", {
+    onClick: onClose,
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      background: "transparent",
+      color: "#94a3b8",
+      padding: "6px 10px",
+      cursor: "pointer"
+    }
+  }, "Close")), !FLOTILLA_V1_ENABLED && /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#f59e0b"
+    }
+  }, "Flotilla is currently behind feature flag. UI operates at Armada/Fleet scope."), loading ? /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 12,
+      color: "#64748b"
+    }
+  }, "Loading editor state...") : /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "grid",
+      gridTemplateColumns: "1fr 1fr 1fr",
+      gap: 10
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 8,
+      padding: 10,
+      display: "grid",
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd"
+    }
+  }, "Armada Editor"), /*#__PURE__*/React.createElement("input", {
+    value: armadaName,
+    onChange: event => setArmadaName(event.target.value),
+    placeholder: "Armada name",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("button", {
+    onClick: createArmada,
+    disabled: saving,
+    style: {
+      border: "none",
+      background: "#2563eb",
+      color: "#fff",
+      borderRadius: 5,
+      padding: "6px 8px",
+      cursor: "pointer",
+      fontSize: 11
+    }
+  }, "+ Create Armada"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      maxHeight: 130,
+      overflowY: "auto",
+      borderTop: "1px solid #131820",
+      paddingTop: 6
+    }
+  }, state.armadas.map(armada => /*#__PURE__*/React.createElement("div", {
+    key: armada.id,
+    style: {
+      fontSize: 11,
+      color: "#94a3b8",
+      padding: "2px 0",
+      display: "flex",
+      justifyContent: "space-between",
+      gap: 8,
+      alignItems: "center"
+    }
+  }, /*#__PURE__*/React.createElement("span", null, armada.name, " ", /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: "#475569"
+    }
+  }, "#", armada.id)), /*#__PURE__*/React.createElement("button", {
+    onClick: () => cloneArmada(armada.id, armada.name),
+    disabled: saving,
+    style: {
+      border: "1px solid #1e2535",
+      background: "#1e293b",
+      color: "#cbd5e1",
+      borderRadius: 5,
+      padding: "2px 7px",
+      cursor: "pointer",
+      fontSize: 10
+    }
+  }, "Clone"))))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 8,
+      padding: 10,
+      display: "grid",
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd"
+    }
+  }, "Fleet Editor"), /*#__PURE__*/React.createElement("select", {
+    value: selectedArmadaId || "",
+    onChange: event => setSelectedArmadaId(Number(event.target.value)),
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }, /*#__PURE__*/React.createElement("option", {
+    value: ""
+  }, "Select armada"), state.armadas.map(armada => /*#__PURE__*/React.createElement("option", {
+    key: armada.id,
+    value: armada.id
+  }, armada.name))), /*#__PURE__*/React.createElement("input", {
+    value: fleetName,
+    onChange: event => setFleetName(event.target.value),
+    placeholder: "Fleet name",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: fleetColor,
+    onChange: event => setFleetColor(event.target.value),
+    placeholder: "#3b82f6",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("button", {
+    onClick: createFleet,
+    disabled: saving || !selectedArmadaId,
+    style: {
+      border: "none",
+      background: "#0ea5e9",
+      color: "#fff",
+      borderRadius: 5,
+      padding: "6px 8px",
+      cursor: "pointer",
+      fontSize: 11
+    }
+  }, "+ Create Fleet"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      maxHeight: 130,
+      overflowY: "auto",
+      borderTop: "1px solid #131820",
+      paddingTop: 6
+    }
+  }, fleetsForSelectedArmada.map(fleet => /*#__PURE__*/React.createElement("div", {
+    key: fleet.id,
+    style: {
+      fontSize: 11,
+      color: "#94a3b8",
+      padding: "2px 0",
+      display: "flex",
+      justifyContent: "space-between",
+      gap: 8,
+      alignItems: "center"
+    }
+  }, /*#__PURE__*/React.createElement("span", null, fleet.name, " ", /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: fleet.color || "#64748b"
+    }
+  }, fleet.color || "")), /*#__PURE__*/React.createElement("button", {
+    onClick: () => cloneFleet(fleet.id, fleet.name, fleet.armada_id, fleet.color),
+    disabled: saving,
+    style: {
+      border: "1px solid #1e2535",
+      background: "#1e293b",
+      color: "#cbd5e1",
+      borderRadius: 5,
+      padding: "2px 7px",
+      cursor: "pointer",
+      fontSize: 10
+    }
+  }, "Clone"))))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 8,
+      padding: 10,
+      display: "grid",
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd"
+    }
+  }, "Crew Editor"), /*#__PURE__*/React.createElement("input", {
+    value: newCrewName,
+    onChange: event => setNewCrewName(event.target.value),
+    placeholder: "Crew name",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: newCrewUlid,
+    onChange: event => setNewCrewUlid(event.target.value),
+    placeholder: "Crew ULID",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: newRootPath,
+    onChange: event => setNewRootPath(event.target.value),
+    placeholder: "root path",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "grid",
+      gridTemplateColumns: "1fr 1fr",
+      gap: 6
+    }
+  }, /*#__PURE__*/React.createElement("input", {
+    value: captainModel,
+    onChange: event => setCaptainModel(event.target.value),
+    placeholder: "Captain model",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: mateModel,
+    onChange: event => setMateModel(event.target.value),
+    placeholder: "Mate model",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  })), FLOTILLA_V1_ENABLED && /*#__PURE__*/React.createElement("select", {
+    value: selectedFlotillaId || "",
+    onChange: event => setSelectedFlotillaId(Number(event.target.value)),
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }, /*#__PURE__*/React.createElement("option", {
+    value: ""
+  }, "No flotilla"), flotillasForSelectedFleet.map(item => /*#__PURE__*/React.createElement("option", {
+    key: item.id,
+    value: item.id
+  }, item.name))), !hasPlacement && /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#f59e0b"
+    }
+  }, "Placement unresolved: create/select Armada and Fleet first."), /*#__PURE__*/React.createElement("button", {
+    onClick: createCrew,
+    disabled: saving || !hasPlacement,
+    style: {
+      border: "none",
+      background: "#16a34a",
+      color: "#fff",
+      borderRadius: 5,
+      padding: "6px 8px",
+      cursor: "pointer",
+      fontSize: 11
+    }
+  }, "+ Create Crew"))), errorMessage && /*#__PURE__*/React.createElement("div", {
+    style: {
+      color: "#f87171",
+      fontSize: 11
+    }
+  }, errorMessage), successMessage && /*#__PURE__*/React.createElement("div", {
+    style: {
+      color: "#34d399",
+      fontSize: 11
+    }
+  }, successMessage), /*#__PURE__*/React.createElement("div", {
+    style: {
+      borderTop: "1px solid #131820",
+      paddingTop: 10
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd",
+      marginBottom: 8
+    }
+  }, "Crew Placement Controls"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "grid",
+      gap: 8
+    }
+  }, state.crew_refs.map(refRow => {
+    const crew = state.crews.find(item => item.id === refRow.crew_id);
+    const armada = state.armadas.find(item => item.id === refRow.armada_id);
+    const fleet = state.fleets.find(item => item.id === refRow.fleet_id);
+    return /*#__PURE__*/React.createElement("div", {
+      key: refRow.id,
+      style: {
+        border: "1px solid #1e2535",
+        borderRadius: 6,
+        padding: 8,
+        display: "grid",
+        gap: 6
+      }
+    }, /*#__PURE__*/React.createElement("div", {
+      style: {
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        gap: 8
+      }
+    }, /*#__PURE__*/React.createElement("div", {
+      style: {
+        fontSize: 11,
+        color: "#cbd5e1"
+      }
+    }, crew?.crew_name || `crew-${refRow.crew_id}`, " ", /*#__PURE__*/React.createElement("span", {
+      style: {
+        color: "#64748b"
+      }
+    }, "ref#", refRow.id)), /*#__PURE__*/React.createElement("div", {
+      style: {
+        fontSize: 10,
+        color: "#64748b"
+      }
+    }, armada?.name || "unknown", " / ", fleet?.name || "unknown")), /*#__PURE__*/React.createElement("div", {
+      style: {
+        display: "flex",
+        gap: 6,
+        flexWrap: "wrap"
+      }
+    }, /*#__PURE__*/React.createElement("select", {
+      id: `move-armada-${refRow.id}`,
+      defaultValue: refRow.armada_id,
+      style: {
+        background: "#060810",
+        border: "1px solid #1e2535",
+        borderRadius: 5,
+        color: "#cbd5e1",
+        padding: "5px 8px",
+        fontSize: 11
+      }
+    }, state.armadas.map(item => /*#__PURE__*/React.createElement("option", {
+      key: item.id,
+      value: item.id
+    }, item.name))), /*#__PURE__*/React.createElement("select", {
+      id: `move-fleet-${refRow.id}`,
+      defaultValue: refRow.fleet_id,
+      style: {
+        background: "#060810",
+        border: "1px solid #1e2535",
+        borderRadius: 5,
+        color: "#cbd5e1",
+        padding: "5px 8px",
+        fontSize: 11
+      }
+    }, state.fleets.map(item => /*#__PURE__*/React.createElement("option", {
+      key: item.id,
+      value: item.id
+    }, item.name))), /*#__PURE__*/React.createElement("button", {
+      onClick: () => {
+        const armadaValue = Number(document.getElementById(`move-armada-${refRow.id}`)?.value);
+        const fleetValue = Number(document.getElementById(`move-fleet-${refRow.id}`)?.value);
+        moveRef(refRow, armadaValue, fleetValue);
+      },
+      style: {
+        border: "1px solid #1e2535",
+        background: "#1e3a8a",
+        color: "#bfdbfe",
+        borderRadius: 5,
+        padding: "5px 8px",
+        cursor: "pointer",
+        fontSize: 11
+      }
+    }, "Move"), /*#__PURE__*/React.createElement("button", {
+      onClick: () => cloneCrew(refRow.crew_id, crew?.crew_name || `crew-${refRow.crew_id}`),
+      style: {
+        border: "1px solid #1e2535",
+        background: "#312e81",
+        color: "#c7d2fe",
+        borderRadius: 5,
+        padding: "5px 8px",
+        cursor: "pointer",
+        fontSize: 11
+      }
+    }, "Clone Crew"), /*#__PURE__*/React.createElement("button", {
+      onClick: () => unlinkRef(refRow.id),
+      style: {
+        border: "1px solid #1e2535",
+        background: "#3f1d1d",
+        color: "#fca5a5",
+        borderRadius: 5,
+        padding: "5px 8px",
+        cursor: "pointer",
+        fontSize: 11
+      }
+    }, "Unlink")));
+  })))));
+}
 function JumpModal({
   baseUrl,
   defaultTerminal,
@@ -1477,6 +2201,7 @@ function Dashboard() {
   const [search, setSearch] = useState("");
   const [jumpTarget, setJumpTarget] = useState(null);
   const [editorTarget, setEditorTarget] = useState(null);
+  const [orgEditorOpen, setOrgEditorOpen] = useState(false);
   const [hosts, setHosts] = useState([]);
   const [sessions, setSessions] = useState([]);
   const [discoveryRows, setDiscoveryRows] = useState([]);
@@ -1712,6 +2437,18 @@ function Dashboard() {
       flexWrap: "wrap"
     }
   }, /*#__PURE__*/React.createElement("button", {
+    onClick: () => setOrgEditorOpen(true),
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      background: "#111827",
+      color: "#93c5fd",
+      padding: "5px 10px",
+      fontSize: 10,
+      cursor: "pointer",
+      letterSpacing: "0.05em"
+    }
+  }, "Org Editor"), /*#__PURE__*/React.createElement("button", {
     onClick: () => setEditorTarget({
       mode: "create"
     }),
@@ -1898,6 +2635,13 @@ function Dashboard() {
       setEditorTarget(null);
       setActionMessage(message);
       await refresh();
+    }
+  }), /*#__PURE__*/React.createElement(OrganizationEditorModal, {
+    baseUrl: baseUrl,
+    open: orgEditorOpen,
+    onClose: () => setOrgEditorOpen(false),
+    onSaved: message => {
+      setActionMessage(message);
     }
   }), hosts.length === 0 && !loading && /*#__PURE__*/React.createElement("div", {
     style: {

--- a/crates/scmux-daemon/assets/dashboard.js
+++ b/crates/scmux-daemon/assets/dashboard.js
@@ -1,4 +1,4 @@
-const { useState, useEffect, useMemo } = React;
+const { useEffect, useMemo, useState } = React;
 
 const PROJECT_COLORS = {
   "radiant-p3": "#3b82f6",

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -78,6 +78,7 @@ struct HealthResponse {
     sessions_running: i64,
     host_id: i64,
     atm_available: bool,
+    atm_socket_available: bool,
     ci_available: CiAvailability,
     pollers: PollerStates,
     recent_errors: Vec<String>,
@@ -437,6 +438,7 @@ async fn health(
     let db_path = state.db_path.clone();
     let host_id = state.host_id;
     let atm_available = state.atm_available.load(Ordering::Relaxed);
+    let atm_socket_available = crate::atm::atm_socket_available(state.as_ref());
     let ci_available = CiAvailability {
         gh: state.ci_tools.gh_available,
         az: state.ci_tools.az_available,
@@ -475,6 +477,7 @@ async fn health(
         sessions_running,
         host_id,
         atm_available,
+        atm_socket_available,
         ci_available,
         pollers: PollerStates {
             tmux: health_state.tmux,

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -293,6 +293,7 @@ struct CreateCrewBundleRequest {
 
 #[derive(Debug, Deserialize, Default)]
 struct PatchCrewBundleRequest {
+    crew_name: Option<String>,
     crew_ulid: Option<String>,
     members: Option<Vec<CrewMemberPayload>>,
     variants: Option<Vec<CrewVariantPayload>>,
@@ -326,6 +327,7 @@ struct ImportDiscoveryRequest {
     repo_url: Option<String>,
     branch_ref: Option<String>,
     root_path: String,
+    #[serde(default)]
     member_intents: Vec<ImportDiscoveryMemberIntent>,
 }
 
@@ -828,22 +830,20 @@ async fn start_session(
         )
     })?;
 
-    if let Err(message) = validate_start_config(&definition.config_json, &name) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                ok: false,
-                code: "invalid_config".to_string(),
-                message,
-            }),
-        ));
-    }
-    if let Some(binding) = fetch_preferred_crew_variant_binding(Arc::clone(&state), &name).await? {
+    let start_root_path = if let Some(binding) =
+        fetch_preferred_crew_variant_binding(Arc::clone(&state), &name).await?
+    {
         if let Err(message) = validate_crew_variant_binding(&binding, state.host_id) {
             return Err(bad_request("invalid_crew_variant_binding", message));
         }
-    } else if let Err(message) = validate_config_root_path_binding(&definition.config_json) {
-        return Err(bad_request("invalid_crew_variant_binding", message));
+        binding.root_path
+    } else {
+        validate_config_root_path_binding(&definition.config_json)
+            .map_err(|message| bad_request("invalid_crew_variant_binding", message))?
+    };
+
+    if let Err(message) = validate_start_config(&definition.config_json, &name, &start_root_path) {
+        return Err(bad_request("invalid_config", message));
     }
 
     {
@@ -1376,8 +1376,19 @@ async fn patch_crew_bundle(
     Path(id): Path<i64>,
     Json(req): Json<PatchCrewBundleRequest>,
 ) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    if req.crew_name.is_some() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse {
+                ok: false,
+                code: "crew_rename_forbidden".to_string(),
+                message: "crew rename is forbidden".to_string(),
+            }),
+        ));
+    }
+
     let mut _roster_action_lease: Option<SessionActionLease> = None;
-    let editing_roster = req.members.is_some() || req.variants.is_some();
+    let editing_roster = req.members.is_some() || req.variants.is_some() || req.crew_ulid.is_some();
     if editing_roster {
         if let Some(crew_name) = fetch_crew_name(Arc::clone(&state), id).await? {
             _roster_action_lease = Some(acquire_session_action(&crew_name, "edit crew roster")?);
@@ -1426,6 +1437,7 @@ async fn patch_crew_bundle(
         .transpose()?;
 
     let patch = definition_writer::CrewBundlePatch {
+        crew_name: req.crew_name,
         crew_ulid: req.crew_ulid,
         members,
         variants,
@@ -1987,7 +1999,11 @@ fn acquire_session_action(
     Ok(SessionActionLease { session_name: key })
 }
 
-fn validate_start_config(config_json: &str, name: &str) -> Result<(), String> {
+fn validate_start_config(
+    config_json: &str,
+    name: &str,
+    start_root_path: &str,
+) -> Result<(), String> {
     let value: serde_json::Value = serde_json::from_str(config_json)
         .map_err(|err| format!("config_json is not valid JSON: {err}"))?;
     let session_name = value
@@ -2004,10 +2020,11 @@ fn validate_start_config(config_json: &str, name: &str) -> Result<(), String> {
     if panes.is_empty() {
         return Err("config_json.panes[] must contain at least one pane".to_string());
     }
+    validate_startup_prompt_paths(panes, FsPath::new(start_root_path))?;
     Ok(())
 }
 
-fn validate_config_root_path_binding(config_json: &str) -> Result<(), String> {
+fn validate_config_root_path_binding(config_json: &str) -> Result<String, String> {
     let value: serde_json::Value = serde_json::from_str(config_json)
         .map_err(|err| format!("config_json is not valid JSON: {err}"))?;
     let root_path = value
@@ -2027,7 +2044,82 @@ fn validate_config_root_path_binding(config_json: &str) -> Result<(), String> {
             "config_json.root_path is not a directory: {root_path}"
         ));
     }
+    Ok(root_path.to_string())
+}
+
+fn validate_startup_prompt_paths(
+    panes: &[serde_json::Value],
+    start_root_path: &FsPath,
+) -> Result<(), String> {
+    for pane in panes {
+        let pane_name = pane
+            .get("name")
+            .and_then(|raw| raw.as_str())
+            .unwrap_or("unnamed-pane");
+        for prompt in extract_startup_prompt_paths(pane, pane_name)? {
+            let prompt_path = FsPath::new(&prompt);
+            let resolved = if prompt_path.is_absolute() {
+                prompt_path.to_path_buf()
+            } else {
+                start_root_path.join(prompt_path)
+            };
+            if !resolved.exists() || !resolved.is_file() {
+                return Err(format!(
+                    "startup prompt path for pane '{pane_name}' could not be resolved: {}",
+                    resolved.display()
+                ));
+            }
+        }
+    }
     Ok(())
+}
+
+fn extract_startup_prompt_paths(
+    pane: &serde_json::Value,
+    pane_name: &str,
+) -> Result<Vec<String>, String> {
+    if let Some(raw) = pane.get("startup_prompts_json") {
+        if let Some(encoded) = raw.as_str() {
+            let parsed: serde_json::Value = serde_json::from_str(encoded).map_err(|err| {
+                format!("pane '{pane_name}' startup_prompts_json is not valid JSON: {err}")
+            })?;
+            let prompts = parsed.as_array().ok_or_else(|| {
+                format!("pane '{pane_name}' startup_prompts_json must decode to an array")
+            })?;
+            return parse_prompt_array(prompts, pane_name);
+        }
+        let prompts = raw.as_array().ok_or_else(|| {
+            format!("pane '{pane_name}' startup_prompts_json must be a JSON string or array")
+        })?;
+        return parse_prompt_array(prompts, pane_name);
+    }
+
+    if let Some(raw) = pane.get("startup_prompts") {
+        let prompts = raw
+            .as_array()
+            .ok_or_else(|| format!("pane '{pane_name}' startup_prompts must be an array"))?;
+        return parse_prompt_array(prompts, pane_name);
+    }
+
+    Ok(Vec::new())
+}
+
+fn parse_prompt_array(
+    values: &[serde_json::Value],
+    pane_name: &str,
+) -> Result<Vec<String>, String> {
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        let prompt = value
+            .as_str()
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .ok_or_else(|| {
+                format!("pane '{pane_name}' startup prompts must be non-empty strings")
+            })?;
+        out.push(prompt.to_string());
+    }
+    Ok(out)
 }
 
 async fn fetch_preferred_crew_variant_binding(
@@ -2141,13 +2233,6 @@ fn map_discovery_members(
     panes: &[crate::tmux::PaneInfo],
     intents: &[ImportDiscoveryMemberIntent],
 ) -> Result<Vec<definition_writer::CrewMemberInput>, (StatusCode, Json<ErrorResponse>)> {
-    if intents.is_empty() {
-        return Err(bad_request(
-            "missing_member_intents",
-            "member_intents is required and must map each discovered pane".to_string(),
-        ));
-    }
-
     let mut intent_by_pane: HashMap<String, &ImportDiscoveryMemberIntent> = HashMap::new();
     for intent in intents {
         let pane_name = intent.pane_name.trim().to_string();
@@ -2175,51 +2260,92 @@ fn map_discovery_members(
     }
 
     let mut members = Vec::with_capacity(panes.len());
-    for pane in panes {
-        let intent = intent_by_pane.get(&pane.name).ok_or_else(|| {
+    let mut used_member_ids = HashSet::new();
+    for (idx, pane) in panes.iter().enumerate() {
+        if let Some(intent) = intent_by_pane.get(&pane.name) {
+            let startup_prompts_json =
+                serde_json::to_string(&intent.startup_prompts).map_err(|_| {
+                    bad_request(
+                        "invalid_startup_prompts",
+                        format!(
+                            "startup_prompts for pane '{}' could not be serialized",
+                            pane.name
+                        ),
+                    )
+                })?;
+            if intent.member_id.trim().is_empty()
+                || intent.role.trim().is_empty()
+                || intent.ai_provider.trim().is_empty()
+                || intent.model.trim().is_empty()
+            {
+                return Err(bad_request(
+                    "invalid_member_intent",
+                    format!(
+                        "member intent for pane '{}' must include member_id, role, ai_provider, and model",
+                        pane.name
+                    ),
+                ));
+            }
+
+            let member_id = intent.member_id.trim().to_string();
+            if !used_member_ids.insert(member_id.clone()) {
+                return Err(bad_request(
+                    "duplicate_member_id",
+                    format!("duplicate member_id '{}' in import payload", member_id),
+                ));
+            }
+
+            members.push(definition_writer::CrewMemberInput {
+                member_id,
+                role: intent.role.trim().to_string(),
+                ai_provider: intent.ai_provider.trim().to_string(),
+                model: intent.model.trim().to_string(),
+                startup_prompts_json,
+            });
+            continue;
+        }
+
+        let stub_member_id = next_stub_member_id(&pane.name, idx, &mut used_member_ids);
+        let startup_prompts_json = serde_json::to_string(&vec![
+            "TODO: map startup prompt for imported pane".to_string(),
+        ])
+        .map_err(|_| {
             bad_request(
-                "missing_member_intent",
+                "invalid_startup_prompts",
                 format!(
-                    "no member intent provided for discovered pane '{}'",
+                    "startup_prompts for pane '{}' could not be serialized",
                     pane.name
                 ),
             )
         })?;
-
-        let startup_prompts_json =
-            serde_json::to_string(&intent.startup_prompts).map_err(|_| {
-                bad_request(
-                    "invalid_startup_prompts",
-                    format!(
-                        "startup_prompts for pane '{}' could not be serialized",
-                        pane.name
-                    ),
-                )
-            })?;
-        if intent.member_id.trim().is_empty()
-            || intent.role.trim().is_empty()
-            || intent.ai_provider.trim().is_empty()
-            || intent.model.trim().is_empty()
-        {
-            return Err(bad_request(
-                "invalid_member_intent",
-                format!(
-                    "member intent for pane '{}' must include member_id, role, ai_provider, and model",
-                    pane.name
-                ),
-            ));
-        }
-
         members.push(definition_writer::CrewMemberInput {
-            member_id: intent.member_id.trim().to_string(),
-            role: intent.role.trim().to_string(),
-            ai_provider: intent.ai_provider.trim().to_string(),
-            model: intent.model.trim().to_string(),
+            member_id: stub_member_id,
+            role: "unknown".to_string(),
+            ai_provider: "unknown".to_string(),
+            model: "unknown".to_string(),
             startup_prompts_json,
         });
     }
 
     Ok(members)
+}
+
+fn next_stub_member_id(pane_name: &str, pane_index: usize, used: &mut HashSet<String>) -> String {
+    let base = sanitize_identifier(pane_name);
+    let prefix = if base.is_empty() { "pane" } else { &base };
+    let mut candidate = format!("unmapped-{prefix}");
+    if used.insert(candidate.clone()) {
+        return candidate;
+    }
+
+    let mut counter = pane_index + 1;
+    loop {
+        candidate = format!("unmapped-{prefix}-{counter}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        counter += 1;
+    }
 }
 
 fn extract_shutdown_targets(config_json: &str) -> Vec<ShutdownTarget> {

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -8,9 +8,10 @@ use axum::{
 };
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 use tower_http::cors::CorsLayer;
 
 use crate::atm::ShutdownTarget;
@@ -69,6 +70,7 @@ const REACT_JS: &[u8] = include_bytes!("../assets/react.min.js");
 const REACT_DOM_JS: &[u8] = include_bytes!("../assets/react-dom.min.js");
 const DEFAULT_POLL_INTERVAL_SECS: u64 = 15;
 const DEFAULT_STOP_GRACE_SECS: u64 = 10;
+static SESSION_ACTIONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 #[derive(Serialize)]
 struct HealthResponse {
@@ -373,6 +375,19 @@ struct DashboardConfigResponse {
     hosts: Vec<HostSummary>,
     default_terminal: String,
     poll_interval_ms: u64,
+}
+
+struct SessionActionLease {
+    session_name: String,
+}
+
+impl Drop for SessionActionLease {
+    fn drop(&mut self) {
+        let lock = SESSION_ACTIONS.get_or_init(|| Mutex::new(HashSet::new()));
+        if let Ok(mut held) = lock.lock() {
+            held.remove(&self.session_name);
+        }
+    }
 }
 
 async fn serve_dashboard_asset(
@@ -736,6 +751,7 @@ async fn start_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let _action_lease = acquire_session_action(&name, "start")?;
     let definition = {
         let state = Arc::clone(&state);
         let name = name.clone();
@@ -799,6 +815,7 @@ async fn stop_session(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let _action_lease = acquire_session_action(&name, "stop")?;
     let definition = {
         let state = Arc::clone(&state);
         let name = name.clone();
@@ -1298,9 +1315,11 @@ async fn patch_crew_bundle(
     Path(id): Path<i64>,
     Json(req): Json<PatchCrewBundleRequest>,
 ) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let mut _roster_action_lease: Option<SessionActionLease> = None;
     let editing_roster = req.members.is_some() || req.variants.is_some();
     if editing_roster {
         if let Some(crew_name) = fetch_crew_name(Arc::clone(&state), id).await? {
+            _roster_action_lease = Some(acquire_session_action(&crew_name, "edit crew roster")?);
             let is_running = {
                 let runtime = state.runtime.lock().expect("runtime lock");
                 runtime
@@ -1657,6 +1676,31 @@ fn from_atm_runtime(entry: AtmRuntimeSummary) -> SessionAtmSummary {
         state: entry.state,
         last_transition: entry.last_transition,
     }
+}
+
+fn acquire_session_action(
+    session_name: &str,
+    action: &str,
+) -> Result<SessionActionLease, (StatusCode, Json<ErrorResponse>)> {
+    let key = session_name.trim().to_string();
+    let lock = SESSION_ACTIONS.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut held = lock
+        .lock()
+        .map_err(|_| internal_error("failed to lock session action map".to_string()))?;
+    if held.contains(&key) {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                ok: false,
+                code: "action_in_progress".to_string(),
+                message: format!(
+                    "cannot {action} session '{session_name}': another lifecycle action is in progress"
+                ),
+            }),
+        ));
+    }
+    held.insert(key.clone());
+    Ok(SessionActionLease { session_name: key })
 }
 
 fn validate_start_config(config_json: &str, name: &str) -> Result<(), String> {

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -8,8 +8,8 @@ use axum::{
 };
 use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::path::PathBuf;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path as FsPath, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, OnceLock};
 use tower_http::cors::CorsLayer;
@@ -34,6 +34,11 @@ pub fn router(state: Arc<AppState>) -> Router {
         )
         .route("/dashboard-config.json", get(get_dashboard_config))
         .route("/discovery", get(get_discovery))
+        .route("/runtime/crews", get(list_runtime_crews))
+        .route(
+            "/runtime/discovery/unregistered",
+            get(get_unregistered_discovery),
+        )
         .route("/sessions", get(list_sessions).post(create_session))
         .route(
             "/sessions/:name",
@@ -59,6 +64,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/editor/crews/:id/clone", post(clone_crew_bundle))
         .route("/editor/crew-refs/:id/move", post(move_crew_ref))
         .route("/editor/crew-refs/:id", delete(unlink_crew_ref))
+        .route("/editor/import-discovery", post(import_discovery_session))
         .layer(CorsLayer::permissive())
         .layer(from_fn_with_state(middleware_state, touch_last_api_access))
         .with_state(state)
@@ -305,6 +311,54 @@ struct MoveCrewRefRequest {
     fleet_id: i64,
     flotilla_id: Option<i64>,
     alias_name: Option<Option<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportDiscoveryRequest {
+    session_name: String,
+    crew_name: Option<String>,
+    crew_ulid: Option<String>,
+    armada_id: i64,
+    fleet_id: i64,
+    flotilla_id: Option<i64>,
+    alias_name: Option<String>,
+    host_id: Option<i64>,
+    repo_url: Option<String>,
+    branch_ref: Option<String>,
+    root_path: String,
+    member_intents: Vec<ImportDiscoveryMemberIntent>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ImportDiscoveryMemberIntent {
+    pane_name: String,
+    member_id: String,
+    role: String,
+    ai_provider: String,
+    model: String,
+    startup_prompts: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RuntimeCrewSummary {
+    crew_id: i64,
+    crew_name: String,
+    crew_ulid: String,
+    host_id: i64,
+    root_path: String,
+    repo_url: Option<String>,
+    branch_ref: Option<String>,
+    status: String,
+    discovered: bool,
+    pane_count: usize,
+    binding_valid: bool,
+    binding_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CrewVariantBinding {
+    host_id: i64,
+    root_path: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -783,6 +837,13 @@ async fn start_session(
                 message,
             }),
         ));
+    }
+    if let Some(binding) = fetch_preferred_crew_variant_binding(Arc::clone(&state), &name).await? {
+        if let Err(message) = validate_crew_variant_binding(&binding, state.host_id) {
+            return Err(bad_request("invalid_crew_variant_binding", message));
+        }
+    } else if let Err(message) = validate_config_root_path_binding(&definition.config_json) {
+        return Err(bad_request("invalid_crew_variant_binding", message));
     }
 
     {
@@ -1619,6 +1680,229 @@ async fn get_discovery(
     Json(rows)
 }
 
+async fn get_unregistered_discovery(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<crate::runtime::DiscoverySession>>, (StatusCode, Json<ErrorResponse>)> {
+    let discovery_rows = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        runtime.discovery_rows()
+    };
+    let registered_names = tokio::task::spawn_blocking({
+        let state = Arc::clone(&state);
+        move || -> anyhow::Result<HashSet<String>> {
+            let db_conn = state.db.lock().expect("db lock");
+            let mut names = HashSet::new();
+
+            let mut crew_stmt = db_conn.prepare("SELECT crew_name FROM crews")?;
+            let crew_rows = crew_stmt.query_map([], |r| r.get::<_, String>(0))?;
+            for name in crew_rows.collect::<rusqlite::Result<Vec<_>>>()? {
+                names.insert(name);
+            }
+
+            let mut session_stmt =
+                db_conn.prepare("SELECT name FROM sessions WHERE enabled = 1")?;
+            let session_rows = session_stmt.query_map([], |r| r.get::<_, String>(0))?;
+            for name in session_rows.collect::<rusqlite::Result<Vec<_>>>()? {
+                names.insert(name);
+            }
+
+            Ok(names)
+        }
+    })
+    .await
+    .map_err(|_| internal_error("failed to join get_unregistered_discovery task".to_string()))?
+    .map_err(|err| internal_error(format!("failed to list registered crews: {err}")))?;
+
+    let rows = discovery_rows
+        .into_iter()
+        .filter(|row| !registered_names.contains(&row.name))
+        .collect::<Vec<_>>();
+    Ok(Json(rows))
+}
+
+async fn list_runtime_crews(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<RuntimeCrewSummary>>, (StatusCode, Json<ErrorResponse>)> {
+    #[derive(Debug)]
+    struct CrewVariantRow {
+        crew_id: i64,
+        crew_name: String,
+        crew_ulid: String,
+        host_id: i64,
+        repo_url: Option<String>,
+        branch_ref: Option<String>,
+        root_path: String,
+    }
+
+    let variant_rows = tokio::task::spawn_blocking({
+        let state = Arc::clone(&state);
+        move || -> anyhow::Result<Vec<CrewVariantRow>> {
+            let db_conn = state.db.lock().expect("db lock");
+            let mut stmt = db_conn.prepare(
+                "SELECT c.id, c.crew_name, c.crew_ulid, cv.host_id, cv.repo_url, cv.branch_ref, cv.root_path
+                 FROM crews c
+                 JOIN crew_variants cv ON cv.crew_id = c.id
+                 ORDER BY c.crew_name, cv.id",
+            )?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(CrewVariantRow {
+                    crew_id: r.get(0)?,
+                    crew_name: r.get(1)?,
+                    crew_ulid: r.get(2)?,
+                    host_id: r.get(3)?,
+                    repo_url: r.get(4)?,
+                    branch_ref: r.get(5)?,
+                    root_path: r.get(6)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>().map_err(anyhow::Error::from)
+        }
+    })
+    .await
+    .map_err(|_| internal_error("failed to join list_runtime_crews task".to_string()))?
+    .map_err(|err| internal_error(format!("failed to list crew variants: {err}")))?;
+
+    let rows = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        let discovery_rows = runtime.discovery_rows();
+        variant_rows
+            .into_iter()
+            .map(|row| {
+                let discovery = discovery_rows
+                    .iter()
+                    .find(|item| item.name == row.crew_name);
+                let status = runtime
+                    .session(&row.crew_name)
+                    .map(|entry| entry.status.clone())
+                    .or_else(|| discovery.map(|item| derive_discovery_status(&item.panes)))
+                    .unwrap_or_else(|| "stopped".to_string());
+                let binding = CrewVariantBinding {
+                    host_id: row.host_id,
+                    root_path: row.root_path.clone(),
+                };
+                let binding_error = validate_crew_variant_binding(&binding, state.host_id).err();
+                RuntimeCrewSummary {
+                    crew_id: row.crew_id,
+                    crew_name: row.crew_name,
+                    crew_ulid: row.crew_ulid,
+                    host_id: row.host_id,
+                    root_path: row.root_path,
+                    repo_url: row.repo_url,
+                    branch_ref: row.branch_ref,
+                    status,
+                    discovered: discovery.is_some(),
+                    pane_count: discovery.map(|item| item.panes.len()).unwrap_or(0),
+                    binding_valid: binding_error.is_none(),
+                    binding_error,
+                }
+            })
+            .collect::<Vec<_>>()
+    };
+
+    Ok(Json(rows))
+}
+
+async fn import_discovery_session(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ImportDiscoveryRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let session_name = req.session_name.trim().to_string();
+    if session_name.is_empty() {
+        return Err(bad_request(
+            "invalid_session_name",
+            "session_name is required".to_string(),
+        ));
+    }
+    let root_path = req.root_path.trim().to_string();
+    if root_path.is_empty() {
+        return Err(bad_request(
+            "invalid_root_path",
+            "root_path is required".to_string(),
+        ));
+    }
+
+    let discovery = {
+        let runtime = state.runtime.lock().expect("runtime lock");
+        runtime.discovery_rows()
+    };
+    let row = discovery
+        .into_iter()
+        .find(|item| item.name == session_name)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    ok: false,
+                    code: "discovery_not_found".to_string(),
+                    message: format!("discovered session '{session_name}' not found"),
+                }),
+            )
+        })?;
+    if row.panes.is_empty() {
+        return Err(bad_request(
+            "empty_discovery_session",
+            "cannot import a discovered session with zero panes".to_string(),
+        ));
+    }
+
+    let host_id = req.host_id.unwrap_or(state.host_id);
+    let crew_name = req
+        .crew_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&session_name)
+        .to_string();
+    let crew_ulid = req
+        .crew_ulid
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| generate_import_crew_ulid(&crew_name));
+
+    let members = map_discovery_members(&row.panes, &req.member_intents)?;
+    let bundle = definition_writer::NewCrewBundle {
+        crew_name: crew_name.clone(),
+        crew_ulid,
+        members,
+        variants: vec![definition_writer::CrewVariantInput {
+            host_id,
+            repo_url: req.repo_url,
+            branch_ref: req.branch_ref,
+            root_path: root_path.clone(),
+            config_json: None,
+        }],
+        placement: definition_writer::CrewPlacementInput {
+            armada_id: req.armada_id,
+            fleet_id: req.fleet_id,
+            flotilla_id: req.flotilla_id,
+            alias_name: req.alias_name,
+        },
+    };
+
+    let created = tokio::task::spawn_blocking({
+        let state = Arc::clone(&state);
+        move || {
+            let db_conn = state.db.lock().expect("db lock");
+            definition_writer::create_crew_bundle(&db_conn, &bundle)
+        }
+    })
+    .await
+    .map_err(|_| internal_error("failed to join import_discovery_session task".to_string()))?;
+
+    match created {
+        Ok(crew_id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!(
+                "imported discovered session '{}' into crew '{}' (id={})",
+                session_name, crew_name, crew_id
+            ),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
 async fn fetch_hosts(state: Arc<AppState>) -> anyhow::Result<Vec<HostSummary>> {
     let reachability = {
         let map = state.reachability.lock().expect("reachability lock");
@@ -1723,6 +2007,221 @@ fn validate_start_config(config_json: &str, name: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_config_root_path_binding(config_json: &str) -> Result<(), String> {
+    let value: serde_json::Value = serde_json::from_str(config_json)
+        .map_err(|err| format!("config_json is not valid JSON: {err}"))?;
+    let root_path = value
+        .get("root_path")
+        .and_then(|raw| raw.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            "config_json.root_path is required when no crew variant binding is defined".to_string()
+        })?;
+    let path = FsPath::new(root_path);
+    if !path.exists() {
+        return Err(format!("config_json.root_path does not exist: {root_path}"));
+    }
+    if !path.is_dir() {
+        return Err(format!(
+            "config_json.root_path is not a directory: {root_path}"
+        ));
+    }
+    Ok(())
+}
+
+async fn fetch_preferred_crew_variant_binding(
+    state: Arc<AppState>,
+    crew_name: &str,
+) -> Result<Option<CrewVariantBinding>, (StatusCode, Json<ErrorResponse>)> {
+    let crew_name = crew_name.to_string();
+    let host_id = state.host_id;
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT cv.host_id, cv.root_path
+                 FROM crews c
+                 JOIN crew_variants cv ON cv.crew_id = c.id
+                 WHERE c.crew_name = ?1
+                 ORDER BY CASE WHEN cv.host_id = ?2 THEN 0 ELSE 1 END, cv.id
+                 LIMIT 1",
+                rusqlite::params![crew_name, host_id],
+                |r| {
+                    Ok(CrewVariantBinding {
+                        host_id: r.get(0)?,
+                        root_path: r.get(1)?,
+                    })
+                },
+            )
+            .optional()
+    })
+    .await
+    .map_err(|_| {
+        internal_error("failed to join fetch_preferred_crew_variant_binding task".to_string())
+    })?;
+
+    result.map_err(|_| internal_error("failed to read crew variant binding".to_string()))
+}
+
+fn validate_crew_variant_binding(
+    binding: &CrewVariantBinding,
+    daemon_host_id: i64,
+) -> Result<(), String> {
+    if binding.host_id != daemon_host_id {
+        return Err(format!(
+            "crew variant host_id {} does not match local daemon host_id {}",
+            binding.host_id, daemon_host_id
+        ));
+    }
+    let root_path = binding.root_path.trim();
+    if root_path.is_empty() {
+        return Err("crew variant root_path is required".to_string());
+    }
+    let path = FsPath::new(root_path);
+    if !path.exists() {
+        return Err(format!(
+            "crew variant root_path does not exist: {root_path}"
+        ));
+    }
+    if !path.is_dir() {
+        return Err(format!(
+            "crew variant root_path is not a directory: {root_path}"
+        ));
+    }
+    Ok(())
+}
+
+fn derive_discovery_status(panes: &[crate::tmux::PaneInfo]) -> String {
+    if panes.is_empty() {
+        return "stopped".to_string();
+    }
+    let any_active = panes.iter().any(|pane| {
+        matches!(
+            pane.status.to_ascii_lowercase().as_str(),
+            "active" | "running" | "stuck"
+        )
+    });
+    if any_active {
+        "running".to_string()
+    } else {
+        "idle".to_string()
+    }
+}
+
+fn generate_import_crew_ulid(crew_name: &str) -> String {
+    let suffix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let label = sanitize_identifier(crew_name);
+    format!(
+        "import-{}-{}",
+        if label.is_empty() { "crew" } else { &label },
+        suffix
+    )
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_dash = false;
+        } else if !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+fn map_discovery_members(
+    panes: &[crate::tmux::PaneInfo],
+    intents: &[ImportDiscoveryMemberIntent],
+) -> Result<Vec<definition_writer::CrewMemberInput>, (StatusCode, Json<ErrorResponse>)> {
+    if intents.is_empty() {
+        return Err(bad_request(
+            "missing_member_intents",
+            "member_intents is required and must map each discovered pane".to_string(),
+        ));
+    }
+
+    let mut intent_by_pane: HashMap<String, &ImportDiscoveryMemberIntent> = HashMap::new();
+    for intent in intents {
+        let pane_name = intent.pane_name.trim().to_string();
+        if pane_name.is_empty() {
+            return Err(bad_request(
+                "invalid_member_intent",
+                "member_intents[].pane_name is required".to_string(),
+            ));
+        }
+        if intent.startup_prompts.is_empty() {
+            return Err(bad_request(
+                "invalid_startup_prompts",
+                format!(
+                    "member intent for pane '{}' must include startup_prompts",
+                    pane_name
+                ),
+            ));
+        }
+        if intent_by_pane.insert(pane_name.clone(), intent).is_some() {
+            return Err(bad_request(
+                "duplicate_member_intent",
+                format!("duplicate member intent for pane '{}'", pane_name),
+            ));
+        }
+    }
+
+    let mut members = Vec::with_capacity(panes.len());
+    for pane in panes {
+        let intent = intent_by_pane.get(&pane.name).ok_or_else(|| {
+            bad_request(
+                "missing_member_intent",
+                format!(
+                    "no member intent provided for discovered pane '{}'",
+                    pane.name
+                ),
+            )
+        })?;
+
+        let startup_prompts_json =
+            serde_json::to_string(&intent.startup_prompts).map_err(|_| {
+                bad_request(
+                    "invalid_startup_prompts",
+                    format!(
+                        "startup_prompts for pane '{}' could not be serialized",
+                        pane.name
+                    ),
+                )
+            })?;
+        if intent.member_id.trim().is_empty()
+            || intent.role.trim().is_empty()
+            || intent.ai_provider.trim().is_empty()
+            || intent.model.trim().is_empty()
+        {
+            return Err(bad_request(
+                "invalid_member_intent",
+                format!(
+                    "member intent for pane '{}' must include member_id, role, ai_provider, and model",
+                    pane.name
+                ),
+            ));
+        }
+
+        members.push(definition_writer::CrewMemberInput {
+            member_id: intent.member_id.trim().to_string(),
+            role: intent.role.trim().to_string(),
+            ai_provider: intent.ai_provider.trim().to_string(),
+            model: intent.model.trim().to_string(),
+            startup_prompts_json,
+        });
+    }
+
+    Ok(members)
+}
+
 fn extract_shutdown_targets(config_json: &str) -> Vec<ShutdownTarget> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(config_json) else {
         return Vec::new();
@@ -1769,6 +2268,13 @@ fn map_member_payload(
 fn map_variant_payload(
     payload: &CrewVariantPayload,
 ) -> Result<definition_writer::CrewVariantInput, (StatusCode, Json<ErrorResponse>)> {
+    if payload.root_path.trim().is_empty() {
+        return Err(bad_request(
+            "invalid_root_path",
+            "root_path is required".to_string(),
+        ));
+    }
+
     let config_json = payload
         .config_json
         .as_ref()

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -3,9 +3,10 @@ use axum::{
     http::{header, StatusCode},
     middleware::{from_fn_with_state, Next},
     response::{IntoResponse, Json, Response},
-    routing::{get, post},
+    routing::{delete, get, post},
     Router,
 };
+use rusqlite::OptionalExtension;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -40,6 +41,21 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/sessions/:name/start", post(start_session))
         .route("/sessions/:name/stop", post(stop_session))
         .route("/sessions/:name/jump", post(jump_session))
+        .route("/editor/state", get(get_editor_state))
+        .route("/editor/armadas", post(create_armada))
+        .route("/editor/armadas/:id", axum::routing::patch(patch_armada))
+        .route("/editor/fleets", post(create_fleet))
+        .route("/editor/fleets/:id", axum::routing::patch(patch_fleet))
+        .route("/editor/flotillas", post(create_flotilla))
+        .route(
+            "/editor/flotillas/:id",
+            axum::routing::patch(patch_flotilla),
+        )
+        .route("/editor/crews", post(create_crew_bundle))
+        .route("/editor/crews/:id", axum::routing::patch(patch_crew_bundle))
+        .route("/editor/crews/:id/clone", post(clone_crew_bundle))
+        .route("/editor/crew-refs/:id/move", post(move_crew_ref))
+        .route("/editor/crew-refs/:id", delete(unlink_crew_ref))
         .layer(CorsLayer::permissive())
         .layer(from_fn_with_state(middleware_state, touch_last_api_access))
         .with_state(state)
@@ -176,6 +192,151 @@ struct PatchHostRequest {
     address: Option<String>,
     ssh_user: Option<Option<String>>,
     api_port: Option<u16>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateArmadaRequest {
+    name: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchArmadaRequest {
+    name: Option<String>,
+    description: Option<Option<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateFleetRequest {
+    armada_id: i64,
+    name: String,
+    color: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchFleetRequest {
+    armada_id: Option<i64>,
+    name: Option<String>,
+    color: Option<Option<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateFlotillaRequest {
+    fleet_id: i64,
+    name: String,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchFlotillaRequest {
+    fleet_id: Option<i64>,
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CrewMemberPayload {
+    member_id: String,
+    role: String,
+    ai_provider: String,
+    model: String,
+    startup_prompts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CrewVariantPayload {
+    host_id: i64,
+    repo_url: Option<String>,
+    branch_ref: Option<String>,
+    root_path: String,
+    config_json: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CrewPlacementPayload {
+    armada_id: i64,
+    fleet_id: i64,
+    flotilla_id: Option<i64>,
+    alias_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateCrewBundleRequest {
+    crew_name: String,
+    crew_ulid: String,
+    members: Vec<CrewMemberPayload>,
+    variants: Vec<CrewVariantPayload>,
+    placement: CrewPlacementPayload,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PatchCrewBundleRequest {
+    crew_ulid: Option<String>,
+    members: Option<Vec<CrewMemberPayload>>,
+    variants: Option<Vec<CrewVariantPayload>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CloneCrewBundleRequest {
+    crew_name: String,
+    crew_ulid: String,
+    placement: CrewPlacementPayload,
+}
+
+#[derive(Debug, Deserialize)]
+struct MoveCrewRefRequest {
+    armada_id: i64,
+    fleet_id: i64,
+    flotilla_id: Option<i64>,
+    alias_name: Option<Option<String>>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorStateResponse {
+    armadas: Vec<EditorArmada>,
+    fleets: Vec<EditorFleet>,
+    flotillas: Vec<EditorFlotilla>,
+    crews: Vec<EditorCrew>,
+    crew_refs: Vec<EditorCrewRef>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorArmada {
+    id: i64,
+    name: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorFleet {
+    id: i64,
+    armada_id: i64,
+    name: String,
+    color: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorFlotilla {
+    id: i64,
+    fleet_id: i64,
+    name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorCrew {
+    id: i64,
+    crew_name: String,
+    crew_ulid: String,
+    member_count: i64,
+    variant_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct EditorCrewRef {
+    id: i64,
+    crew_id: i64,
+    armada_id: i64,
+    fleet_id: i64,
+    flotilla_id: Option<i64>,
+    alias_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -850,6 +1011,484 @@ async fn delete_host(
     }
 }
 
+async fn create_armada(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateArmadaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let armada = definition_writer::NewArmada {
+        name: req.name.clone(),
+        description: req.description,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_armada(&db_conn, &armada)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_armada task".to_string()))?;
+
+    match result {
+        Ok(id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("armada '{id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_armada(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchArmadaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::ArmadaPatch {
+        name: req.name,
+        description: req.description,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_armada(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_armada task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("armada '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("armada '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn create_fleet(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateFleetRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let fleet = definition_writer::NewFleet {
+        armada_id: req.armada_id,
+        name: req.name.clone(),
+        color: req.color,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_fleet(&db_conn, &fleet)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_fleet task".to_string()))?;
+
+    match result {
+        Ok(id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("fleet '{id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_fleet(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchFleetRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::FleetPatch {
+        armada_id: req.armada_id,
+        name: req.name,
+        color: req.color,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_fleet(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_fleet task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("fleet '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("fleet '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn create_flotilla(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateFlotillaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let flotilla = definition_writer::NewFlotilla {
+        fleet_id: req.fleet_id,
+        name: req.name.clone(),
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_flotilla(&db_conn, &flotilla)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_flotilla task".to_string()))?;
+
+    match result {
+        Ok(id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("flotilla '{id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_flotilla(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchFlotillaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::FlotillaPatch {
+        fleet_id: req.fleet_id,
+        name: req.name,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_flotilla(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_flotilla task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("flotilla '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("flotilla '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn create_crew_bundle(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateCrewBundleRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let members = req
+        .members
+        .iter()
+        .map(map_member_payload)
+        .collect::<Result<Vec<_>, _>>()?;
+    let variants = req
+        .variants
+        .iter()
+        .map(map_variant_payload)
+        .collect::<Result<Vec<_>, _>>()?;
+    let placement = map_placement_payload(&req.placement);
+
+    let bundle = definition_writer::NewCrewBundle {
+        crew_name: req.crew_name,
+        crew_ulid: req.crew_ulid,
+        members,
+        variants,
+        placement,
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::create_crew_bundle(&db_conn, &bundle)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join create_crew_bundle task".to_string()))?;
+
+    match result {
+        Ok(crew_id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew '{crew_id}' created"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn patch_crew_bundle(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<PatchCrewBundleRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let editing_roster = req.members.is_some() || req.variants.is_some();
+    if editing_roster {
+        if let Some(crew_name) = fetch_crew_name(Arc::clone(&state), id).await? {
+            let live = tmux::live_sessions().await.unwrap_or_default();
+            if live.contains_key(&crew_name) {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(ErrorResponse {
+                        ok: false,
+                        code: "running_edit_forbidden".to_string(),
+                        message: "running crew roster/prompt edits are not allowed".to_string(),
+                    }),
+                ));
+            }
+        }
+    }
+
+    let members = req
+        .members
+        .as_ref()
+        .map(|items| {
+            items
+                .iter()
+                .map(map_member_payload)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+    let variants = req
+        .variants
+        .as_ref()
+        .map(|items| {
+            items
+                .iter()
+                .map(map_variant_payload)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+
+    let patch = definition_writer::CrewBundlePatch {
+        crew_ulid: req.crew_ulid,
+        members,
+        variants,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::patch_crew_bundle(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join patch_crew_bundle task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew '{id}' updated"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("crew '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn clone_crew_bundle(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<CloneCrewBundleRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let request = definition_writer::CloneCrewRequest {
+        crew_name: req.crew_name,
+        crew_ulid: req.crew_ulid,
+        placement: map_placement_payload(&req.placement),
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::clone_crew(&db_conn, id, &request)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join clone_crew_bundle task".to_string()))?;
+
+    match result {
+        Ok(new_id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew cloned to '{new_id}'"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn move_crew_ref(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<MoveCrewRefRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let patch = definition_writer::MoveCrewRefPatch {
+        armada_id: req.armada_id,
+        fleet_id: req.fleet_id,
+        flotilla_id: req.flotilla_id,
+        alias_name: req.alias_name,
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::move_crew_ref(&db_conn, id, &patch)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join move_crew_ref task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew ref '{id}' moved"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("crew ref '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn unlink_crew_ref(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::unlink_crew_ref(&db_conn, id)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join unlink_crew_ref task".to_string()))?;
+
+    match result {
+        Ok(true) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("crew ref '{id}' unlinked"),
+        })),
+        Ok(false) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                ok: false,
+                code: "not_found".to_string(),
+                message: format!("crew ref '{id}' not found"),
+            }),
+        )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn get_editor_state(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<EditorStateResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let result = tokio::task::spawn_blocking(move || -> anyhow::Result<EditorStateResponse> {
+        let db_conn = state.db.lock().expect("db lock");
+
+        let armadas = {
+            let mut stmt =
+                db_conn.prepare("SELECT id, name, description FROM armadas ORDER BY name")?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorArmada {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    description: r.get(2)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let fleets = {
+            let mut stmt =
+                db_conn.prepare("SELECT id, armada_id, name, color FROM fleets ORDER BY name")?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorFleet {
+                    id: r.get(0)?,
+                    armada_id: r.get(1)?,
+                    name: r.get(2)?,
+                    color: r.get(3)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let flotillas = {
+            let mut stmt = db_conn.prepare("SELECT id, fleet_id, name FROM flotillas ORDER BY name")?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorFlotilla {
+                    id: r.get(0)?,
+                    fleet_id: r.get(1)?,
+                    name: r.get(2)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let crews = {
+            let mut stmt = db_conn.prepare(
+                "SELECT c.id, c.crew_name, c.crew_ulid,
+                        (SELECT COUNT(*) FROM crew_members cm WHERE cm.crew_id = c.id) AS member_count,
+                        (SELECT COUNT(*) FROM crew_variants cv WHERE cv.crew_id = c.id) AS variant_count
+                 FROM crews c
+                 ORDER BY c.crew_name",
+            )?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorCrew {
+                    id: r.get(0)?,
+                    crew_name: r.get(1)?,
+                    crew_ulid: r.get(2)?,
+                    member_count: r.get(3)?,
+                    variant_count: r.get(4)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        let crew_refs = {
+            let mut stmt = db_conn.prepare(
+                "SELECT id, crew_id, armada_id, fleet_id, flotilla_id, alias_name
+                 FROM crew_refs
+                 ORDER BY armada_id, fleet_id, id",
+            )?;
+            let mapped = stmt.query_map([], |r| {
+                Ok(EditorCrewRef {
+                    id: r.get(0)?,
+                    crew_id: r.get(1)?,
+                    armada_id: r.get(2)?,
+                    fleet_id: r.get(3)?,
+                    flotilla_id: r.get(4)?,
+                    alias_name: r.get(5)?,
+                })
+            })?;
+            mapped.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+
+        Ok(EditorStateResponse {
+            armadas,
+            fleets,
+            flotillas,
+            crews,
+            crew_refs,
+        })
+    })
+    .await
+    .map_err(|_| internal_error("failed to join get_editor_state task".to_string()))?;
+
+    match result {
+        Ok(body) => Ok(Json(body)),
+        Err(err) => Err(internal_error(format!(
+            "failed to load editor state: {err}"
+        ))),
+    }
+}
+
 async fn get_dashboard_config(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<DashboardConfigResponse>, (StatusCode, Json<ErrorResponse>)> {
@@ -984,6 +1623,77 @@ fn extract_shutdown_targets(config_json: &str) -> Vec<ShutdownTarget> {
             })
         })
         .collect::<Vec<_>>()
+}
+
+fn map_member_payload(
+    payload: &CrewMemberPayload,
+) -> Result<definition_writer::CrewMemberInput, (StatusCode, Json<ErrorResponse>)> {
+    let startup_prompts_json = serde_json::to_string(&payload.startup_prompts).map_err(|_| {
+        bad_request(
+            "invalid_startup_prompts",
+            "startup_prompts could not be serialized".to_string(),
+        )
+    })?;
+
+    Ok(definition_writer::CrewMemberInput {
+        member_id: payload.member_id.clone(),
+        role: payload.role.clone(),
+        ai_provider: payload.ai_provider.clone(),
+        model: payload.model.clone(),
+        startup_prompts_json,
+    })
+}
+
+fn map_variant_payload(
+    payload: &CrewVariantPayload,
+) -> Result<definition_writer::CrewVariantInput, (StatusCode, Json<ErrorResponse>)> {
+    let config_json = payload
+        .config_json
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|_| {
+            bad_request(
+                "invalid_variant_config",
+                "invalid variant config_json".to_string(),
+            )
+        })?;
+
+    Ok(definition_writer::CrewVariantInput {
+        host_id: payload.host_id,
+        repo_url: payload.repo_url.clone(),
+        branch_ref: payload.branch_ref.clone(),
+        root_path: payload.root_path.clone(),
+        config_json,
+    })
+}
+
+fn map_placement_payload(payload: &CrewPlacementPayload) -> definition_writer::CrewPlacementInput {
+    definition_writer::CrewPlacementInput {
+        armada_id: payload.armada_id,
+        fleet_id: payload.fleet_id,
+        flotilla_id: payload.flotilla_id,
+        alias_name: payload.alias_name.clone(),
+    }
+}
+
+async fn fetch_crew_name(
+    state: Arc<AppState>,
+    crew_id: i64,
+) -> Result<Option<String>, (StatusCode, Json<ErrorResponse>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT crew_name FROM crews WHERE id = ?1",
+                rusqlite::params![crew_id],
+                |r| r.get::<_, String>(0),
+            )
+            .optional()
+    })
+    .await
+    .map_err(|_| internal_error("failed to join fetch_crew_name task".to_string()))?;
+    result.map_err(|_| internal_error("failed to read crew name".to_string()))
 }
 
 fn map_write_error(err: definition_writer::WriteError) -> (StatusCode, Json<ErrorResponse>) {

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -44,8 +44,10 @@ pub fn router(state: Arc<AppState>) -> Router {
         .route("/editor/state", get(get_editor_state))
         .route("/editor/armadas", post(create_armada))
         .route("/editor/armadas/:id", axum::routing::patch(patch_armada))
+        .route("/editor/armadas/:id/clone", post(clone_armada))
         .route("/editor/fleets", post(create_fleet))
         .route("/editor/fleets/:id", axum::routing::patch(patch_fleet))
+        .route("/editor/fleets/:id/clone", post(clone_fleet))
         .route("/editor/flotillas", post(create_flotilla))
         .route(
             "/editor/flotillas/:id",
@@ -207,6 +209,12 @@ struct PatchArmadaRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct CloneArmadaRequest {
+    name: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct CreateFleetRequest {
     armada_id: i64,
     name: String,
@@ -218,6 +226,13 @@ struct PatchFleetRequest {
     armada_id: Option<i64>,
     name: Option<String>,
     color: Option<Option<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CloneFleetRequest {
+    armada_id: Option<i64>,
+    name: String,
+    color: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1068,6 +1083,31 @@ async fn patch_armada(
     }
 }
 
+async fn clone_armada(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<CloneArmadaRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let request = definition_writer::CloneArmadaRequest {
+        name: req.name,
+        description: req.description,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::clone_armada(&db_conn, id, &request)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join clone_armada task".to_string()))?;
+
+    match result {
+        Ok(clone_id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("armada cloned to '{clone_id}'"),
+        })),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
 async fn create_fleet(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateFleetRequest>,
@@ -1123,6 +1163,32 @@ async fn patch_fleet(
                 message: format!("fleet '{id}' not found"),
             }),
         )),
+        Err(err) => Err(map_write_error(err)),
+    }
+}
+
+async fn clone_fleet(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<i64>,
+    Json(req): Json<CloneFleetRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let request = definition_writer::CloneFleetRequest {
+        armada_id: req.armada_id,
+        name: req.name,
+        color: req.color,
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let db_conn = state.db.lock().expect("db lock");
+        definition_writer::clone_fleet(&db_conn, id, &request)
+    })
+    .await
+    .map_err(|_| internal_error("failed to join clone_fleet task".to_string()))?;
+
+    match result {
+        Ok(clone_id) => Ok(Json(ActionResponse {
+            ok: true,
+            message: format!("fleet cloned to '{clone_id}'"),
+        })),
         Err(err) => Err(map_write_error(err)),
     }
 }
@@ -1232,8 +1298,17 @@ async fn patch_crew_bundle(
     let editing_roster = req.members.is_some() || req.variants.is_some();
     if editing_roster {
         if let Some(crew_name) = fetch_crew_name(Arc::clone(&state), id).await? {
-            let live = tmux::live_sessions().await.unwrap_or_default();
-            if live.contains_key(&crew_name) {
+            let is_running = {
+                let runtime = state.runtime.lock().expect("runtime lock");
+                runtime
+                    .session(&crew_name)
+                    .is_some_and(|entry| entry.status != "stopped")
+                    || runtime
+                        .discovery_rows()
+                        .iter()
+                        .any(|row| row.name == crew_name)
+            };
+            if is_running {
                 return Err((
                     StatusCode::CONFLICT,
                     Json(ErrorResponse {

--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -3,9 +3,7 @@ use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -154,7 +152,6 @@ pub async fn send_shutdown_messages(
     targets: &[ShutdownTarget],
 ) -> anyhow::Result<usize> {
     if !state.config.atm.enabled || !state.config.atm.allow_shutdown {
-        tracing::warn!("ATM send not implemented");
         return Ok(0);
     }
 
@@ -162,61 +159,15 @@ pub async fn send_shutdown_messages(
         return Ok(0);
     }
 
-    let allowed_teams = configured_teams(state).into_iter().collect::<HashSet<_>>();
-    if allowed_teams.is_empty() {
-        tracing::warn!("ATM shutdown skipped: atm.teams allowlist is empty");
-        return Ok(0);
-    }
-
-    let unique = targets
+    let configured_targets = targets
         .iter()
-        .filter(|target| allowed_teams.contains(&target.team))
-        .map(|target| (target.team.clone(), target.agent.clone()))
-        .collect::<HashSet<_>>();
-
-    let mut sent = 0usize;
-    for (team, agent) in unique {
-        let output = tokio::process::Command::new(atm_bin())
-            .arg("send")
-            .arg(&agent)
-            .arg("--team")
-            .arg(&team)
-            .arg("scmux: graceful shutdown requested; please stop current work and exit")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .output()
-            .await;
-
-        match output {
-            Ok(result) if result.status.success() => {
-                sent += 1;
-            }
-            Ok(result) => {
-                let message = String::from_utf8_lossy(&result.stderr).trim().to_string();
-                tracing::warn!(
-                    "atm shutdown message failed team='{}' agent='{}': {}",
-                    team,
-                    agent,
-                    if message.is_empty() {
-                        format!("exit {}", result.status)
-                    } else {
-                        message
-                    }
-                );
-            }
-            Err(err) => {
-                tracing::warn!(
-                    "atm shutdown message execution failed team='{}' agent='{}': {}",
-                    team,
-                    agent,
-                    err
-                );
-            }
-        }
-    }
-
-    Ok(sent)
+        .map(|target| format!("{}@{}", target.agent, target.team))
+        .collect::<Vec<_>>();
+    tracing::warn!(
+        "ATM send not implemented: skipping graceful shutdown send; targets={:?}",
+        configured_targets
+    );
+    Ok(0)
 }
 
 fn resolve_socket_path(state: &AppState) -> PathBuf {
@@ -336,10 +287,6 @@ fn request_id() -> String {
     )
 }
 
-fn atm_bin() -> String {
-    std::env::var("SCMUX_ATM_BIN").unwrap_or_else(|_| "atm".to_string())
-}
-
 #[cfg(unix)]
 async fn query_socket_raw<T: DeserializeOwned>(
     socket_path: &Path,
@@ -387,4 +334,108 @@ async fn query_socket_raw<T: DeserializeOwned>(
     _request_json: &str,
 ) -> anyhow::Result<T> {
     Err(anyhow!("ATM socket IPC is only available on Unix"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AtmConfig, Config, DaemonConfig, PollingConfig};
+    use crate::{ci, db, definition_writer, runtime, AppState, RuntimeHealth, SystemClock};
+    use tempfile::TempDir;
+
+    fn build_state(atm: AtmConfig) -> (TempDir, AppState) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("atm-tests.db");
+        let conn = db::open(db_path.to_str().expect("utf8 path")).expect("open db");
+        let host_id = definition_writer::ensure_local_host(&conn).expect("local host");
+
+        (
+            tmp,
+            AppState {
+                db: std::sync::Mutex::new(conn),
+                db_path: db_path.to_string_lossy().to_string(),
+                host_id,
+                config: Config {
+                    daemon: DaemonConfig {
+                        port: None,
+                        db_path: None,
+                        default_terminal: Some("iterm2".to_string()),
+                        log_level: None,
+                    },
+                    polling: PollingConfig {
+                        tmux_interval_secs: Some(15),
+                        health_interval_secs: Some(60),
+                        ci_active_interval_secs: None,
+                        ci_idle_interval_secs: None,
+                    },
+                    atm,
+                },
+                reachability: std::sync::Mutex::new(std::collections::HashMap::new()),
+                runtime: std::sync::Mutex::new(runtime::RuntimeProjection::default()),
+                ci_tools: ci::ToolAvailability::default(),
+                clock: std::sync::Arc::new(SystemClock),
+                atm_available: std::sync::atomic::AtomicBool::new(false),
+                last_api_access: std::sync::atomic::AtomicU64::new(0),
+                started_at: std::time::Instant::now(),
+                health: std::sync::Mutex::new(RuntimeHealth::default()),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn td_atm_09_shutdown_send_returns_early_when_allow_shutdown_false() {
+        let (_tmp, state) = build_state(AtmConfig {
+            enabled: true,
+            teams: vec!["scmux-dev".to_string()],
+            allow_shutdown: false,
+            socket_path: None,
+            stuck_minutes: Some(10),
+            stop_grace_secs: None,
+        });
+
+        let sent = send_shutdown_messages(
+            &state,
+            &[ShutdownTarget {
+                team: "scmux-dev".to_string(),
+                agent: "team-lead".to_string(),
+            }],
+        )
+        .await
+        .expect("send");
+
+        assert_eq!(sent, 0);
+    }
+
+    #[test]
+    fn td_atm_teams_are_config_only_not_scanned_from_home() {
+        let home = tempfile::tempdir().expect("home");
+        std::fs::create_dir_all(home.path().join(".claude/teams/should-not-load"))
+            .expect("create teams dir");
+        let prev_home = std::env::var("HOME").ok();
+        // SAFETY: test-only env mutation within single test scope.
+        unsafe { std::env::set_var("HOME", home.path()) };
+
+        let (_tmp, state) = build_state(AtmConfig {
+            enabled: true,
+            teams: vec!["scmux-dev".to_string()],
+            allow_shutdown: false,
+            socket_path: None,
+            stuck_minutes: Some(10),
+            stop_grace_secs: None,
+        });
+
+        let teams = configured_teams(&state);
+        assert_eq!(teams, vec!["scmux-dev".to_string()]);
+
+        match prev_home {
+            Some(value) => {
+                // SAFETY: restoring previous test-only env var value.
+                unsafe { std::env::set_var("HOME", value) };
+            }
+            None => {
+                // SAFETY: restoring previous test-only env var absence.
+                unsafe { std::env::remove_var("HOME") };
+            }
+        }
+    }
 }

--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -169,6 +169,27 @@ pub async fn send_shutdown_messages(
     Ok(0)
 }
 
+pub(crate) fn atm_socket_available(state: &AppState) -> bool {
+    if !state.config.atm.enabled {
+        return false;
+    }
+
+    let socket_path = resolve_socket_path(state);
+    if !socket_path.exists() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        std::os::unix::net::UnixStream::connect(&socket_path).is_ok()
+    }
+
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
 fn resolve_socket_path(state: &AppState) -> PathBuf {
     if let Some(path) = state
         .config

--- a/crates/scmux-daemon/src/atm.rs
+++ b/crates/scmux-daemon/src/atm.rs
@@ -158,7 +158,6 @@ pub async fn send_shutdown_messages(
     if targets.is_empty() {
         return Ok(0);
     }
-
     let configured_targets = targets
         .iter()
         .map(|target| format!("{}@{}", target.agent, target.team))

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -204,6 +204,8 @@ pub fn get_host(conn: &Connection, host_id: i64) -> anyhow::Result<Option<HostDe
     Ok(row)
 }
 
+// Persistent write helpers are crate-visible for module organization, but gated by
+// `definition_writer::WriteGuard`, which cannot be constructed outside definition_writer.
 pub(crate) fn create_session(
     _guard: &crate::definition_writer::WriteGuard,
     conn: &Connection,

--- a/crates/scmux-daemon/src/db.rs
+++ b/crates/scmux-daemon/src/db.rs
@@ -463,6 +463,80 @@ fn migrate(conn: &Connection) -> Result<()> {
             UPDATE sessions SET updated_at = datetime('now') WHERE id = OLD.id;
           END;
 
+        CREATE TABLE IF NOT EXISTS armadas (
+            id          INTEGER PRIMARY KEY,
+            name        TEXT NOT NULL UNIQUE,
+            description TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS fleets (
+            id          INTEGER PRIMARY KEY,
+            armada_id   INTEGER NOT NULL REFERENCES armadas(id) ON DELETE CASCADE,
+            name        TEXT NOT NULL,
+            color       TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (armada_id, name)
+        );
+
+        CREATE TABLE IF NOT EXISTS flotillas (
+            id          INTEGER PRIMARY KEY,
+            fleet_id    INTEGER NOT NULL REFERENCES fleets(id) ON DELETE CASCADE,
+            name        TEXT NOT NULL,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (fleet_id, name)
+        );
+
+        CREATE TABLE IF NOT EXISTS crews (
+            id          INTEGER PRIMARY KEY,
+            crew_name   TEXT NOT NULL UNIQUE,
+            crew_ulid   TEXT NOT NULL UNIQUE,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS crew_members (
+            id                   INTEGER PRIMARY KEY,
+            crew_id              INTEGER NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
+            member_id            TEXT NOT NULL,
+            role                 TEXT NOT NULL,
+            ai_provider          TEXT NOT NULL,
+            model                TEXT NOT NULL,
+            startup_prompts_json TEXT NOT NULL,
+            created_at           DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (crew_id, member_id)
+        );
+
+        CREATE TABLE IF NOT EXISTS crew_variants (
+            id          INTEGER PRIMARY KEY,
+            crew_id     INTEGER NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
+            host_id     INTEGER NOT NULL REFERENCES hosts(id) ON DELETE CASCADE,
+            repo_url    TEXT,
+            branch_ref  TEXT,
+            root_path   TEXT NOT NULL,
+            config_json TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (crew_id, host_id, repo_url, branch_ref, root_path)
+        );
+
+        CREATE TABLE IF NOT EXISTS crew_refs (
+            id          INTEGER PRIMARY KEY,
+            crew_id     INTEGER NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
+            armada_id   INTEGER NOT NULL REFERENCES armadas(id) ON DELETE CASCADE,
+            fleet_id    INTEGER NOT NULL REFERENCES fleets(id) ON DELETE CASCADE,
+            flotilla_id INTEGER REFERENCES flotillas(id) ON DELETE SET NULL,
+            alias_name  TEXT,
+            created_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_fleets_armada         ON fleets (armada_id);
+        CREATE INDEX IF NOT EXISTS idx_flotillas_fleet       ON flotillas (fleet_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_members_crew     ON crew_members (crew_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_variants_crew    ON crew_variants (crew_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_crew        ON crew_refs (crew_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_armada      ON crew_refs (armada_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_fleet       ON crew_refs (fleet_id);
+        CREATE INDEX IF NOT EXISTS idx_crew_refs_flotilla    ON crew_refs (flotilla_id);
+
         DROP TABLE IF EXISTS session_status;
         DROP TABLE IF EXISTS session_ci;
         DROP TABLE IF EXISTS session_atm;

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -194,6 +194,7 @@ pub fn ensure_local_host(conn: &Connection) -> Result<i64, WriteError> {
 }
 
 pub fn create_armada(conn: &Connection, armada: &NewArmada) -> Result<i64, WriteError> {
+    let _guard = WriteGuard(());
     conn.execute(
         "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
         params![armada.name, armada.description],
@@ -207,6 +208,7 @@ pub fn patch_armada(
     armada_id: i64,
     patch: &ArmadaPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM armadas WHERE id = ?1",
@@ -256,6 +258,7 @@ pub fn clone_armada(
     source_armada_id: i64,
     request: &CloneArmadaRequest,
 ) -> Result<i64, WriteError> {
+    let _guard = WriteGuard(());
     let source_description: Option<String> = conn
         .query_row(
             "SELECT description FROM armadas WHERE id = ?1",
@@ -281,6 +284,7 @@ pub fn clone_armada(
 }
 
 pub fn create_fleet(conn: &Connection, fleet: &NewFleet) -> Result<i64, WriteError> {
+    let _guard = WriteGuard(());
     ensure_armada_exists(conn, fleet.armada_id)?;
     conn.execute(
         "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
@@ -295,6 +299,7 @@ pub fn patch_fleet(
     fleet_id: i64,
     patch: &FleetPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM fleets WHERE id = ?1",
@@ -352,6 +357,7 @@ pub fn clone_fleet(
     source_fleet_id: i64,
     request: &CloneFleetRequest,
 ) -> Result<i64, WriteError> {
+    let _guard = WriteGuard(());
     let source_row: Option<(i64, Option<String>)> = conn
         .query_row(
             "SELECT armada_id, color FROM fleets WHERE id = ?1",
@@ -381,6 +387,7 @@ pub fn clone_fleet(
 }
 
 pub fn create_flotilla(conn: &Connection, flotilla: &NewFlotilla) -> Result<i64, WriteError> {
+    let _guard = WriteGuard(());
     ensure_fleet_exists(conn, flotilla.fleet_id)?;
     conn.execute(
         "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
@@ -395,6 +402,7 @@ pub fn patch_flotilla(
     flotilla_id: i64,
     patch: &FlotillaPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM flotillas WHERE id = ?1",
@@ -441,6 +449,7 @@ pub fn patch_flotilla(
 }
 
 pub fn create_crew_bundle(conn: &Connection, bundle: &NewCrewBundle) -> Result<i64, WriteError> {
+    let _guard = WriteGuard(());
     validate_captain_count(&bundle.members)?;
     validate_startup_prompts_non_empty(&bundle.members)?;
     validate_variants_non_empty(&bundle.variants)?;
@@ -480,6 +489,7 @@ pub fn patch_crew_bundle(
     crew_id: i64,
     patch: &CrewBundlePatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     if let Some(members) = patch.members.as_ref() {
         validate_captain_count(members)?;
         validate_startup_prompts_non_empty(members)?;
@@ -536,6 +546,7 @@ pub fn clone_crew(
     source_crew_id: i64,
     request: &CloneCrewRequest,
 ) -> Result<i64, WriteError> {
+    let _guard = WriteGuard(());
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
 
     let source_exists: Option<i64> = tx
@@ -597,6 +608,7 @@ pub fn move_crew_ref(
     ref_id: i64,
     patch: &MoveCrewRefPatch,
 ) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
     let exists: Option<i64> = tx
         .query_row(
@@ -647,6 +659,7 @@ pub fn move_crew_ref(
 }
 
 pub fn unlink_crew_ref(conn: &Connection, ref_id: i64) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
     let crew_id: Option<i64> = tx
         .query_row(

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -112,6 +112,7 @@ pub struct NewCrewBundle {
 
 #[derive(Debug, Clone, Default)]
 pub struct CrewBundlePatch {
+    pub crew_name: Option<String>,
     pub crew_ulid: Option<String>,
     pub members: Option<Vec<CrewMemberInput>>,
     pub variants: Option<Vec<CrewVariantInput>>,
@@ -195,12 +196,15 @@ pub fn ensure_local_host(conn: &Connection) -> Result<i64, WriteError> {
 
 pub fn create_armada(conn: &Connection, armada: &NewArmada) -> Result<i64, WriteError> {
     let _guard = WriteGuard(());
-    conn.execute(
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    tx.execute(
         "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
         params![armada.name, armada.description],
     )
     .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    let armada_id = tx.last_insert_rowid();
+    tx.commit().map_err(map_write_error)?;
+    Ok(armada_id)
 }
 
 pub fn patch_armada(
@@ -209,7 +213,8 @@ pub fn patch_armada(
     patch: &ArmadaPatch,
 ) -> Result<bool, WriteError> {
     let _guard = WriteGuard(());
-    let exists: Option<i64> = conn
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let exists: Option<i64> = tx
         .query_row(
             "SELECT id FROM armadas WHERE id = ?1",
             params![armada_id],
@@ -235,6 +240,7 @@ pub fn patch_armada(
         });
     }
     if set_parts.is_empty() {
+        tx.commit().map_err(map_write_error)?;
         return Ok(true);
     }
 
@@ -248,8 +254,9 @@ pub fn patch_armada(
     sql.push_str(" WHERE id = ?");
     values.push(SqlValue::Integer(armada_id));
 
-    conn.execute(&sql, rusqlite::params_from_iter(values))
+    tx.execute(&sql, rusqlite::params_from_iter(values))
         .map_err(map_write_error)?;
+    tx.commit().map_err(map_write_error)?;
     Ok(true)
 }
 
@@ -259,7 +266,8 @@ pub fn clone_armada(
     request: &CloneArmadaRequest,
 ) -> Result<i64, WriteError> {
     let _guard = WriteGuard(());
-    let source_description: Option<String> = conn
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let source_description: Option<String> = tx
         .query_row(
             "SELECT description FROM armadas WHERE id = ?1",
             params![source_armada_id],
@@ -275,23 +283,28 @@ pub fn clone_armada(
         source_description
     };
 
-    conn.execute(
+    tx.execute(
         "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
         params![request.name, description],
     )
     .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    let clone_id = tx.last_insert_rowid();
+    tx.commit().map_err(map_write_error)?;
+    Ok(clone_id)
 }
 
 pub fn create_fleet(conn: &Connection, fleet: &NewFleet) -> Result<i64, WriteError> {
     let _guard = WriteGuard(());
-    ensure_armada_exists(conn, fleet.armada_id)?;
-    conn.execute(
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    ensure_armada_exists(&tx, fleet.armada_id)?;
+    tx.execute(
         "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
         params![fleet.armada_id, fleet.name, fleet.color],
     )
     .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    let fleet_id = tx.last_insert_rowid();
+    tx.commit().map_err(map_write_error)?;
+    Ok(fleet_id)
 }
 
 pub fn patch_fleet(
@@ -300,7 +313,8 @@ pub fn patch_fleet(
     patch: &FleetPatch,
 ) -> Result<bool, WriteError> {
     let _guard = WriteGuard(());
-    let exists: Option<i64> = conn
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let exists: Option<i64> = tx
         .query_row(
             "SELECT id FROM fleets WHERE id = ?1",
             params![fleet_id],
@@ -313,7 +327,7 @@ pub fn patch_fleet(
     }
 
     if let Some(armada_id) = patch.armada_id {
-        ensure_armada_exists(conn, armada_id)?;
+        ensure_armada_exists(&tx, armada_id)?;
     }
 
     let mut set_parts: Vec<&str> = Vec::new();
@@ -334,6 +348,7 @@ pub fn patch_fleet(
         });
     }
     if set_parts.is_empty() {
+        tx.commit().map_err(map_write_error)?;
         return Ok(true);
     }
 
@@ -347,8 +362,9 @@ pub fn patch_fleet(
     sql.push_str(" WHERE id = ?");
     values.push(SqlValue::Integer(fleet_id));
 
-    conn.execute(&sql, rusqlite::params_from_iter(values))
+    tx.execute(&sql, rusqlite::params_from_iter(values))
         .map_err(map_write_error)?;
+    tx.commit().map_err(map_write_error)?;
     Ok(true)
 }
 
@@ -358,7 +374,8 @@ pub fn clone_fleet(
     request: &CloneFleetRequest,
 ) -> Result<i64, WriteError> {
     let _guard = WriteGuard(());
-    let source_row: Option<(i64, Option<String>)> = conn
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let source_row: Option<(i64, Option<String>)> = tx
         .query_row(
             "SELECT armada_id, color FROM fleets WHERE id = ?1",
             params![source_fleet_id],
@@ -371,30 +388,35 @@ pub fn clone_fleet(
     };
 
     let armada_id = request.armada_id.unwrap_or(source_armada_id);
-    ensure_armada_exists(conn, armada_id)?;
+    ensure_armada_exists(&tx, armada_id)?;
     let color = if request.color.is_some() {
         request.color.clone()
     } else {
         source_color
     };
 
-    conn.execute(
+    tx.execute(
         "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
         params![armada_id, request.name, color],
     )
     .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    let clone_id = tx.last_insert_rowid();
+    tx.commit().map_err(map_write_error)?;
+    Ok(clone_id)
 }
 
 pub fn create_flotilla(conn: &Connection, flotilla: &NewFlotilla) -> Result<i64, WriteError> {
     let _guard = WriteGuard(());
-    ensure_fleet_exists(conn, flotilla.fleet_id)?;
-    conn.execute(
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    ensure_fleet_exists(&tx, flotilla.fleet_id)?;
+    tx.execute(
         "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
         params![flotilla.fleet_id, flotilla.name],
     )
     .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
+    let flotilla_id = tx.last_insert_rowid();
+    tx.commit().map_err(map_write_error)?;
+    Ok(flotilla_id)
 }
 
 pub fn patch_flotilla(
@@ -403,7 +425,8 @@ pub fn patch_flotilla(
     patch: &FlotillaPatch,
 ) -> Result<bool, WriteError> {
     let _guard = WriteGuard(());
-    let exists: Option<i64> = conn
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let exists: Option<i64> = tx
         .query_row(
             "SELECT id FROM flotillas WHERE id = ?1",
             params![flotilla_id],
@@ -416,7 +439,7 @@ pub fn patch_flotilla(
     }
 
     if let Some(fleet_id) = patch.fleet_id {
-        ensure_fleet_exists(conn, fleet_id)?;
+        ensure_fleet_exists(&tx, fleet_id)?;
     }
 
     let mut set_parts: Vec<&str> = Vec::new();
@@ -430,6 +453,7 @@ pub fn patch_flotilla(
         values.push(SqlValue::Text(name.clone()));
     }
     if set_parts.is_empty() {
+        tx.commit().map_err(map_write_error)?;
         return Ok(true);
     }
 
@@ -443,8 +467,9 @@ pub fn patch_flotilla(
     sql.push_str(" WHERE id = ?");
     values.push(SqlValue::Integer(flotilla_id));
 
-    conn.execute(&sql, rusqlite::params_from_iter(values))
+    tx.execute(&sql, rusqlite::params_from_iter(values))
         .map_err(map_write_error)?;
+    tx.commit().map_err(map_write_error)?;
     Ok(true)
 }
 
@@ -490,6 +515,11 @@ pub fn patch_crew_bundle(
     patch: &CrewBundlePatch,
 ) -> Result<bool, WriteError> {
     let _guard = WriteGuard(());
+    if patch.crew_name.is_some() {
+        return Err(WriteError::Forbidden(
+            "crew rename is forbidden".to_string(),
+        ));
+    }
     if let Some(members) = patch.members.as_ref() {
         validate_captain_count(members)?;
         validate_startup_prompts_non_empty(members)?;
@@ -790,8 +820,8 @@ fn validate_placement(
     Ok(())
 }
 
-fn ensure_armada_exists(conn: &Connection, armada_id: i64) -> Result<(), WriteError> {
-    let exists: bool = conn
+fn ensure_armada_exists(tx: &rusqlite::Transaction<'_>, armada_id: i64) -> Result<(), WriteError> {
+    let exists: bool = tx
         .query_row(
             "SELECT COUNT(*) > 0 FROM armadas WHERE id = ?1",
             params![armada_id],
@@ -804,8 +834,8 @@ fn ensure_armada_exists(conn: &Connection, armada_id: i64) -> Result<(), WriteEr
     Ok(())
 }
 
-fn ensure_fleet_exists(conn: &Connection, fleet_id: i64) -> Result<(), WriteError> {
-    let exists: bool = conn
+fn ensure_fleet_exists(tx: &rusqlite::Transaction<'_>, fleet_id: i64) -> Result<(), WriteError> {
+    let exists: bool = tx
         .query_row(
             "SELECT COUNT(*) > 0 FROM fleets WHERE id = ?1",
             params![fleet_id],

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -37,6 +37,12 @@ pub struct ArmadaPatch {
 }
 
 #[derive(Debug, Clone)]
+pub struct CloneArmadaRequest {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct NewFleet {
     pub armada_id: i64,
     pub name: String,
@@ -48,6 +54,13 @@ pub struct FleetPatch {
     pub armada_id: Option<i64>,
     pub name: Option<String>,
     pub color: Option<Option<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloneFleetRequest {
+    pub armada_id: Option<i64>,
+    pub name: String,
+    pub color: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -181,8 +194,12 @@ pub fn ensure_local_host(conn: &Connection) -> Result<i64, WriteError> {
 }
 
 pub fn create_armada(conn: &Connection, armada: &NewArmada) -> Result<i64, WriteError> {
-    let guard = WriteGuard(());
-    write_armada(&guard, conn, armada)
+    conn.execute(
+        "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
+        params![armada.name, armada.description],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
 }
 
 pub fn patch_armada(
@@ -190,7 +207,6 @@ pub fn patch_armada(
     armada_id: i64,
     patch: &ArmadaPatch,
 ) -> Result<bool, WriteError> {
-    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM armadas WHERE id = ?1",
@@ -235,10 +251,43 @@ pub fn patch_armada(
     Ok(true)
 }
 
+pub fn clone_armada(
+    conn: &Connection,
+    source_armada_id: i64,
+    request: &CloneArmadaRequest,
+) -> Result<i64, WriteError> {
+    let source_description: Option<String> = conn
+        .query_row(
+            "SELECT description FROM armadas WHERE id = ?1",
+            params![source_armada_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?
+        .ok_or(WriteError::NotFound)?;
+
+    let description = if request.description.is_some() {
+        request.description.clone()
+    } else {
+        source_description
+    };
+
+    conn.execute(
+        "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
+        params![request.name, description],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
 pub fn create_fleet(conn: &Connection, fleet: &NewFleet) -> Result<i64, WriteError> {
-    let guard = WriteGuard(());
     ensure_armada_exists(conn, fleet.armada_id)?;
-    write_fleet(&guard, conn, fleet)
+    conn.execute(
+        "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
+        params![fleet.armada_id, fleet.name, fleet.color],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
 }
 
 pub fn patch_fleet(
@@ -246,7 +295,6 @@ pub fn patch_fleet(
     fleet_id: i64,
     patch: &FleetPatch,
 ) -> Result<bool, WriteError> {
-    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM fleets WHERE id = ?1",
@@ -299,10 +347,47 @@ pub fn patch_fleet(
     Ok(true)
 }
 
+pub fn clone_fleet(
+    conn: &Connection,
+    source_fleet_id: i64,
+    request: &CloneFleetRequest,
+) -> Result<i64, WriteError> {
+    let source_row: Option<(i64, Option<String>)> = conn
+        .query_row(
+            "SELECT armada_id, color FROM fleets WHERE id = ?1",
+            params![source_fleet_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    let Some((source_armada_id, source_color)) = source_row else {
+        return Err(WriteError::NotFound);
+    };
+
+    let armada_id = request.armada_id.unwrap_or(source_armada_id);
+    ensure_armada_exists(conn, armada_id)?;
+    let color = if request.color.is_some() {
+        request.color.clone()
+    } else {
+        source_color
+    };
+
+    conn.execute(
+        "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
+        params![armada_id, request.name, color],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
 pub fn create_flotilla(conn: &Connection, flotilla: &NewFlotilla) -> Result<i64, WriteError> {
-    let guard = WriteGuard(());
     ensure_fleet_exists(conn, flotilla.fleet_id)?;
-    write_flotilla(&guard, conn, flotilla)
+    conn.execute(
+        "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
+        params![flotilla.fleet_id, flotilla.name],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
 }
 
 pub fn patch_flotilla(
@@ -310,7 +395,6 @@ pub fn patch_flotilla(
     flotilla_id: i64,
     patch: &FlotillaPatch,
 ) -> Result<bool, WriteError> {
-    let _guard = WriteGuard(());
     let exists: Option<i64> = conn
         .query_row(
             "SELECT id FROM flotillas WHERE id = ?1",
@@ -357,16 +441,22 @@ pub fn patch_flotilla(
 }
 
 pub fn create_crew_bundle(conn: &Connection, bundle: &NewCrewBundle) -> Result<i64, WriteError> {
-    let guard = WriteGuard(());
     validate_captain_count(&bundle.members)?;
+    validate_startup_prompts_non_empty(&bundle.members)?;
+    validate_variants_non_empty(&bundle.variants)?;
 
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
     validate_placement(&tx, &bundle.placement)?;
 
-    let crew_id = write_crew(&guard, &tx, &bundle.crew_name, &bundle.crew_ulid)?;
+    tx.execute(
+        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
+        params![bundle.crew_name, bundle.crew_ulid],
+    )
+    .map_err(map_write_error)?;
+    let crew_id = tx.last_insert_rowid();
 
-    insert_members(&guard, &tx, crew_id, &bundle.members)?;
-    insert_variants(&guard, &tx, crew_id, &bundle.variants)?;
+    insert_members(&tx, crew_id, &bundle.members)?;
+    insert_variants(&tx, crew_id, &bundle.variants)?;
 
     tx.execute(
         "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
@@ -390,9 +480,12 @@ pub fn patch_crew_bundle(
     crew_id: i64,
     patch: &CrewBundlePatch,
 ) -> Result<bool, WriteError> {
-    let guard = WriteGuard(());
     if let Some(members) = patch.members.as_ref() {
         validate_captain_count(members)?;
+        validate_startup_prompts_non_empty(members)?;
+    }
+    if let Some(variants) = patch.variants.as_ref() {
+        validate_variants_non_empty(variants)?;
     }
 
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
@@ -422,7 +515,7 @@ pub fn patch_crew_bundle(
             params![crew_id],
         )
         .map_err(map_write_error)?;
-        insert_members(&guard, &tx, crew_id, members)?;
+        insert_members(&tx, crew_id, members)?;
     }
 
     if let Some(variants) = patch.variants.as_ref() {
@@ -431,7 +524,7 @@ pub fn patch_crew_bundle(
             params![crew_id],
         )
         .map_err(map_write_error)?;
-        insert_variants(&guard, &tx, crew_id, variants)?;
+        insert_variants(&tx, crew_id, variants)?;
     }
 
     tx.commit().map_err(map_write_error)?;
@@ -443,7 +536,6 @@ pub fn clone_crew(
     source_crew_id: i64,
     request: &CloneCrewRequest,
 ) -> Result<i64, WriteError> {
-    let guard = WriteGuard(());
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
 
     let source_exists: Option<i64> = tx
@@ -460,61 +552,28 @@ pub fn clone_crew(
 
     validate_placement(&tx, &request.placement)?;
 
-    let new_crew_id = write_crew(&guard, &tx, &request.crew_name, &request.crew_ulid)?;
+    tx.execute(
+        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
+        params![request.crew_name, request.crew_ulid],
+    )
+    .map_err(map_write_error)?;
+    let new_crew_id = tx.last_insert_rowid();
 
-    let source_members = {
-        let mut stmt = tx
-            .prepare(
-                "SELECT member_id, role, ai_provider, model, startup_prompts_json
-                 FROM crew_members
-                 WHERE crew_id = ?1",
-            )
-            .map_err(map_write_error)?;
-        let mapped = stmt
-            .query_map(params![source_crew_id], |r| {
-                Ok(CrewMemberInput {
-                    member_id: r.get(0)?,
-                    role: r.get(1)?,
-                    ai_provider: r.get(2)?,
-                    model: r.get(3)?,
-                    startup_prompts_json: r.get(4)?,
-                })
-            })
-            .map_err(map_write_error)?;
-        mapped
-            .collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(map_write_error)?
-    };
-    for member in &source_members {
-        write_crew_member(&guard, &tx, new_crew_id, member)?;
-    }
+    tx.execute(
+        "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
+         SELECT ?1, member_id, role, ai_provider, model, startup_prompts_json
+         FROM crew_members WHERE crew_id = ?2",
+        params![new_crew_id, source_crew_id],
+    )
+    .map_err(map_write_error)?;
 
-    let source_variants = {
-        let mut stmt = tx
-            .prepare(
-                "SELECT host_id, repo_url, branch_ref, root_path, config_json
-                 FROM crew_variants
-                 WHERE crew_id = ?1",
-            )
-            .map_err(map_write_error)?;
-        let mapped = stmt
-            .query_map(params![source_crew_id], |r| {
-                Ok(CrewVariantInput {
-                    host_id: r.get(0)?,
-                    repo_url: r.get(1)?,
-                    branch_ref: r.get(2)?,
-                    root_path: r.get(3)?,
-                    config_json: r.get(4)?,
-                })
-            })
-            .map_err(map_write_error)?;
-        mapped
-            .collect::<rusqlite::Result<Vec<_>>>()
-            .map_err(map_write_error)?
-    };
-    for variant in &source_variants {
-        write_crew_variant(&guard, &tx, new_crew_id, variant)?;
-    }
+    tx.execute(
+        "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
+         SELECT ?1, host_id, repo_url, branch_ref, root_path, config_json
+         FROM crew_variants WHERE crew_id = ?2",
+        params![new_crew_id, source_crew_id],
+    )
+    .map_err(map_write_error)?;
 
     tx.execute(
         "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
@@ -538,7 +597,6 @@ pub fn move_crew_ref(
     ref_id: i64,
     patch: &MoveCrewRefPatch,
 ) -> Result<bool, WriteError> {
-    let _guard = WriteGuard(());
     let tx = conn.unchecked_transaction().map_err(map_write_error)?;
     let exists: Option<i64> = tx
         .query_row(
@@ -623,123 +681,48 @@ pub fn unlink_crew_ref(conn: &Connection, ref_id: i64) -> Result<bool, WriteErro
 }
 
 fn insert_members(
-    guard: &WriteGuard,
     tx: &rusqlite::Transaction<'_>,
     crew_id: i64,
     members: &[CrewMemberInput],
 ) -> Result<(), WriteError> {
     for member in members {
-        write_crew_member(guard, tx, crew_id, member)?;
+        tx.execute(
+            "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                crew_id,
+                member.member_id,
+                member.role,
+                member.ai_provider,
+                member.model,
+                member.startup_prompts_json
+            ],
+        )
+        .map_err(map_write_error)?;
     }
     Ok(())
 }
 
 fn insert_variants(
-    guard: &WriteGuard,
     tx: &rusqlite::Transaction<'_>,
     crew_id: i64,
     variants: &[CrewVariantInput],
 ) -> Result<(), WriteError> {
     for variant in variants {
-        write_crew_variant(guard, tx, crew_id, variant)?;
+        tx.execute(
+            "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                crew_id,
+                variant.host_id,
+                variant.repo_url,
+                variant.branch_ref,
+                variant.root_path,
+                variant.config_json
+            ],
+        )
+        .map_err(map_write_error)?;
     }
-    Ok(())
-}
-
-fn write_armada(
-    _guard: &WriteGuard,
-    conn: &Connection,
-    armada: &NewArmada,
-) -> Result<i64, WriteError> {
-    conn.execute(
-        "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
-        params![armada.name, armada.description],
-    )
-    .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
-}
-
-fn write_fleet(
-    _guard: &WriteGuard,
-    conn: &Connection,
-    fleet: &NewFleet,
-) -> Result<i64, WriteError> {
-    conn.execute(
-        "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
-        params![fleet.armada_id, fleet.name, fleet.color],
-    )
-    .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
-}
-
-fn write_flotilla(
-    _guard: &WriteGuard,
-    conn: &Connection,
-    flotilla: &NewFlotilla,
-) -> Result<i64, WriteError> {
-    conn.execute(
-        "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
-        params![flotilla.fleet_id, flotilla.name],
-    )
-    .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
-}
-
-fn write_crew(
-    _guard: &WriteGuard,
-    conn: &Connection,
-    crew_name: &str,
-    crew_ulid: &str,
-) -> Result<i64, WriteError> {
-    conn.execute(
-        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
-        params![crew_name, crew_ulid],
-    )
-    .map_err(map_write_error)?;
-    Ok(conn.last_insert_rowid())
-}
-
-fn write_crew_member(
-    _guard: &WriteGuard,
-    conn: &Connection,
-    crew_id: i64,
-    member: &CrewMemberInput,
-) -> Result<(), WriteError> {
-    conn.execute(
-        "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![
-            crew_id,
-            member.member_id,
-            member.role,
-            member.ai_provider,
-            member.model,
-            member.startup_prompts_json
-        ],
-    )
-    .map_err(map_write_error)?;
-    Ok(())
-}
-
-fn write_crew_variant(
-    _guard: &WriteGuard,
-    conn: &Connection,
-    crew_id: i64,
-    variant: &CrewVariantInput,
-) -> Result<(), WriteError> {
-    conn.execute(
-        "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-        params![
-            crew_id,
-            variant.host_id,
-            variant.repo_url,
-            variant.branch_ref,
-            variant.root_path,
-            variant.config_json
-        ],
-    )
-    .map_err(map_write_error)?;
     Ok(())
 }
 
@@ -830,6 +813,34 @@ fn validate_captain_count(members: &[CrewMemberInput]) -> Result<(), WriteError>
     if captain_count != 1 {
         return Err(WriteError::Validation(
             "crew must have exactly one captain".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_startup_prompts_non_empty(members: &[CrewMemberInput]) -> Result<(), WriteError> {
+    for member in members {
+        let parsed: serde_json::Value = serde_json::from_str(&member.startup_prompts_json)
+            .map_err(|err| {
+                WriteError::Validation(format!("invalid startup_prompts_json: {err}"))
+            })?;
+        let prompts = parsed.as_array().ok_or_else(|| {
+            WriteError::Validation("startup_prompts must be an array".to_string())
+        })?;
+        if prompts.is_empty() {
+            return Err(WriteError::Validation(format!(
+                "member '{}' must include at least one startup prompt",
+                member.member_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_variants_non_empty(variants: &[CrewVariantInput]) -> Result<(), WriteError> {
+    if variants.is_empty() {
+        return Err(WriteError::Validation(
+            "crew must include at least one variant".to_string(),
         ));
     }
     Ok(())

--- a/crates/scmux-daemon/src/definition_writer.rs
+++ b/crates/scmux-daemon/src/definition_writer.rs
@@ -1,5 +1,5 @@
 use crate::db;
-use rusqlite::Connection;
+use rusqlite::{params, types::Value as SqlValue, Connection, OptionalExtension};
 
 pub struct WriteGuard(());
 
@@ -22,6 +22,101 @@ impl WriteError {
             | Self::Internal(msg) => msg.clone(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewArmada {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ArmadaPatch {
+    pub name: Option<String>,
+    pub description: Option<Option<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewFleet {
+    pub armada_id: i64,
+    pub name: String,
+    pub color: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FleetPatch {
+    pub armada_id: Option<i64>,
+    pub name: Option<String>,
+    pub color: Option<Option<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewFlotilla {
+    pub fleet_id: i64,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FlotillaPatch {
+    pub fleet_id: Option<i64>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrewMemberInput {
+    pub member_id: String,
+    pub role: String,
+    pub ai_provider: String,
+    pub model: String,
+    pub startup_prompts_json: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrewVariantInput {
+    pub host_id: i64,
+    pub repo_url: Option<String>,
+    pub branch_ref: Option<String>,
+    pub root_path: String,
+    pub config_json: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CrewPlacementInput {
+    pub armada_id: i64,
+    pub fleet_id: i64,
+    pub flotilla_id: Option<i64>,
+    pub alias_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewCrewBundle {
+    pub crew_name: String,
+    pub crew_ulid: String,
+    pub members: Vec<CrewMemberInput>,
+    pub variants: Vec<CrewVariantInput>,
+    pub placement: CrewPlacementInput,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CrewBundlePatch {
+    pub crew_ulid: Option<String>,
+    pub members: Option<Vec<CrewMemberInput>>,
+    pub variants: Option<Vec<CrewVariantInput>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloneCrewRequest {
+    pub crew_name: String,
+    pub crew_ulid: String,
+    pub placement: CrewPlacementInput,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MoveCrewRefPatch {
+    pub armada_id: i64,
+    pub fleet_id: i64,
+    pub flotilla_id: Option<i64>,
+    pub alias_name: Option<Option<String>>,
 }
 
 pub fn create_session(conn: &Connection, new_session: &db::NewSession) -> Result<i64, WriteError> {
@@ -85,6 +180,661 @@ pub fn ensure_local_host(conn: &Connection) -> Result<i64, WriteError> {
     db::ensure_local_host(conn).map_err(|err| WriteError::Internal(err.to_string()))
 }
 
+pub fn create_armada(conn: &Connection, armada: &NewArmada) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
+    write_armada(&guard, conn, armada)
+}
+
+pub fn patch_armada(
+    conn: &Connection,
+    armada_id: i64,
+    patch: &ArmadaPatch,
+) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM armadas WHERE id = ?1",
+            params![armada_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    let mut set_parts: Vec<&str> = Vec::new();
+    let mut values: Vec<SqlValue> = Vec::new();
+    if let Some(name) = &patch.name {
+        set_parts.push("name = ?");
+        values.push(SqlValue::Text(name.clone()));
+    }
+    if let Some(description) = &patch.description {
+        set_parts.push("description = ?");
+        values.push(match description {
+            Some(value) => SqlValue::Text(value.clone()),
+            None => SqlValue::Null,
+        });
+    }
+    if set_parts.is_empty() {
+        return Ok(true);
+    }
+
+    let mut sql = String::from("UPDATE armadas SET ");
+    for (idx, part) in set_parts.iter().enumerate() {
+        if idx > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(part);
+    }
+    sql.push_str(" WHERE id = ?");
+    values.push(SqlValue::Integer(armada_id));
+
+    conn.execute(&sql, rusqlite::params_from_iter(values))
+        .map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn create_fleet(conn: &Connection, fleet: &NewFleet) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
+    ensure_armada_exists(conn, fleet.armada_id)?;
+    write_fleet(&guard, conn, fleet)
+}
+
+pub fn patch_fleet(
+    conn: &Connection,
+    fleet_id: i64,
+    patch: &FleetPatch,
+) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM fleets WHERE id = ?1",
+            params![fleet_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    if let Some(armada_id) = patch.armada_id {
+        ensure_armada_exists(conn, armada_id)?;
+    }
+
+    let mut set_parts: Vec<&str> = Vec::new();
+    let mut values: Vec<SqlValue> = Vec::new();
+    if let Some(armada_id) = patch.armada_id {
+        set_parts.push("armada_id = ?");
+        values.push(SqlValue::Integer(armada_id));
+    }
+    if let Some(name) = &patch.name {
+        set_parts.push("name = ?");
+        values.push(SqlValue::Text(name.clone()));
+    }
+    if let Some(color) = &patch.color {
+        set_parts.push("color = ?");
+        values.push(match color {
+            Some(value) => SqlValue::Text(value.clone()),
+            None => SqlValue::Null,
+        });
+    }
+    if set_parts.is_empty() {
+        return Ok(true);
+    }
+
+    let mut sql = String::from("UPDATE fleets SET ");
+    for (idx, part) in set_parts.iter().enumerate() {
+        if idx > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(part);
+    }
+    sql.push_str(" WHERE id = ?");
+    values.push(SqlValue::Integer(fleet_id));
+
+    conn.execute(&sql, rusqlite::params_from_iter(values))
+        .map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn create_flotilla(conn: &Connection, flotilla: &NewFlotilla) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
+    ensure_fleet_exists(conn, flotilla.fleet_id)?;
+    write_flotilla(&guard, conn, flotilla)
+}
+
+pub fn patch_flotilla(
+    conn: &Connection,
+    flotilla_id: i64,
+    patch: &FlotillaPatch,
+) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
+    let exists: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM flotillas WHERE id = ?1",
+            params![flotilla_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    if let Some(fleet_id) = patch.fleet_id {
+        ensure_fleet_exists(conn, fleet_id)?;
+    }
+
+    let mut set_parts: Vec<&str> = Vec::new();
+    let mut values: Vec<SqlValue> = Vec::new();
+    if let Some(fleet_id) = patch.fleet_id {
+        set_parts.push("fleet_id = ?");
+        values.push(SqlValue::Integer(fleet_id));
+    }
+    if let Some(name) = &patch.name {
+        set_parts.push("name = ?");
+        values.push(SqlValue::Text(name.clone()));
+    }
+    if set_parts.is_empty() {
+        return Ok(true);
+    }
+
+    let mut sql = String::from("UPDATE flotillas SET ");
+    for (idx, part) in set_parts.iter().enumerate() {
+        if idx > 0 {
+            sql.push_str(", ");
+        }
+        sql.push_str(part);
+    }
+    sql.push_str(" WHERE id = ?");
+    values.push(SqlValue::Integer(flotilla_id));
+
+    conn.execute(&sql, rusqlite::params_from_iter(values))
+        .map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn create_crew_bundle(conn: &Connection, bundle: &NewCrewBundle) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
+    validate_captain_count(&bundle.members)?;
+
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    validate_placement(&tx, &bundle.placement)?;
+
+    let crew_id = write_crew(&guard, &tx, &bundle.crew_name, &bundle.crew_ulid)?;
+
+    insert_members(&guard, &tx, crew_id, &bundle.members)?;
+    insert_variants(&guard, &tx, crew_id, &bundle.variants)?;
+
+    tx.execute(
+        "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            crew_id,
+            bundle.placement.armada_id,
+            bundle.placement.fleet_id,
+            bundle.placement.flotilla_id,
+            bundle.placement.alias_name
+        ],
+    )
+    .map_err(map_write_error)?;
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(crew_id)
+}
+
+pub fn patch_crew_bundle(
+    conn: &Connection,
+    crew_id: i64,
+    patch: &CrewBundlePatch,
+) -> Result<bool, WriteError> {
+    let guard = WriteGuard(());
+    if let Some(members) = patch.members.as_ref() {
+        validate_captain_count(members)?;
+    }
+
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let exists: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM crews WHERE id = ?1",
+            params![crew_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    if let Some(crew_ulid) = patch.crew_ulid.as_ref() {
+        tx.execute(
+            "UPDATE crews SET crew_ulid = ?1 WHERE id = ?2",
+            params![crew_ulid, crew_id],
+        )
+        .map_err(map_write_error)?;
+    }
+
+    if let Some(members) = patch.members.as_ref() {
+        tx.execute(
+            "DELETE FROM crew_members WHERE crew_id = ?1",
+            params![crew_id],
+        )
+        .map_err(map_write_error)?;
+        insert_members(&guard, &tx, crew_id, members)?;
+    }
+
+    if let Some(variants) = patch.variants.as_ref() {
+        tx.execute(
+            "DELETE FROM crew_variants WHERE crew_id = ?1",
+            params![crew_id],
+        )
+        .map_err(map_write_error)?;
+        insert_variants(&guard, &tx, crew_id, variants)?;
+    }
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn clone_crew(
+    conn: &Connection,
+    source_crew_id: i64,
+    request: &CloneCrewRequest,
+) -> Result<i64, WriteError> {
+    let guard = WriteGuard(());
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+
+    let source_exists: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM crews WHERE id = ?1",
+            params![source_crew_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if source_exists.is_none() {
+        return Err(WriteError::NotFound);
+    }
+
+    validate_placement(&tx, &request.placement)?;
+
+    let new_crew_id = write_crew(&guard, &tx, &request.crew_name, &request.crew_ulid)?;
+
+    let source_members = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT member_id, role, ai_provider, model, startup_prompts_json
+                 FROM crew_members
+                 WHERE crew_id = ?1",
+            )
+            .map_err(map_write_error)?;
+        let mapped = stmt
+            .query_map(params![source_crew_id], |r| {
+                Ok(CrewMemberInput {
+                    member_id: r.get(0)?,
+                    role: r.get(1)?,
+                    ai_provider: r.get(2)?,
+                    model: r.get(3)?,
+                    startup_prompts_json: r.get(4)?,
+                })
+            })
+            .map_err(map_write_error)?;
+        mapped
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_write_error)?
+    };
+    for member in &source_members {
+        write_crew_member(&guard, &tx, new_crew_id, member)?;
+    }
+
+    let source_variants = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT host_id, repo_url, branch_ref, root_path, config_json
+                 FROM crew_variants
+                 WHERE crew_id = ?1",
+            )
+            .map_err(map_write_error)?;
+        let mapped = stmt
+            .query_map(params![source_crew_id], |r| {
+                Ok(CrewVariantInput {
+                    host_id: r.get(0)?,
+                    repo_url: r.get(1)?,
+                    branch_ref: r.get(2)?,
+                    root_path: r.get(3)?,
+                    config_json: r.get(4)?,
+                })
+            })
+            .map_err(map_write_error)?;
+        mapped
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_write_error)?
+    };
+    for variant in &source_variants {
+        write_crew_variant(&guard, &tx, new_crew_id, variant)?;
+    }
+
+    tx.execute(
+        "INSERT INTO crew_refs (crew_id, armada_id, fleet_id, flotilla_id, alias_name)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            new_crew_id,
+            request.placement.armada_id,
+            request.placement.fleet_id,
+            request.placement.flotilla_id,
+            request.placement.alias_name
+        ],
+    )
+    .map_err(map_write_error)?;
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(new_crew_id)
+}
+
+pub fn move_crew_ref(
+    conn: &Connection,
+    ref_id: i64,
+    patch: &MoveCrewRefPatch,
+) -> Result<bool, WriteError> {
+    let _guard = WriteGuard(());
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let exists: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM crew_refs WHERE id = ?1",
+            params![ref_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    if exists.is_none() {
+        return Ok(false);
+    }
+
+    let placement = CrewPlacementInput {
+        armada_id: patch.armada_id,
+        fleet_id: patch.fleet_id,
+        flotilla_id: patch.flotilla_id,
+        alias_name: None,
+    };
+    validate_placement(&tx, &placement)?;
+
+    if let Some(alias_name) = patch.alias_name.as_ref() {
+        tx.execute(
+            "UPDATE crew_refs
+             SET armada_id = ?1, fleet_id = ?2, flotilla_id = ?3, alias_name = ?4
+             WHERE id = ?5",
+            params![
+                patch.armada_id,
+                patch.fleet_id,
+                patch.flotilla_id,
+                alias_name,
+                ref_id
+            ],
+        )
+        .map_err(map_write_error)?;
+    } else {
+        tx.execute(
+            "UPDATE crew_refs
+             SET armada_id = ?1, fleet_id = ?2, flotilla_id = ?3
+             WHERE id = ?4",
+            params![patch.armada_id, patch.fleet_id, patch.flotilla_id, ref_id],
+        )
+        .map_err(map_write_error)?;
+    }
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(true)
+}
+
+pub fn unlink_crew_ref(conn: &Connection, ref_id: i64) -> Result<bool, WriteError> {
+    let tx = conn.unchecked_transaction().map_err(map_write_error)?;
+    let crew_id: Option<i64> = tx
+        .query_row(
+            "SELECT crew_id FROM crew_refs WHERE id = ?1",
+            params![ref_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+    let Some(crew_id) = crew_id else {
+        return Ok(false);
+    };
+
+    tx.execute("DELETE FROM crew_refs WHERE id = ?1", params![ref_id])
+        .map_err(map_write_error)?;
+
+    let remaining_refs: i64 = tx
+        .query_row(
+            "SELECT COUNT(*) FROM crew_refs WHERE crew_id = ?1",
+            params![crew_id],
+            |r| r.get(0),
+        )
+        .map_err(map_write_error)?;
+
+    if remaining_refs == 0 {
+        tx.execute("DELETE FROM crews WHERE id = ?1", params![crew_id])
+            .map_err(map_write_error)?;
+    }
+
+    tx.commit().map_err(map_write_error)?;
+    Ok(true)
+}
+
+fn insert_members(
+    guard: &WriteGuard,
+    tx: &rusqlite::Transaction<'_>,
+    crew_id: i64,
+    members: &[CrewMemberInput],
+) -> Result<(), WriteError> {
+    for member in members {
+        write_crew_member(guard, tx, crew_id, member)?;
+    }
+    Ok(())
+}
+
+fn insert_variants(
+    guard: &WriteGuard,
+    tx: &rusqlite::Transaction<'_>,
+    crew_id: i64,
+    variants: &[CrewVariantInput],
+) -> Result<(), WriteError> {
+    for variant in variants {
+        write_crew_variant(guard, tx, crew_id, variant)?;
+    }
+    Ok(())
+}
+
+fn write_armada(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    armada: &NewArmada,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO armadas (name, description) VALUES (?1, ?2)",
+        params![armada.name, armada.description],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_fleet(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    fleet: &NewFleet,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO fleets (armada_id, name, color) VALUES (?1, ?2, ?3)",
+        params![fleet.armada_id, fleet.name, fleet.color],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_flotilla(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    flotilla: &NewFlotilla,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO flotillas (fleet_id, name) VALUES (?1, ?2)",
+        params![flotilla.fleet_id, flotilla.name],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_crew(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    crew_name: &str,
+    crew_ulid: &str,
+) -> Result<i64, WriteError> {
+    conn.execute(
+        "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
+        params![crew_name, crew_ulid],
+    )
+    .map_err(map_write_error)?;
+    Ok(conn.last_insert_rowid())
+}
+
+fn write_crew_member(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    crew_id: i64,
+    member: &CrewMemberInput,
+) -> Result<(), WriteError> {
+    conn.execute(
+        "INSERT INTO crew_members (crew_id, member_id, role, ai_provider, model, startup_prompts_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            crew_id,
+            member.member_id,
+            member.role,
+            member.ai_provider,
+            member.model,
+            member.startup_prompts_json
+        ],
+    )
+    .map_err(map_write_error)?;
+    Ok(())
+}
+
+fn write_crew_variant(
+    _guard: &WriteGuard,
+    conn: &Connection,
+    crew_id: i64,
+    variant: &CrewVariantInput,
+) -> Result<(), WriteError> {
+    conn.execute(
+        "INSERT INTO crew_variants (crew_id, host_id, repo_url, branch_ref, root_path, config_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            crew_id,
+            variant.host_id,
+            variant.repo_url,
+            variant.branch_ref,
+            variant.root_path,
+            variant.config_json
+        ],
+    )
+    .map_err(map_write_error)?;
+    Ok(())
+}
+
+fn validate_placement(
+    tx: &rusqlite::Transaction<'_>,
+    placement: &CrewPlacementInput,
+) -> Result<(), WriteError> {
+    let fleet_armada: Option<i64> = tx
+        .query_row(
+            "SELECT armada_id FROM fleets WHERE id = ?1",
+            params![placement.fleet_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_write_error)?;
+
+    let Some(fleet_armada) = fleet_armada else {
+        return Err(WriteError::Validation(
+            "fleet_id does not exist".to_string(),
+        ));
+    };
+
+    if fleet_armada != placement.armada_id {
+        return Err(WriteError::Validation(
+            "fleet_id must belong to armada_id".to_string(),
+        ));
+    }
+
+    if let Some(flotilla_id) = placement.flotilla_id {
+        let flotilla_fleet: Option<i64> = tx
+            .query_row(
+                "SELECT fleet_id FROM flotillas WHERE id = ?1",
+                params![flotilla_id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(map_write_error)?;
+
+        let Some(flotilla_fleet) = flotilla_fleet else {
+            return Err(WriteError::Validation(
+                "flotilla_id does not exist".to_string(),
+            ));
+        };
+
+        if flotilla_fleet != placement.fleet_id {
+            return Err(WriteError::Validation(
+                "flotilla_id must belong to fleet_id".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_armada_exists(conn: &Connection, armada_id: i64) -> Result<(), WriteError> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM armadas WHERE id = ?1",
+            params![armada_id],
+            |r| r.get(0),
+        )
+        .map_err(map_write_error)?;
+    if !exists {
+        return Err(WriteError::NotFound);
+    }
+    Ok(())
+}
+
+fn ensure_fleet_exists(conn: &Connection, fleet_id: i64) -> Result<(), WriteError> {
+    let exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) > 0 FROM fleets WHERE id = ?1",
+            params![fleet_id],
+            |r| r.get(0),
+        )
+        .map_err(map_write_error)?;
+    if !exists {
+        return Err(WriteError::NotFound);
+    }
+    Ok(())
+}
+
+fn validate_captain_count(members: &[CrewMemberInput]) -> Result<(), WriteError> {
+    let captain_count = members
+        .iter()
+        .filter(|member| member.role.trim().eq_ignore_ascii_case("captain"))
+        .count();
+    if captain_count != 1 {
+        return Err(WriteError::Validation(
+            "crew must have exactly one captain".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn validate_approved_project(session_name: &str, config_json: &str) -> Result<(), WriteError> {
     let value: serde_json::Value = serde_json::from_str(config_json)
         .map_err(|err| WriteError::Validation(format!("invalid config_json JSON: {err}")))?;
@@ -123,10 +873,13 @@ fn validate_approved_project(session_name: &str, config_json: &str) -> Result<()
     Ok(())
 }
 
-fn map_write_error(err: anyhow::Error) -> WriteError {
+fn map_write_error(err: impl std::fmt::Display) -> WriteError {
     let message = err.to_string();
     if message.contains("UNIQUE constraint failed") {
         return WriteError::Conflict(message);
+    }
+    if message.contains("FOREIGN KEY constraint failed") {
+        return WriteError::Validation(message);
     }
     if message.contains("invalid") || message.contains("required") || message.contains("must") {
         return WriteError::Validation(message);

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -204,6 +204,13 @@ fn write_script(contents: &str) -> tempfile::TempPath {
     file.into_temp_path()
 }
 
+fn test_root_path(name: &str) -> String {
+    std::env::temp_dir()
+        .join(name)
+        .to_string_lossy()
+        .to_string()
+}
+
 fn set_env_var(key: &str, value: &str) -> Option<String> {
     let prev = std::env::var(key).ok();
     // SAFETY: test-only env mutation guarded by async mutex.
@@ -472,7 +479,7 @@ async fn t_ed_01_create_editor_hierarchy_and_crew_bundle() {
                     "host_id": h.state.host_id,
                     "repo_url": "git@github.com:randlee/scmux.git",
                     "branch_ref": "feature/demo",
-                    "root_path": "/tmp/scmux",
+                    "root_path": test_root_path("scmux"),
                     "config_json": { "session_name": "crew-alpha" }
                 }
             ],
@@ -549,7 +556,7 @@ async fn t_ed_02_clone_move_and_unlink_crew_ref_with_reference_count_delete() {
             "variants": [
                 {
                     "host_id": h.state.host_id,
-                    "root_path": "/tmp/crew-src"
+                    "root_path": test_root_path("crew-src")
                 }
             ],
             "placement": { "armada_id": armada_a, "fleet_id": fleet_a }
@@ -652,7 +659,7 @@ async fn t_ed_03_running_crew_blocks_roster_patch() {
             "variants": [
                 {
                     "host_id": h.state.host_id,
-                    "root_path": "/tmp/crew-running"
+                    "root_path": test_root_path("crew-running")
                 }
             ],
             "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
@@ -672,21 +679,10 @@ async fn t_ed_03_running_crew_blocks_roster_patch() {
             )
             .expect("crew id")
     };
-
-    let _guard = env_lock().lock().await;
-    let script = write_script(
-        r#"#!/bin/sh
-if [ "$1" = "list-sessions" ]; then
-  echo "crew-running"
-  exit 0
-fi
-if [ "$1" = "list-panes" ]; then
-  exit 0
-fi
-exit 1
-"#,
-    );
-    let prev_tmux = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
+    {
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.mark_starting("crew-running");
+    }
     let response = h
         .client
         .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
@@ -704,7 +700,6 @@ exit 1
         .send()
         .await
         .expect("patch running crew");
-    restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
 
     assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
     let body: Value = response.json().await.expect("json");
@@ -742,7 +737,7 @@ async fn t_ed_04_invalid_roster_patch_is_atomic() {
             "variants": [
                 {
                     "host_id": h.state.host_id,
-                    "root_path": "/tmp/crew-atomic"
+                    "root_path": test_root_path("crew-atomic")
                 }
             ],
             "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
@@ -805,6 +800,198 @@ async fn t_ed_04_invalid_roster_patch_is_atomic() {
             .expect("after count")
     };
     assert_eq!(after_count, 2);
+}
+
+#[tokio::test]
+async fn t_ed_05_clone_armada_and_fleet_endpoints() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Source Armada").await;
+    let fleet_id = h.create_fleet(armada_id, "Source Fleet").await;
+
+    let armada_clone = h
+        .client
+        .post(format!("{}/editor/armadas/{}/clone", h.base_url, armada_id))
+        .json(&json!({ "name": "Cloned Armada" }))
+        .send()
+        .await
+        .expect("clone armada");
+    assert_eq!(armada_clone.status(), reqwest::StatusCode::OK);
+
+    let cloned_armada_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM armadas WHERE name = 'Cloned Armada'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("cloned armada id")
+    };
+
+    let fleet_clone = h
+        .client
+        .post(format!("{}/editor/fleets/{}/clone", h.base_url, fleet_id))
+        .json(&json!({
+            "armada_id": cloned_armada_id,
+            "name": "Cloned Fleet"
+        }))
+        .send()
+        .await
+        .expect("clone fleet");
+    assert_eq!(fleet_clone.status(), reqwest::StatusCode::OK);
+
+    let db_conn = h.state.db.lock().expect("db lock");
+    let exists: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM fleets WHERE armada_id = ?1 AND name = 'Cloned Fleet'",
+            rusqlite::params![cloned_armada_id],
+            |r| r.get(0),
+        )
+        .expect("cloned fleet count");
+    assert_eq!(exists, 1);
+}
+
+#[tokio::test]
+async fn t_ed_06_create_crew_rejects_empty_startup_prompts() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Prompts").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let response = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-empty-prompts",
+            "crew_ulid": "01JEMPTYPROMPTS00000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": []
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": test_root_path("crew-empty-prompts")
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create invalid crew");
+
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["code"], "validation_error");
+}
+
+#[tokio::test]
+async fn t_ed_07_create_crew_rejects_empty_variants() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Variants").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let response = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-no-variants",
+            "crew_ulid": "01JNOVARIANTS000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["lead.md"]
+                }
+            ],
+            "variants": [],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create invalid crew");
+
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["code"], "validation_error");
+}
+
+#[tokio::test]
+async fn t_ed_08_running_guard_uses_runtime_projection() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Runtime").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-runtime-guard",
+            "crew_ulid": "01JRUNTIMEGUARD0000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": test_root_path("crew-runtime-guard")
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-runtime-guard'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+    {
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.mark_starting("crew-runtime-guard");
+    }
+
+    let response = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["updated.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("patch crew");
+
+    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["code"], "running_edit_forbidden");
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -356,6 +356,45 @@ async fn t_lc_01_post_sessions_name_start_launches_tmux_from_config() {
 }
 
 #[tokio::test]
+async fn t_lc_08_concurrent_start_rejected_when_action_in_progress() {
+    let h = ApiHarness::new().await;
+    h.create_session("alpha").await;
+
+    let _guard = env_lock().lock().await;
+    let script = write_script("#!/bin/sh\nsleep 1\nexit 0\n");
+    let prev = set_env_var("SCMUX_TMUXP_BIN", script.to_string_lossy().as_ref());
+
+    let first_client = h.client.clone();
+    let first_url = format!("{}/sessions/alpha/start", h.base_url);
+    let first = tokio::spawn(async move {
+        first_client
+            .post(first_url)
+            .send()
+            .await
+            .expect("first start request")
+    });
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    let second = h
+        .client
+        .post(format!("{}/sessions/alpha/start", h.base_url))
+        .send()
+        .await
+        .expect("second start request");
+
+    let first = first.await.expect("join first");
+    restore_env_var("SCMUX_TMUXP_BIN", prev);
+
+    assert_eq!(second.status(), reqwest::StatusCode::CONFLICT);
+    let second_body: Value = second.json().await.expect("second json");
+    assert_eq!(second_body["code"], "action_in_progress");
+
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+    let first_body: Value = first.json().await.expect("first json");
+    assert_eq!(first_body["ok"], true);
+}
+
+#[tokio::test]
 async fn t_lc_06_start_failure_returns_500_and_keeps_session_stopped() {
     let h = ApiHarness::new().await;
     h.create_session("alpha").await;
@@ -393,6 +432,43 @@ async fn t_lc_06_start_failure_returns_500_and_keeps_session_stopped() {
     assert_eq!(sessions.status(), reqwest::StatusCode::OK);
     let rows: Vec<Value> = sessions.json().await.expect("json");
     assert_eq!(rows[0]["status"], "stopped");
+}
+
+#[tokio::test]
+async fn t_rb_02_single_session_start_failure_does_not_cascade() {
+    let h = ApiHarness::new().await;
+    h.create_session("alpha").await;
+    h.create_session("beta").await;
+
+    let _guard = env_lock().lock().await;
+    let fail_script = write_script("#!/bin/sh\necho \"tmuxp failed\" 1>&2\nexit 1\n");
+    let prev = set_env_var("SCMUX_TMUXP_BIN", fail_script.to_string_lossy().as_ref());
+
+    let alpha_response = h
+        .client
+        .post(format!("{}/sessions/alpha/start", h.base_url))
+        .send()
+        .await
+        .expect("alpha start request");
+    assert_eq!(
+        alpha_response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
+
+    let ok_script = write_script("#!/bin/sh\nexit 0\n");
+    set_env_var("SCMUX_TMUXP_BIN", ok_script.to_string_lossy().as_ref());
+
+    let beta_response = h
+        .client
+        .post(format!("{}/sessions/beta/start", h.base_url))
+        .send()
+        .await
+        .expect("beta start request");
+    restore_env_var("SCMUX_TMUXP_BIN", prev);
+
+    assert_eq!(beta_response.status(), reqwest::StatusCode::OK);
+    let beta_body: Value = beta_response.json().await.expect("beta json");
+    assert_eq!(beta_body["ok"], true);
 }
 
 #[tokio::test]
@@ -445,6 +521,57 @@ exit 1
         marker_log.contains("kill\n"),
         "expected tmux hard-stop after grace timeout, got: {marker_log:?}"
     );
+}
+
+#[tokio::test]
+async fn t_rb_03_stop_error_path_does_not_issue_bulk_stop() {
+    let h = ApiHarness::new().await;
+    h.create_session("alpha").await;
+    h.create_session("beta").await;
+
+    let _guard = env_lock().lock().await;
+    let marker = tempfile::NamedTempFile::new().expect("marker file");
+    let marker_path = marker.path().to_string_lossy().to_string();
+
+    let script = write_script(&format!(
+        r#"#!/bin/sh
+if [ "$1" = "list-sessions" ]; then
+  echo "alpha"
+  echo "beta"
+  exit 0
+fi
+if [ "$1" = "kill-session" ]; then
+  echo "$3" >> "{marker_path}"
+  if [ "$3" = "alpha" ]; then
+    echo "forced failure" 1>&2
+    exit 1
+  fi
+  exit 0
+fi
+exit 1
+"#,
+    ));
+    let prev_tmux = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
+
+    let response = h
+        .client
+        .post(format!("{}/sessions/alpha/stop", h.base_url))
+        .send()
+        .await
+        .expect("stop alpha request");
+    restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
+
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["ok"], false);
+
+    let marker_log = std::fs::read_to_string(marker.path()).expect("read marker");
+    let attempts = marker_log
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    assert_eq!(attempts, vec!["alpha"]);
 }
 
 #[tokio::test]
@@ -706,6 +833,166 @@ async fn t_ed_03_running_crew_blocks_roster_patch() {
     assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
     let body: Value = response.json().await.expect("json");
     assert_eq!(body["code"], "running_edit_forbidden");
+}
+
+#[tokio::test]
+async fn t_ed_09_starting_runtime_blocks_roster_patch() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Run").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-starting",
+            "crew_ulid": "01JCREWSTARTING00000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": test_root_path("crew-starting")
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-starting");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-starting'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+    {
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.mark_starting("crew-starting");
+    }
+
+    let response = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["updated.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("patch crew-starting");
+
+    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["code"], "running_edit_forbidden");
+}
+
+#[tokio::test]
+async fn t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress() {
+    let h = ApiHarness::new().await;
+    h.create_session("crew-action").await;
+    let armada_id = h.create_armada("Action").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-action",
+            "crew_ulid": "01JCREWACTION000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": test_root_path("crew-action")
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-action");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-action'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+
+    let _guard = env_lock().lock().await;
+    let slow_script = write_script("#!/bin/sh\nsleep 1\nexit 0\n");
+    let prev = set_env_var("SCMUX_TMUXP_BIN", slow_script.to_string_lossy().as_ref());
+
+    let start_client = h.client.clone();
+    let start_url = format!("{}/sessions/crew-action/start", h.base_url);
+    let start_task = tokio::spawn(async move {
+        start_client
+            .post(start_url)
+            .send()
+            .await
+            .expect("start request")
+    });
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    let patch_response = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["updated.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("patch request");
+
+    let start_response = start_task.await.expect("join start");
+    restore_env_var("SCMUX_TMUXP_BIN", prev);
+    assert_eq!(start_response.status(), reqwest::StatusCode::OK);
+
+    assert_eq!(patch_response.status(), reqwest::StatusCode::CONFLICT);
+    let patch_body: Value = patch_response.json().await.expect("patch json");
+    assert_eq!(patch_body["code"], "action_in_progress");
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -101,11 +101,13 @@ impl ApiHarness {
     }
 
     async fn create_session(&self, name: &str) {
+        let root_path = self._tmp.path().to_string_lossy().to_string();
         let payload = json!({
             "name": name,
             "project": "demo",
             "config_json": {
                 "session_name": name,
+                "root_path": root_path,
                 "panes": [
                     { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
                 ]
@@ -353,6 +355,78 @@ async fn t_lc_01_post_sessions_name_start_launches_tmux_from_config() {
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Value = response.json().await.expect("json");
     assert_eq!(body["ok"], true);
+}
+
+#[tokio::test]
+async fn t_lc_07_start_rejects_invalid_crew_variant_binding() {
+    let h = ApiHarness::new().await;
+    h.create_session("crew-invalid").await;
+
+    {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .execute(
+                "INSERT INTO crews (crew_name, crew_ulid) VALUES (?1, ?2)",
+                rusqlite::params!["crew-invalid", "01JCREWINVALID000000000000"],
+            )
+            .expect("insert crew");
+        let crew_id: i64 = db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-invalid'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id");
+        db_conn
+            .execute(
+                "INSERT INTO crew_variants (crew_id, host_id, root_path) VALUES (?1, ?2, ?3)",
+                rusqlite::params![crew_id, h.state.host_id, "/path/does/not/exist"],
+            )
+            .expect("insert variant");
+    }
+
+    let response = h
+        .client
+        .post(format!("{}/sessions/crew-invalid/start", h.base_url))
+        .send()
+        .await
+        .expect("start request");
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["code"], "invalid_crew_variant_binding");
+}
+
+#[tokio::test]
+async fn t_lc_08_start_rejects_missing_root_path_when_no_crew_variant() {
+    let h = ApiHarness::new().await;
+    let response = h
+        .client
+        .post(format!("{}/sessions", h.base_url))
+        .json(&json!({
+            "name": "missing-root",
+            "project": "demo",
+            "config_json": {
+                "session_name": "missing-root",
+                "panes": [
+                    { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
+                ]
+            },
+            "auto_start": false
+        }))
+        .send()
+        .await
+        .expect("create session");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let start = h
+        .client
+        .post(format!("{}/sessions/missing-root/start", h.base_url))
+        .send()
+        .await
+        .expect("start session");
+    assert_eq!(start.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = start.json().await.expect("json");
+    assert_eq!(body["code"], "invalid_crew_variant_binding");
 }
 
 #[tokio::test]
@@ -913,6 +987,8 @@ async fn t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress() {
     h.create_session("crew-action").await;
     let armada_id = h.create_armada("Action").await;
     let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+    let _crew_root = tempfile::tempdir().expect("temp crew-action root");
+    let crew_root_path = _crew_root.path().display().to_string();
 
     let create = h
         .client
@@ -932,7 +1008,7 @@ async fn t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress() {
             "variants": [
                 {
                     "host_id": h.state.host_id,
-                    "root_path": test_root_path("crew-action")
+                    "root_path": crew_root_path
                 }
             ],
             "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
@@ -1089,6 +1165,208 @@ async fn t_ed_04_invalid_roster_patch_is_atomic() {
             .expect("after count")
     };
     assert_eq!(after_count, 2);
+}
+
+#[tokio::test]
+async fn t_ed_05_import_discovery_creates_crew_bundle() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Import").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    {
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        let mut live = std::collections::HashMap::new();
+        live.insert(
+            "external-session".to_string(),
+            vec![
+                PaneInfo {
+                    index: 0,
+                    name: "team-lead".to_string(),
+                    status: "active".to_string(),
+                    last_activity: "now".to_string(),
+                    current_command: "claude".to_string(),
+                },
+                PaneInfo {
+                    index: 1,
+                    name: "arch-cmux".to_string(),
+                    status: "idle".to_string(),
+                    last_activity: "now".to_string(),
+                    current_command: "codex".to_string(),
+                },
+            ],
+        );
+        runtime.apply_tmux_snapshot(
+            &Vec::new(),
+            &live,
+            &std::collections::HashMap::new(),
+            "2026-03-08T00:00:00Z",
+        );
+    }
+
+    let response = h
+        .client
+        .post(format!("{}/editor/import-discovery", h.base_url))
+        .json(&json!({
+            "session_name": "external-session",
+            "armada_id": armada_id,
+            "fleet_id": fleet_id,
+            "root_path": test_root_path("external-session"),
+            "member_intents": [
+                {
+                    "pane_name": "team-lead",
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["prompts/lead.md"]
+                },
+                {
+                    "pane_name": "arch-cmux",
+                    "member_id": "arch-cmux",
+                    "role": "mate",
+                    "ai_provider": "codex",
+                    "model": "codex-high",
+                    "startup_prompts": ["prompts/arch.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("import discovery request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let db_conn = h.state.db.lock().expect("db lock");
+    let crew_count: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crews WHERE crew_name = 'external-session'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("crew count");
+    let member_count: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_members cm JOIN crews c ON c.id = cm.crew_id WHERE c.crew_name = 'external-session'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("member count");
+    assert_eq!(crew_count, 1);
+    assert_eq!(member_count, 2);
+}
+
+#[tokio::test]
+async fn t_rt_01_runtime_crews_and_unregistered_discovery_endpoints() {
+    let h = ApiHarness::new().await;
+    h.create_session("legacy-defined").await;
+    let armada_id = h.create_armada("Runtime").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+    let root = tempfile::tempdir().expect("temp root");
+    let root_path = root.path().to_string_lossy().to_string();
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-runtime",
+            "crew_ulid": "01JCREWRUNTIME000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": root_path
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create runtime crew");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    {
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        let mut live = std::collections::HashMap::new();
+        live.insert(
+            "crew-runtime".to_string(),
+            vec![PaneInfo {
+                index: 0,
+                name: "team-lead".to_string(),
+                status: "active".to_string(),
+                last_activity: "now".to_string(),
+                current_command: "claude".to_string(),
+            }],
+        );
+        live.insert(
+            "unregistered".to_string(),
+            vec![PaneInfo {
+                index: 0,
+                name: "solo".to_string(),
+                status: "idle".to_string(),
+                last_activity: "now".to_string(),
+                current_command: "bash".to_string(),
+            }],
+        );
+        live.insert(
+            "legacy-defined".to_string(),
+            vec![PaneInfo {
+                index: 0,
+                name: "legacy".to_string(),
+                status: "idle".to_string(),
+                last_activity: "now".to_string(),
+                current_command: "bash".to_string(),
+            }],
+        );
+        runtime.apply_tmux_snapshot(
+            &Vec::new(),
+            &live,
+            &std::collections::HashMap::new(),
+            "2026-03-08T00:00:00Z",
+        );
+    }
+
+    let runtime_response = h
+        .client
+        .get(format!("{}/runtime/crews", h.base_url))
+        .send()
+        .await
+        .expect("runtime crews request");
+    assert_eq!(runtime_response.status(), reqwest::StatusCode::OK);
+    let runtime_body: Value = runtime_response.json().await.expect("runtime json");
+    let runtime_rows = runtime_body.as_array().expect("runtime array");
+    assert!(runtime_rows.iter().any(|row| {
+        row["crew_name"] == "crew-runtime"
+            && row["discovered"] == true
+            && row["binding_valid"] == true
+    }));
+
+    let unregistered_response = h
+        .client
+        .get(format!("{}/runtime/discovery/unregistered", h.base_url))
+        .send()
+        .await
+        .expect("unregistered discovery request");
+    assert_eq!(unregistered_response.status(), reqwest::StatusCode::OK);
+    let unregistered_body: Value = unregistered_response
+        .json()
+        .await
+        .expect("unregistered json");
+    let names = unregistered_body
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|row| row["name"].as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+    assert!(names.contains(&"unregistered".to_string()));
+    assert!(!names.contains(&"crew-runtime".to_string()));
+    assert!(!names.contains(&"legacy-defined".to_string()));
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -121,6 +121,66 @@ impl ApiHarness {
             .expect("create session request");
         assert_eq!(response.status(), reqwest::StatusCode::OK);
     }
+
+    async fn create_armada(&self, name: &str) -> i64 {
+        let response = self
+            .client
+            .post(format!("{}/editor/armadas", self.base_url))
+            .json(&json!({ "name": name }))
+            .send()
+            .await
+            .expect("create armada request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let db_conn = self.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM armadas WHERE name = ?1",
+                rusqlite::params![name],
+                |r| r.get(0),
+            )
+            .expect("armada id")
+    }
+
+    async fn create_fleet(&self, armada_id: i64, name: &str) -> i64 {
+        let response = self
+            .client
+            .post(format!("{}/editor/fleets", self.base_url))
+            .json(&json!({ "armada_id": armada_id, "name": name }))
+            .send()
+            .await
+            .expect("create fleet request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let db_conn = self.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM fleets WHERE armada_id = ?1 AND name = ?2",
+                rusqlite::params![armada_id, name],
+                |r| r.get(0),
+            )
+            .expect("fleet id")
+    }
+
+    async fn create_flotilla(&self, fleet_id: i64, name: &str) -> i64 {
+        let response = self
+            .client
+            .post(format!("{}/editor/flotillas", self.base_url))
+            .json(&json!({ "fleet_id": fleet_id, "name": name }))
+            .send()
+            .await
+            .expect("create flotilla request");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+        let db_conn = self.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM flotillas WHERE fleet_id = ?1 AND name = ?2",
+                rusqlite::params![fleet_id, name],
+                |r| r.get(0),
+            )
+            .expect("flotilla id")
+    }
 }
 
 impl Drop for ApiHarness {
@@ -376,6 +436,375 @@ exit 1
         marker_log.contains("kill\n"),
         "expected tmux hard-stop after grace timeout, got: {marker_log:?}"
     );
+}
+
+#[tokio::test]
+async fn t_ed_01_create_editor_hierarchy_and_crew_bundle() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Work Dev").await;
+    let fleet_id = h.create_fleet(armada_id, "Core").await;
+    let flotilla_id = h.create_flotilla(fleet_id, "Backend").await;
+
+    let response = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-alpha",
+            "crew_ulid": "01JCREWALPHA00000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["prompts/arch-startup.md", "prompts/pm-startup.md"]
+                },
+                {
+                    "member_id": "arch-cmux",
+                    "role": "mate",
+                    "ai_provider": "codex",
+                    "model": "codex-high",
+                    "startup_prompts": ["prompts/arch-cmux-startup.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "repo_url": "git@github.com:randlee/scmux.git",
+                    "branch_ref": "feature/demo",
+                    "root_path": "/tmp/scmux",
+                    "config_json": { "session_name": "crew-alpha" }
+                }
+            ],
+            "placement": {
+                "armada_id": armada_id,
+                "fleet_id": fleet_id,
+                "flotilla_id": flotilla_id
+            }
+        }))
+        .send()
+        .await
+        .expect("create crew bundle");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let db_conn = h.state.db.lock().expect("db lock");
+    let crews: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crews WHERE crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("crew count");
+    let members: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_members cm JOIN crews c ON c.id = cm.crew_id WHERE c.crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("member count");
+    let variants: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_variants cv JOIN crews c ON c.id = cv.crew_id WHERE c.crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("variant count");
+    let refs_count: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_refs cr JOIN crews c ON c.id = cr.crew_id WHERE c.crew_name = 'crew-alpha'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("ref count");
+
+    assert_eq!(crews, 1);
+    assert_eq!(members, 2);
+    assert_eq!(variants, 1);
+    assert_eq!(refs_count, 1);
+}
+
+#[tokio::test]
+async fn t_ed_02_clone_move_and_unlink_crew_ref_with_reference_count_delete() {
+    let h = ApiHarness::new().await;
+    let armada_a = h.create_armada("A").await;
+    let fleet_a = h.create_fleet(armada_a, "Fleet-A").await;
+    let armada_b = h.create_armada("B").await;
+    let fleet_b = h.create_fleet(armada_b, "Fleet-B").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-src",
+            "crew_ulid": "01JCREWSRC0000000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": "/tmp/crew-src"
+                }
+            ],
+            "placement": { "armada_id": armada_a, "fleet_id": fleet_a }
+        }))
+        .send()
+        .await
+        .expect("create source crew");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let (source_crew_id, source_ref_id): (i64, i64) = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT c.id, r.id FROM crews c JOIN crew_refs r ON r.crew_id = c.id WHERE c.crew_name = 'crew-src' LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("source ids")
+    };
+
+    let clone = h
+        .client
+        .post(format!(
+            "{}/editor/crews/{}/clone",
+            h.base_url, source_crew_id
+        ))
+        .json(&json!({
+            "crew_name": "crew-clone",
+            "crew_ulid": "01JCREWCLONE00000000000000",
+            "placement": { "armada_id": armada_b, "fleet_id": fleet_b }
+        }))
+        .send()
+        .await
+        .expect("clone crew");
+    assert_eq!(clone.status(), reqwest::StatusCode::OK);
+
+    let move_ref = h
+        .client
+        .post(format!(
+            "{}/editor/crew-refs/{}/move",
+            h.base_url, source_ref_id
+        ))
+        .json(&json!({
+            "armada_id": armada_b,
+            "fleet_id": fleet_b
+        }))
+        .send()
+        .await
+        .expect("move crew ref");
+    assert_eq!(move_ref.status(), reqwest::StatusCode::OK);
+
+    let unlink = h
+        .client
+        .delete(format!("{}/editor/crew-refs/{}", h.base_url, source_ref_id))
+        .send()
+        .await
+        .expect("unlink crew ref");
+    assert_eq!(unlink.status(), reqwest::StatusCode::OK);
+
+    let db_conn = h.state.db.lock().expect("db lock");
+    let source_exists: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crews WHERE id = ?1",
+            rusqlite::params![source_crew_id],
+            |r| r.get(0),
+        )
+        .expect("source exists count");
+    let clone_exists: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crews WHERE crew_name = 'crew-clone'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("clone exists count");
+    assert_eq!(source_exists, 0);
+    assert_eq!(clone_exists, 1);
+}
+
+#[tokio::test]
+async fn t_ed_03_running_crew_blocks_roster_patch() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Run").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-running",
+            "crew_ulid": "01JCREWRUN000000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": "/tmp/crew-running"
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-running");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-running'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+
+    let _guard = env_lock().lock().await;
+    let script = write_script(
+        r#"#!/bin/sh
+if [ "$1" = "list-sessions" ]; then
+  echo "crew-running"
+  exit 0
+fi
+if [ "$1" = "list-panes" ]; then
+  exit 0
+fi
+exit 1
+"#,
+    );
+    let prev_tmux = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
+    let response = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["updated.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("patch running crew");
+    restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
+
+    assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
+    let body: Value = response.json().await.expect("json");
+    assert_eq!(body["code"], "running_edit_forbidden");
+}
+
+#[tokio::test]
+async fn t_ed_04_invalid_roster_patch_is_atomic() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Atomic").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-atomic",
+            "crew_ulid": "01JCREWATOMIC000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                },
+                {
+                    "member_id": "arch-cmux",
+                    "role": "mate",
+                    "ai_provider": "codex",
+                    "model": "codex-high",
+                    "startup_prompts": ["b.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": "/tmp/crew-atomic"
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-atomic");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-atomic'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+
+    let before_count: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT COUNT(*) FROM crew_members WHERE crew_id = ?1",
+                rusqlite::params![crew_id],
+                |r| r.get(0),
+            )
+            .expect("before count")
+    };
+    assert_eq!(before_count, 2);
+
+    let response = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "members": [
+                {
+                    "member_id": "arch-cmux",
+                    "role": "mate",
+                    "ai_provider": "codex",
+                    "model": "codex-high",
+                    "startup_prompts": ["only-mate.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("invalid patch request");
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let after_count: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT COUNT(*) FROM crew_members WHERE crew_id = ?1",
+                rusqlite::params![crew_id],
+                |r| r.get(0),
+            )
+            .expect("after count")
+    };
+    assert_eq!(after_count, 2);
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -245,6 +245,8 @@ async fn t_a_01_get_health_returns_200_with_correct_fields() {
     assert_eq!(body["status"], "ok");
     assert!(body["uptime_secs"].as_u64().is_some());
     assert!(body["session_count"].as_i64().is_some());
+    assert!(body["atm_available"].as_bool().is_some());
+    assert!(body["atm_socket_available"].as_bool().is_some());
     assert!(body["db_path"].as_str().is_some());
     assert!(body["version"].as_str().is_some());
 }

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -430,6 +430,48 @@ async fn t_lc_08_start_rejects_missing_root_path_when_no_crew_variant() {
 }
 
 #[tokio::test]
+async fn t_lc_09_start_rejects_unresolvable_startup_prompt_paths() {
+    let h = ApiHarness::new().await;
+    let root = tempfile::tempdir().expect("temp root");
+    let root_path = root.path().to_string_lossy().to_string();
+    let response = h
+        .client
+        .post(format!("{}/sessions", h.base_url))
+        .json(&json!({
+            "name": "prompt-missing",
+            "project": "demo",
+            "config_json": {
+                "session_name": "prompt-missing",
+                "root_path": root_path,
+                "panes": [
+                    {
+                        "name": "agent",
+                        "command": "sleep 1",
+                        "atm_agent": "agent",
+                        "atm_team": "scmux-dev",
+                        "startup_prompts_json": "[\"prompts/missing.md\"]"
+                    }
+                ]
+            },
+            "auto_start": false
+        }))
+        .send()
+        .await
+        .expect("create session");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let start = h
+        .client
+        .post(format!("{}/sessions/prompt-missing/start", h.base_url))
+        .send()
+        .await
+        .expect("start session");
+    assert_eq!(start.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = start.json().await.expect("json");
+    assert_eq!(body["code"], "invalid_config");
+}
+
+#[tokio::test]
 async fn t_lc_08_concurrent_start_rejected_when_action_in_progress() {
     let h = ApiHarness::new().await;
     h.create_session("alpha").await;
@@ -1072,6 +1114,132 @@ async fn t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress() {
 }
 
 #[tokio::test]
+async fn t_crew_rename_forbidden() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Rename").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+    let root = tempfile::tempdir().expect("temp root");
+    let root_path = root.path().display().to_string();
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-rename",
+            "crew_ulid": "01JCREWRENAME000000000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": root_path
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-rename");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-rename'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+
+    let patch = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "crew_name": "crew-rename-new"
+        }))
+        .send()
+        .await
+        .expect("rename patch");
+    assert_eq!(patch.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+    let body: Value = patch.json().await.expect("json");
+    assert_eq!(body["code"], "crew_rename_forbidden");
+}
+
+#[tokio::test]
+async fn t_ed_11_running_crew_blocks_crew_ulid_patch() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Run Ulid").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+    let root = tempfile::tempdir().expect("temp root");
+    let root_path = root.path().display().to_string();
+
+    let create = h
+        .client
+        .post(format!("{}/editor/crews", h.base_url))
+        .json(&json!({
+            "crew_name": "crew-ulid-running",
+            "crew_ulid": "01JCREWULIDRUNNING0000000",
+            "members": [
+                {
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["a.md"]
+                }
+            ],
+            "variants": [
+                {
+                    "host_id": h.state.host_id,
+                    "root_path": root_path
+                }
+            ],
+            "placement": { "armada_id": armada_id, "fleet_id": fleet_id }
+        }))
+        .send()
+        .await
+        .expect("create crew-ulid-running");
+    assert_eq!(create.status(), reqwest::StatusCode::OK);
+
+    let crew_id: i64 = {
+        let db_conn = h.state.db.lock().expect("db lock");
+        db_conn
+            .query_row(
+                "SELECT id FROM crews WHERE crew_name = 'crew-ulid-running'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("crew id")
+    };
+    {
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        runtime.mark_starting("crew-ulid-running");
+    }
+
+    let patch = h
+        .client
+        .patch(format!("{}/editor/crews/{}", h.base_url, crew_id))
+        .json(&json!({
+            "crew_ulid": "01JCREWULIDRUNNING1111111"
+        }))
+        .send()
+        .await
+        .expect("ulid patch");
+    assert_eq!(patch.status(), reqwest::StatusCode::CONFLICT);
+    let body: Value = patch.json().await.expect("json");
+    assert_eq!(body["code"], "running_edit_forbidden");
+}
+
+#[tokio::test]
 async fn t_ed_04_invalid_roster_patch_is_atomic() {
     let h = ApiHarness::new().await;
     let armada_id = h.create_armada("Atomic").await;
@@ -1252,6 +1420,85 @@ async fn t_ed_05_import_discovery_creates_crew_bundle() {
         .expect("member count");
     assert_eq!(crew_count, 1);
     assert_eq!(member_count, 2);
+}
+
+#[tokio::test]
+async fn t_ed_11_import_discovery_partial_mapping_creates_stub_members() {
+    let h = ApiHarness::new().await;
+    let armada_id = h.create_armada("Import Partial").await;
+    let fleet_id = h.create_fleet(armada_id, "Fleet").await;
+
+    {
+        let mut runtime = h.state.runtime.lock().expect("runtime lock");
+        let mut live = std::collections::HashMap::new();
+        live.insert(
+            "external-partial".to_string(),
+            vec![
+                PaneInfo {
+                    index: 0,
+                    name: "team-lead".to_string(),
+                    status: "active".to_string(),
+                    last_activity: "now".to_string(),
+                    current_command: "claude".to_string(),
+                },
+                PaneInfo {
+                    index: 1,
+                    name: "arch-cmux".to_string(),
+                    status: "idle".to_string(),
+                    last_activity: "now".to_string(),
+                    current_command: "codex".to_string(),
+                },
+            ],
+        );
+        runtime.apply_tmux_snapshot(
+            &Vec::new(),
+            &live,
+            &std::collections::HashMap::new(),
+            "2026-03-08T00:00:00Z",
+        );
+    }
+
+    let response = h
+        .client
+        .post(format!("{}/editor/import-discovery", h.base_url))
+        .json(&json!({
+            "session_name": "external-partial",
+            "armada_id": armada_id,
+            "fleet_id": fleet_id,
+            "root_path": test_root_path("external-partial"),
+            "member_intents": [
+                {
+                    "pane_name": "team-lead",
+                    "member_id": "team-lead",
+                    "role": "captain",
+                    "ai_provider": "claude",
+                    "model": "claude-opus",
+                    "startup_prompts": ["prompts/lead.md"]
+                }
+            ]
+        }))
+        .send()
+        .await
+        .expect("import discovery request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let db_conn = h.state.db.lock().expect("db lock");
+    let member_count: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_members cm JOIN crews c ON c.id = cm.crew_id WHERE c.crew_name = 'external-partial'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("member count");
+    let unknown_count: i64 = db_conn
+        .query_row(
+            "SELECT COUNT(*) FROM crew_members cm JOIN crews c ON c.id = cm.crew_id WHERE c.crew_name = 'external-partial' AND cm.role = 'unknown'",
+            [],
+            |r| r.get(0),
+        )
+        .expect("unknown role count");
+    assert_eq!(member_count, 2);
+    assert_eq!(unknown_count, 1);
 }
 
 #[tokio::test]

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -327,7 +327,7 @@ async fn t_lc_06_start_failure_returns_500_and_keeps_session_stopped() {
 }
 
 #[tokio::test]
-async fn t_lc_03_stop_sends_atm_then_grace_then_hard_stop() {
+async fn t_lc_03_stop_grace_then_hard_stop_when_atm_send_is_stubbed() {
     let h = ApiHarness::new().await;
     h.create_session("alpha").await;
 
@@ -348,17 +348,7 @@ fi
 exit 1
 "#,
     ));
-    let atm_script = write_script(&format!(
-        r#"#!/bin/sh
-if [ "$1" = "send" ]; then
-  echo "send" >> "{marker_path}"
-  exit 0
-fi
-exit 1
-"#
-    ));
     let prev_tmux = set_env_var("SCMUX_TMUX_BIN", script.to_string_lossy().as_ref());
-    let prev_atm = set_env_var("SCMUX_ATM_BIN", atm_script.to_string_lossy().as_ref());
     let started = Instant::now();
 
     let response = h
@@ -368,7 +358,6 @@ exit 1
         .await
         .expect("stop request");
     restore_env_var("SCMUX_TMUX_BIN", prev_tmux);
-    restore_env_var("SCMUX_ATM_BIN", prev_atm);
 
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Value = response.json().await.expect("json");
@@ -384,8 +373,8 @@ exit 1
 
     let marker_log = std::fs::read_to_string(marker.path()).expect("read marker");
     assert!(
-        marker_log.contains("send\nkill\n"),
-        "expected ATM send before tmux hard-stop, got: {marker_log:?}"
+        marker_log.contains("kill\n"),
+        "expected tmux hard-stop after grace timeout, got: {marker_log:?}"
     );
 }
 

--- a/crates/scmux-daemon/tests/ci_tests.rs
+++ b/crates/scmux-daemon/tests/ci_tests.rs
@@ -76,7 +76,7 @@ fn insert_ci_session(
             project: Some("ci".to_string()),
             host_id: state.host_id,
             config_json: format!(
-                r#"{{"session_name":"{name}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
+                r#"{{"session_name":"{name}","root_path":"/tmp","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
             ),
             cron_schedule: None,
             auto_start: false,

--- a/crates/scmux-daemon/tests/e2e_tests.rs
+++ b/crates/scmux-daemon/tests/e2e_tests.rs
@@ -114,6 +114,7 @@ impl E2eHarness {
             "project": "e2e",
             "config_json": {
                 "session_name": name,
+                "root_path": "/tmp",
                 "panes": [
                     { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
                 ]

--- a/crates/scmux-daemon/tests/integration_tests.rs
+++ b/crates/scmux-daemon/tests/integration_tests.rs
@@ -115,7 +115,7 @@ fn insert_session(
             project: Some("integration".to_string()),
             host_id: state.host_id,
             config_json: format!(
-                r#"{{"session_name":"{name}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
+                r#"{{"session_name":"{name}","root_path":"/tmp","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
             ),
             cron_schedule,
             auto_start,
@@ -282,7 +282,7 @@ async fn t_i_06_invalid_cron_does_not_attempt_start() {
                     name,
                     state.host_id,
                     format!(
-                        r#"{{"session_name":"{}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#,
+                        r#"{{"session_name":"{}","root_path":"/tmp","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#,
                         name
                     )
                 ],
@@ -593,7 +593,7 @@ async fn t_wg_01_definition_writer_create_path_mutates_sqlite() {
                 project: Some("writer-gate".to_string()),
                 host_id: state.host_id,
                 config_json: format!(
-                    r#"{{"session_name":"{name}","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
+                    r#"{{"session_name":"{name}","root_path":"/tmp","panes":[{{"name":"agent","command":"sleep 1","atm_agent":"agent","atm_team":"scmux-dev"}}]}}"#
                 ),
                 cron_schedule: None,
                 auto_start: false,
@@ -683,7 +683,7 @@ async fn t_wg_03_unapproved_project_write_is_rejected() {
             name: name.clone(),
             project: Some("writer-gate".to_string()),
             host_id: state.host_id,
-            config_json: format!(r#"{{"session_name":"{name}","panes":[]}}"#),
+            config_json: format!(r#"{{"session_name":"{name}","root_path":"/tmp","panes":[]}}"#),
             cron_schedule: None,
             auto_start: false,
             github_repo: None,

--- a/crates/scmux/src/client.rs
+++ b/crates/scmux/src/client.rs
@@ -185,6 +185,8 @@ pub struct HealthResponse {
     #[serde(default)]
     pub atm_available: bool,
     #[serde(default)]
+    pub atm_socket_available: bool,
+    #[serde(default)]
     pub ci_available: Option<CiAvailability>,
     #[serde(default)]
     pub pollers: Option<PollerStates>,
@@ -215,6 +217,32 @@ pub struct PollerStates {
     pub hosts: PollerHealth,
     pub ci: PollerHealth,
     pub atm: PollerHealth,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DiscoverySession {
+    pub name: String,
+    #[serde(default)]
+    pub panes: Vec<PaneSummary>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RuntimeCrewSummary {
+    pub crew_id: i64,
+    pub crew_name: String,
+    pub crew_ulid: String,
+    pub host_id: i64,
+    pub root_path: String,
+    #[serde(default)]
+    pub repo_url: Option<String>,
+    #[serde(default)]
+    pub branch_ref: Option<String>,
+    pub status: String,
+    pub discovered: bool,
+    pub pane_count: usize,
+    pub binding_valid: bool,
+    #[serde(default)]
+    pub binding_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -363,6 +391,16 @@ impl ApiClient {
 
     pub async fn health(&self) -> Result<HealthResponse, ClientError> {
         self.request_json(Method::GET, "/health", None::<&()>).await
+    }
+
+    pub async fn list_runtime_crews(&self) -> Result<Vec<RuntimeCrewSummary>, ClientError> {
+        self.request_json(Method::GET, "/runtime/crews", None::<&()>)
+            .await
+    }
+
+    pub async fn list_unregistered_discovery(&self) -> Result<Vec<DiscoverySession>, ClientError> {
+        self.request_json(Method::GET, "/runtime/discovery/unregistered", None::<&()>)
+            .await
     }
 
     async fn request_json<T, B>(

--- a/crates/scmux/src/main.rs
+++ b/crates/scmux/src/main.rs
@@ -80,7 +80,9 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
         },
         Command::Doctor => {
             let health = client.health().await.map_err(map_client_error)?;
-            output::print_doctor(&health);
+            let runtime_crews = client.list_runtime_crews().await.ok();
+            let unregistered = client.list_unregistered_discovery().await.ok();
+            output::print_doctor(&health, runtime_crews.as_deref(), unregistered.as_deref());
         }
     }
 

--- a/crates/scmux/src/output.rs
+++ b/crates/scmux/src/output.rs
@@ -1,6 +1,9 @@
 //! Terminal output formatting helpers for `scmux` commands.
 
-use crate::client::{ActionResponse, HealthResponse, HostSummary, SessionSummary};
+use crate::client::{
+    ActionResponse, DiscoverySession, HealthResponse, HostSummary, RuntimeCrewSummary,
+    SessionSummary,
+};
 use std::collections::HashMap;
 
 pub fn print_session_list(sessions: &[SessionSummary], hosts: &[HostSummary]) {
@@ -70,7 +73,11 @@ pub fn print_health(status: &HealthResponse) {
     println!("db_path: {}", status.db_path);
 }
 
-pub fn print_doctor(status: &HealthResponse) {
+pub fn print_doctor(
+    status: &HealthResponse,
+    runtime_crews: Option<&[RuntimeCrewSummary]>,
+    unregistered_discovery: Option<&[DiscoverySession]>,
+) {
     println!("doctor");
     println!("  status: {}", status.status);
     println!("  version: {}", status.version);
@@ -79,6 +86,7 @@ pub fn print_doctor(status: &HealthResponse) {
     println!("  sessions_running: {}", status.sessions_running);
     println!("  session_count: {}", status.session_count);
     println!("  atm_available: {}", status.atm_available);
+    println!("  atm_socket_available: {}", status.atm_socket_available);
     if let Some(ci) = &status.ci_available {
         println!("  ci_available: gh={} az={}", ci.gh, ci.az);
     }
@@ -94,6 +102,16 @@ pub fn print_doctor(status: &HealthResponse) {
         for row in &status.recent_errors {
             println!("    - {row}");
         }
+    }
+    if let Some(crews) = runtime_crews {
+        println!("  runtime_crews: {}", crews.len());
+        let invalid = crews.iter().filter(|crew| !crew.binding_valid).count();
+        if invalid > 0 {
+            println!("    invalid_bindings: {invalid}");
+        }
+    }
+    if let Some(rows) = unregistered_discovery {
+        println!("  unregistered_discovery_sessions: {}", rows.len());
     }
     println!("  db_path: {}", status.db_path);
 }

--- a/crates/scmux/tests/e2e_tests.rs
+++ b/crates/scmux/tests/e2e_tests.rs
@@ -103,6 +103,7 @@ impl CliE2eHarness {
             "project": "e2e",
             "config_json": {
                 "session_name": name,
+                "root_path": "/tmp",
                 "panes": [
                     { "name": "agent", "command": "sleep 1", "atm_agent": "agent", "atm_team": "scmux-dev" }
                 ]

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,4 +1,4 @@
-const { useEffect, useMemo, useState } = React;
+const { useState, useEffect, useMemo } = React;
 
 const PROJECT_COLORS = {
   "radiant-p3": "#3b82f6",
@@ -50,6 +50,7 @@ const STATUS_DOT = {
 };
 const DEFAULT_BASE_URL = "http://localhost:7878";
 const DEFAULT_POLL_MS = 15_000;
+const FLOTILLA_V1_ENABLED = false;
 function daemonBaseUrl() {
   if (typeof window === "undefined") {
     return DEFAULT_BASE_URL;
@@ -895,6 +896,729 @@ function DiscoveryView({
     colSpan: 4
   }, "no panes reported")))))));
 }
+function makeCrewUlid() {
+  return `01J${Date.now().toString(36).toUpperCase()}${Math.random().toString(36).slice(2, 12).toUpperCase()}`;
+}
+function OrganizationEditorModal({
+  baseUrl,
+  open,
+  onClose,
+  onSaved
+}) {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
+  const [state, setState] = useState({
+    armadas: [],
+    fleets: [],
+    flotillas: [],
+    crews: [],
+    crew_refs: []
+  });
+  const [armadaName, setArmadaName] = useState("");
+  const [fleetName, setFleetName] = useState("");
+  const [fleetColor, setFleetColor] = useState("#3b82f6");
+  const [newCrewName, setNewCrewName] = useState("");
+  const [newCrewUlid, setNewCrewUlid] = useState(makeCrewUlid());
+  const [captainModel, setCaptainModel] = useState("claude-opus");
+  const [mateModel, setMateModel] = useState("codex-high");
+  const [newRootPath, setNewRootPath] = useState("/tmp/scmux");
+  const [selectedArmadaId, setSelectedArmadaId] = useState(null);
+  const [selectedFleetId, setSelectedFleetId] = useState(null);
+  const [selectedFlotillaId, setSelectedFlotillaId] = useState(null);
+  const loadState = async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const response = await fetch(`${baseUrl}/editor/state`);
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || `HTTP ${response.status}`);
+      }
+      setState({
+        armadas: Array.isArray(body.armadas) ? body.armadas : [],
+        fleets: Array.isArray(body.fleets) ? body.fleets : [],
+        flotillas: Array.isArray(body.flotillas) ? body.flotillas : [],
+        crews: Array.isArray(body.crews) ? body.crews : [],
+        crew_refs: Array.isArray(body.crew_refs) ? body.crew_refs : []
+      });
+    } catch (error) {
+      setErrorMessage(`Failed to load editor state: ${String(error)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    loadState();
+  }, [open]);
+  useEffect(() => {
+    if (!selectedArmadaId && state.armadas.length) {
+      setSelectedArmadaId(state.armadas[0].id);
+    }
+  }, [state.armadas, selectedArmadaId]);
+  useEffect(() => {
+    const fleetsForArmada = state.fleets.filter(fleet => fleet.armada_id === selectedArmadaId);
+    if (!fleetsForArmada.length) {
+      setSelectedFleetId(null);
+      return;
+    }
+    if (!fleetsForArmada.some(fleet => fleet.id === selectedFleetId)) {
+      setSelectedFleetId(fleetsForArmada[0].id);
+    }
+  }, [state.fleets, selectedArmadaId, selectedFleetId]);
+  useEffect(() => {
+    const flotillasForFleet = state.flotillas.filter(item => item.fleet_id === selectedFleetId);
+    if (!flotillasForFleet.length) {
+      setSelectedFlotillaId(null);
+      return;
+    }
+    if (!flotillasForFleet.some(item => item.id === selectedFlotillaId)) {
+      setSelectedFlotillaId(flotillasForFleet[0].id);
+    }
+  }, [state.flotillas, selectedFleetId, selectedFlotillaId]);
+  if (!open) {
+    return null;
+  }
+  const fleetsForSelectedArmada = state.fleets.filter(fleet => fleet.armada_id === selectedArmadaId);
+  const flotillasForSelectedFleet = state.flotillas.filter(item => item.fleet_id === selectedFleetId);
+  const hasPlacement = Number.isFinite(selectedArmadaId) && Number.isFinite(selectedFleetId);
+  const submitJson = async (url, method, payload, successText) => {
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || body.code || `HTTP ${response.status}`);
+      }
+      setSuccessMessage(successText || body.message || "Saved");
+      await loadState();
+      if (onSaved) {
+        onSaved(successText || body.message || "Saved");
+      }
+      return true;
+    } catch (error) {
+      setErrorMessage(String(error));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+  const createArmada = async () => {
+    if (!armadaName.trim()) {
+      setErrorMessage("Armada name is required.");
+      return;
+    }
+    const ok = await submitJson(`${baseUrl}/editor/armadas`, "POST", {
+      name: armadaName.trim()
+    }, `Armada created: ${armadaName.trim()}`);
+    if (ok) {
+      setArmadaName("");
+    }
+  };
+  const cloneArmada = async (armadaId, sourceName) => {
+    const copyName = `${sourceName}-clone`;
+    await submitJson(`${baseUrl}/editor/armadas/${armadaId}/clone`, "POST", {
+      name: copyName
+    }, `Cloned armada to ${copyName}`);
+  };
+  const createFleet = async () => {
+    if (!fleetName.trim()) {
+      setErrorMessage("Fleet name is required.");
+      return;
+    }
+    if (!selectedArmadaId) {
+      setErrorMessage("Create/select an Armada before creating a Fleet.");
+      return;
+    }
+    const ok = await submitJson(`${baseUrl}/editor/fleets`, "POST", {
+      armada_id: selectedArmadaId,
+      name: fleetName.trim(),
+      color: fleetColor
+    }, `Fleet created: ${fleetName.trim()}`);
+    if (ok) {
+      setFleetName("");
+    }
+  };
+  const cloneFleet = async (fleetId, sourceName, sourceArmadaId, sourceColor) => {
+    const copyName = `${sourceName}-clone`;
+    await submitJson(`${baseUrl}/editor/fleets/${fleetId}/clone`, "POST", {
+      armada_id: selectedArmadaId || sourceArmadaId,
+      name: copyName,
+      color: sourceColor || null
+    }, `Cloned fleet to ${copyName}`);
+  };
+  const createCrew = async () => {
+    if (!newCrewName.trim()) {
+      setErrorMessage("Crew name is required.");
+      return;
+    }
+    if (!hasPlacement) {
+      setErrorMessage("Crew placement is unresolved. Select Armada and Fleet.");
+      return;
+    }
+    const payload = {
+      crew_name: newCrewName.trim(),
+      crew_ulid: newCrewUlid.trim() || makeCrewUlid(),
+      members: [{
+        member_id: "team-lead",
+        role: "captain",
+        ai_provider: "claude",
+        model: captainModel.trim() || "claude-opus",
+        startup_prompts: ["prompts/arch-startup.md", "prompts/pm-startup.md"]
+      }, {
+        member_id: "arch-cmux",
+        role: "mate",
+        ai_provider: "codex",
+        model: mateModel.trim() || "codex-high",
+        startup_prompts: ["prompts/arch-cmux-startup.md"]
+      }],
+      variants: [{
+        host_id: 1,
+        root_path: newRootPath.trim() || "/tmp/scmux"
+      }],
+      placement: {
+        armada_id: selectedArmadaId,
+        fleet_id: selectedFleetId,
+        flotilla_id: FLOTILLA_V1_ENABLED ? selectedFlotillaId : null
+      }
+    };
+    const ok = await submitJson(`${baseUrl}/editor/crews`, "POST", payload, `Crew created: ${newCrewName.trim()}`);
+    if (ok) {
+      setNewCrewName("");
+      setNewCrewUlid(makeCrewUlid());
+    }
+  };
+  const moveRef = async (refRow, nextArmadaId, nextFleetId) => {
+    if (!nextArmadaId || !nextFleetId) {
+      setErrorMessage("Move requires target armada and fleet.");
+      return;
+    }
+    await submitJson(`${baseUrl}/editor/crew-refs/${refRow.id}/move`, "POST", {
+      armada_id: Number(nextArmadaId),
+      fleet_id: Number(nextFleetId),
+      flotilla_id: null
+    }, `Moved crew ref ${refRow.id}`);
+  };
+  const cloneCrew = async (crewId, crewName) => {
+    const copyName = `${crewName}-clone`;
+    await submitJson(`${baseUrl}/editor/crews/${crewId}/clone`, "POST", {
+      crew_name: copyName,
+      crew_ulid: makeCrewUlid(),
+      placement: {
+        armada_id: selectedArmadaId,
+        fleet_id: selectedFleetId,
+        flotilla_id: FLOTILLA_V1_ENABLED ? selectedFlotillaId : null
+      }
+    }, `Cloned crew to ${copyName}`);
+  };
+  const unlinkRef = async refId => {
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      const response = await fetch(`${baseUrl}/editor/crew-refs/${refId}`, {
+        method: "DELETE"
+      });
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || `HTTP ${response.status}`);
+      }
+      setSuccessMessage(body.message || `Unlinked ref ${refId}`);
+      await loadState();
+      if (onSaved) {
+        onSaved(body.message || `Unlinked ref ${refId}`);
+      }
+    } catch (error) {
+      setErrorMessage(String(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+  return /*#__PURE__*/React.createElement("div", {
+    style: {
+      position: "fixed",
+      inset: 0,
+      background: "rgba(0,0,0,0.8)",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      zIndex: 230
+    },
+    onClick: onClose
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      width: "min(1100px, 96vw)",
+      maxHeight: "92vh",
+      overflowY: "auto",
+      background: "#0d1117",
+      border: "1px solid #1e2535",
+      borderRadius: 10,
+      padding: 16,
+      display: "grid",
+      gap: 14
+    },
+    onClick: event => event.stopPropagation()
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center"
+    }
+  }, /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 10,
+      color: "#475569",
+      letterSpacing: "0.1em"
+    }
+  }, "ORGANIZATION EDITOR"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 13,
+      color: "#cbd5e1"
+    }
+  }, "Armada / Fleet", FLOTILLA_V1_ENABLED ? " / Flotilla" : "", " / Crew")), /*#__PURE__*/React.createElement("button", {
+    onClick: onClose,
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      background: "transparent",
+      color: "#94a3b8",
+      padding: "6px 10px",
+      cursor: "pointer"
+    }
+  }, "Close")), !FLOTILLA_V1_ENABLED && /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#f59e0b"
+    }
+  }, "Flotilla is currently behind feature flag. UI operates at Armada/Fleet scope."), loading ? /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 12,
+      color: "#64748b"
+    }
+  }, "Loading editor state...") : /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "grid",
+      gridTemplateColumns: "1fr 1fr 1fr",
+      gap: 10
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 8,
+      padding: 10,
+      display: "grid",
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd"
+    }
+  }, "Armada Editor"), /*#__PURE__*/React.createElement("input", {
+    value: armadaName,
+    onChange: event => setArmadaName(event.target.value),
+    placeholder: "Armada name",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("button", {
+    onClick: createArmada,
+    disabled: saving,
+    style: {
+      border: "none",
+      background: "#2563eb",
+      color: "#fff",
+      borderRadius: 5,
+      padding: "6px 8px",
+      cursor: "pointer",
+      fontSize: 11
+    }
+  }, "+ Create Armada"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      maxHeight: 130,
+      overflowY: "auto",
+      borderTop: "1px solid #131820",
+      paddingTop: 6
+    }
+  }, state.armadas.map(armada => /*#__PURE__*/React.createElement("div", {
+    key: armada.id,
+    style: {
+      fontSize: 11,
+      color: "#94a3b8",
+      padding: "2px 0",
+      display: "flex",
+      justifyContent: "space-between",
+      gap: 8,
+      alignItems: "center"
+    }
+  }, /*#__PURE__*/React.createElement("span", null, armada.name, " ", /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: "#475569"
+    }
+  }, "#", armada.id)), /*#__PURE__*/React.createElement("button", {
+    onClick: () => cloneArmada(armada.id, armada.name),
+    disabled: saving,
+    style: {
+      border: "1px solid #1e2535",
+      background: "#1e293b",
+      color: "#cbd5e1",
+      borderRadius: 5,
+      padding: "2px 7px",
+      cursor: "pointer",
+      fontSize: 10
+    }
+  }, "Clone"))))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 8,
+      padding: 10,
+      display: "grid",
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd"
+    }
+  }, "Fleet Editor"), /*#__PURE__*/React.createElement("select", {
+    value: selectedArmadaId || "",
+    onChange: event => setSelectedArmadaId(Number(event.target.value)),
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }, /*#__PURE__*/React.createElement("option", {
+    value: ""
+  }, "Select armada"), state.armadas.map(armada => /*#__PURE__*/React.createElement("option", {
+    key: armada.id,
+    value: armada.id
+  }, armada.name))), /*#__PURE__*/React.createElement("input", {
+    value: fleetName,
+    onChange: event => setFleetName(event.target.value),
+    placeholder: "Fleet name",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: fleetColor,
+    onChange: event => setFleetColor(event.target.value),
+    placeholder: "#3b82f6",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("button", {
+    onClick: createFleet,
+    disabled: saving || !selectedArmadaId,
+    style: {
+      border: "none",
+      background: "#0ea5e9",
+      color: "#fff",
+      borderRadius: 5,
+      padding: "6px 8px",
+      cursor: "pointer",
+      fontSize: 11
+    }
+  }, "+ Create Fleet"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      maxHeight: 130,
+      overflowY: "auto",
+      borderTop: "1px solid #131820",
+      paddingTop: 6
+    }
+  }, fleetsForSelectedArmada.map(fleet => /*#__PURE__*/React.createElement("div", {
+    key: fleet.id,
+    style: {
+      fontSize: 11,
+      color: "#94a3b8",
+      padding: "2px 0",
+      display: "flex",
+      justifyContent: "space-between",
+      gap: 8,
+      alignItems: "center"
+    }
+  }, /*#__PURE__*/React.createElement("span", null, fleet.name, " ", /*#__PURE__*/React.createElement("span", {
+    style: {
+      color: fleet.color || "#64748b"
+    }
+  }, fleet.color || "")), /*#__PURE__*/React.createElement("button", {
+    onClick: () => cloneFleet(fleet.id, fleet.name, fleet.armada_id, fleet.color),
+    disabled: saving,
+    style: {
+      border: "1px solid #1e2535",
+      background: "#1e293b",
+      color: "#cbd5e1",
+      borderRadius: 5,
+      padding: "2px 7px",
+      cursor: "pointer",
+      fontSize: 10
+    }
+  }, "Clone"))))), /*#__PURE__*/React.createElement("div", {
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 8,
+      padding: 10,
+      display: "grid",
+      gap: 8
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd"
+    }
+  }, "Crew Editor"), /*#__PURE__*/React.createElement("input", {
+    value: newCrewName,
+    onChange: event => setNewCrewName(event.target.value),
+    placeholder: "Crew name",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: newCrewUlid,
+    onChange: event => setNewCrewUlid(event.target.value),
+    placeholder: "Crew ULID",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: newRootPath,
+    onChange: event => setNewRootPath(event.target.value),
+    placeholder: "root path",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "grid",
+      gridTemplateColumns: "1fr 1fr",
+      gap: 6
+    }
+  }, /*#__PURE__*/React.createElement("input", {
+    value: captainModel,
+    onChange: event => setCaptainModel(event.target.value),
+    placeholder: "Captain model",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }), /*#__PURE__*/React.createElement("input", {
+    value: mateModel,
+    onChange: event => setMateModel(event.target.value),
+    placeholder: "Mate model",
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  })), FLOTILLA_V1_ENABLED && /*#__PURE__*/React.createElement("select", {
+    value: selectedFlotillaId || "",
+    onChange: event => setSelectedFlotillaId(Number(event.target.value)),
+    style: {
+      background: "#060810",
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      color: "#cbd5e1",
+      padding: "7px 9px"
+    }
+  }, /*#__PURE__*/React.createElement("option", {
+    value: ""
+  }, "No flotilla"), flotillasForSelectedFleet.map(item => /*#__PURE__*/React.createElement("option", {
+    key: item.id,
+    value: item.id
+  }, item.name))), !hasPlacement && /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#f59e0b"
+    }
+  }, "Placement unresolved: create/select Armada and Fleet first."), /*#__PURE__*/React.createElement("button", {
+    onClick: createCrew,
+    disabled: saving || !hasPlacement,
+    style: {
+      border: "none",
+      background: "#16a34a",
+      color: "#fff",
+      borderRadius: 5,
+      padding: "6px 8px",
+      cursor: "pointer",
+      fontSize: 11
+    }
+  }, "+ Create Crew"))), errorMessage && /*#__PURE__*/React.createElement("div", {
+    style: {
+      color: "#f87171",
+      fontSize: 11
+    }
+  }, errorMessage), successMessage && /*#__PURE__*/React.createElement("div", {
+    style: {
+      color: "#34d399",
+      fontSize: 11
+    }
+  }, successMessage), /*#__PURE__*/React.createElement("div", {
+    style: {
+      borderTop: "1px solid #131820",
+      paddingTop: 10
+    }
+  }, /*#__PURE__*/React.createElement("div", {
+    style: {
+      fontSize: 11,
+      color: "#93c5fd",
+      marginBottom: 8
+    }
+  }, "Crew Placement Controls"), /*#__PURE__*/React.createElement("div", {
+    style: {
+      display: "grid",
+      gap: 8
+    }
+  }, state.crew_refs.map(refRow => {
+    const crew = state.crews.find(item => item.id === refRow.crew_id);
+    const armada = state.armadas.find(item => item.id === refRow.armada_id);
+    const fleet = state.fleets.find(item => item.id === refRow.fleet_id);
+    return /*#__PURE__*/React.createElement("div", {
+      key: refRow.id,
+      style: {
+        border: "1px solid #1e2535",
+        borderRadius: 6,
+        padding: 8,
+        display: "grid",
+        gap: 6
+      }
+    }, /*#__PURE__*/React.createElement("div", {
+      style: {
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        gap: 8
+      }
+    }, /*#__PURE__*/React.createElement("div", {
+      style: {
+        fontSize: 11,
+        color: "#cbd5e1"
+      }
+    }, crew?.crew_name || `crew-${refRow.crew_id}`, " ", /*#__PURE__*/React.createElement("span", {
+      style: {
+        color: "#64748b"
+      }
+    }, "ref#", refRow.id)), /*#__PURE__*/React.createElement("div", {
+      style: {
+        fontSize: 10,
+        color: "#64748b"
+      }
+    }, armada?.name || "unknown", " / ", fleet?.name || "unknown")), /*#__PURE__*/React.createElement("div", {
+      style: {
+        display: "flex",
+        gap: 6,
+        flexWrap: "wrap"
+      }
+    }, /*#__PURE__*/React.createElement("select", {
+      id: `move-armada-${refRow.id}`,
+      defaultValue: refRow.armada_id,
+      style: {
+        background: "#060810",
+        border: "1px solid #1e2535",
+        borderRadius: 5,
+        color: "#cbd5e1",
+        padding: "5px 8px",
+        fontSize: 11
+      }
+    }, state.armadas.map(item => /*#__PURE__*/React.createElement("option", {
+      key: item.id,
+      value: item.id
+    }, item.name))), /*#__PURE__*/React.createElement("select", {
+      id: `move-fleet-${refRow.id}`,
+      defaultValue: refRow.fleet_id,
+      style: {
+        background: "#060810",
+        border: "1px solid #1e2535",
+        borderRadius: 5,
+        color: "#cbd5e1",
+        padding: "5px 8px",
+        fontSize: 11
+      }
+    }, state.fleets.map(item => /*#__PURE__*/React.createElement("option", {
+      key: item.id,
+      value: item.id
+    }, item.name))), /*#__PURE__*/React.createElement("button", {
+      onClick: () => {
+        const armadaValue = Number(document.getElementById(`move-armada-${refRow.id}`)?.value);
+        const fleetValue = Number(document.getElementById(`move-fleet-${refRow.id}`)?.value);
+        moveRef(refRow, armadaValue, fleetValue);
+      },
+      style: {
+        border: "1px solid #1e2535",
+        background: "#1e3a8a",
+        color: "#bfdbfe",
+        borderRadius: 5,
+        padding: "5px 8px",
+        cursor: "pointer",
+        fontSize: 11
+      }
+    }, "Move"), /*#__PURE__*/React.createElement("button", {
+      onClick: () => cloneCrew(refRow.crew_id, crew?.crew_name || `crew-${refRow.crew_id}`),
+      style: {
+        border: "1px solid #1e2535",
+        background: "#312e81",
+        color: "#c7d2fe",
+        borderRadius: 5,
+        padding: "5px 8px",
+        cursor: "pointer",
+        fontSize: 11
+      }
+    }, "Clone Crew"), /*#__PURE__*/React.createElement("button", {
+      onClick: () => unlinkRef(refRow.id),
+      style: {
+        border: "1px solid #1e2535",
+        background: "#3f1d1d",
+        color: "#fca5a5",
+        borderRadius: 5,
+        padding: "5px 8px",
+        cursor: "pointer",
+        fontSize: 11
+      }
+    }, "Unlink")));
+  })))));
+}
 function JumpModal({
   baseUrl,
   defaultTerminal,
@@ -1477,6 +2201,7 @@ function Dashboard() {
   const [search, setSearch] = useState("");
   const [jumpTarget, setJumpTarget] = useState(null);
   const [editorTarget, setEditorTarget] = useState(null);
+  const [orgEditorOpen, setOrgEditorOpen] = useState(false);
   const [hosts, setHosts] = useState([]);
   const [sessions, setSessions] = useState([]);
   const [discoveryRows, setDiscoveryRows] = useState([]);
@@ -1712,6 +2437,18 @@ function Dashboard() {
       flexWrap: "wrap"
     }
   }, /*#__PURE__*/React.createElement("button", {
+    onClick: () => setOrgEditorOpen(true),
+    style: {
+      border: "1px solid #1e2535",
+      borderRadius: 5,
+      background: "#111827",
+      color: "#93c5fd",
+      padding: "5px 10px",
+      fontSize: 10,
+      cursor: "pointer",
+      letterSpacing: "0.05em"
+    }
+  }, "Org Editor"), /*#__PURE__*/React.createElement("button", {
     onClick: () => setEditorTarget({
       mode: "create"
     }),
@@ -1898,6 +2635,13 @@ function Dashboard() {
       setEditorTarget(null);
       setActionMessage(message);
       await refresh();
+    }
+  }), /*#__PURE__*/React.createElement(OrganizationEditorModal, {
+    baseUrl: baseUrl,
+    open: orgEditorOpen,
+    onClose: () => setOrgEditorOpen(false),
+    onSaved: message => {
+      setActionMessage(message);
     }
   }), hosts.length === 0 && !loading && /*#__PURE__*/React.createElement("div", {
     style: {

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -1,4 +1,4 @@
-const { useState, useEffect, useMemo } = React;
+const { useEffect, useMemo, useState } = React;
 
 const PROJECT_COLORS = {
   "radiant-p3": "#3b82f6",

--- a/dashboard/team-dashboard.jsx
+++ b/dashboard/team-dashboard.jsx
@@ -25,6 +25,7 @@ const STATUS_DOT = {
 
 const DEFAULT_BASE_URL = "http://localhost:7878";
 const DEFAULT_POLL_MS = 15_000;
+const FLOTILLA_V1_ENABLED = false;
 
 function daemonBaseUrl() {
   if (typeof window === "undefined") {
@@ -753,6 +754,557 @@ function DiscoveryView({ rows }) {
   );
 }
 
+function makeCrewUlid() {
+  return `01J${Date.now().toString(36).toUpperCase()}${Math.random().toString(36).slice(2, 12).toUpperCase()}`;
+}
+
+function OrganizationEditorModal({ baseUrl, open, onClose, onSaved }) {
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
+  const [state, setState] = useState({
+    armadas: [],
+    fleets: [],
+    flotillas: [],
+    crews: [],
+    crew_refs: [],
+  });
+
+  const [armadaName, setArmadaName] = useState("");
+  const [fleetName, setFleetName] = useState("");
+  const [fleetColor, setFleetColor] = useState("#3b82f6");
+  const [newCrewName, setNewCrewName] = useState("");
+  const [newCrewUlid, setNewCrewUlid] = useState(makeCrewUlid());
+  const [captainModel, setCaptainModel] = useState("claude-opus");
+  const [mateModel, setMateModel] = useState("codex-high");
+  const [newRootPath, setNewRootPath] = useState("/tmp/scmux");
+  const [selectedArmadaId, setSelectedArmadaId] = useState(null);
+  const [selectedFleetId, setSelectedFleetId] = useState(null);
+  const [selectedFlotillaId, setSelectedFlotillaId] = useState(null);
+
+  const loadState = async () => {
+    setLoading(true);
+    setErrorMessage(null);
+    try {
+      const response = await fetch(`${baseUrl}/editor/state`);
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || `HTTP ${response.status}`);
+      }
+      setState({
+        armadas: Array.isArray(body.armadas) ? body.armadas : [],
+        fleets: Array.isArray(body.fleets) ? body.fleets : [],
+        flotillas: Array.isArray(body.flotillas) ? body.flotillas : [],
+        crews: Array.isArray(body.crews) ? body.crews : [],
+        crew_refs: Array.isArray(body.crew_refs) ? body.crew_refs : [],
+      });
+    } catch (error) {
+      setErrorMessage(`Failed to load editor state: ${String(error)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    loadState();
+  }, [open]);
+
+  useEffect(() => {
+    if (!selectedArmadaId && state.armadas.length) {
+      setSelectedArmadaId(state.armadas[0].id);
+    }
+  }, [state.armadas, selectedArmadaId]);
+
+  useEffect(() => {
+    const fleetsForArmada = state.fleets.filter((fleet) => fleet.armada_id === selectedArmadaId);
+    if (!fleetsForArmada.length) {
+      setSelectedFleetId(null);
+      return;
+    }
+    if (!fleetsForArmada.some((fleet) => fleet.id === selectedFleetId)) {
+      setSelectedFleetId(fleetsForArmada[0].id);
+    }
+  }, [state.fleets, selectedArmadaId, selectedFleetId]);
+
+  useEffect(() => {
+    const flotillasForFleet = state.flotillas.filter((item) => item.fleet_id === selectedFleetId);
+    if (!flotillasForFleet.length) {
+      setSelectedFlotillaId(null);
+      return;
+    }
+    if (!flotillasForFleet.some((item) => item.id === selectedFlotillaId)) {
+      setSelectedFlotillaId(flotillasForFleet[0].id);
+    }
+  }, [state.flotillas, selectedFleetId, selectedFlotillaId]);
+
+  if (!open) {
+    return null;
+  }
+
+  const fleetsForSelectedArmada = state.fleets.filter((fleet) => fleet.armada_id === selectedArmadaId);
+  const flotillasForSelectedFleet = state.flotillas.filter((item) => item.fleet_id === selectedFleetId);
+  const hasPlacement = Number.isFinite(selectedArmadaId) && Number.isFinite(selectedFleetId);
+
+  const submitJson = async (url, method, payload, successText) => {
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || body.code || `HTTP ${response.status}`);
+      }
+      setSuccessMessage(successText || body.message || "Saved");
+      await loadState();
+      if (onSaved) {
+        onSaved(successText || body.message || "Saved");
+      }
+      return true;
+    } catch (error) {
+      setErrorMessage(String(error));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const createArmada = async () => {
+    if (!armadaName.trim()) {
+      setErrorMessage("Armada name is required.");
+      return;
+    }
+    const ok = await submitJson(
+      `${baseUrl}/editor/armadas`,
+      "POST",
+      { name: armadaName.trim() },
+      `Armada created: ${armadaName.trim()}`,
+    );
+    if (ok) {
+      setArmadaName("");
+    }
+  };
+
+  const cloneArmada = async (armadaId, sourceName) => {
+    const copyName = `${sourceName}-clone`;
+    await submitJson(
+      `${baseUrl}/editor/armadas/${armadaId}/clone`,
+      "POST",
+      { name: copyName },
+      `Cloned armada to ${copyName}`,
+    );
+  };
+
+  const createFleet = async () => {
+    if (!fleetName.trim()) {
+      setErrorMessage("Fleet name is required.");
+      return;
+    }
+    if (!selectedArmadaId) {
+      setErrorMessage("Create/select an Armada before creating a Fleet.");
+      return;
+    }
+    const ok = await submitJson(
+      `${baseUrl}/editor/fleets`,
+      "POST",
+      { armada_id: selectedArmadaId, name: fleetName.trim(), color: fleetColor },
+      `Fleet created: ${fleetName.trim()}`,
+    );
+    if (ok) {
+      setFleetName("");
+    }
+  };
+
+  const cloneFleet = async (fleetId, sourceName, sourceArmadaId, sourceColor) => {
+    const copyName = `${sourceName}-clone`;
+    await submitJson(
+      `${baseUrl}/editor/fleets/${fleetId}/clone`,
+      "POST",
+      {
+        armada_id: selectedArmadaId || sourceArmadaId,
+        name: copyName,
+        color: sourceColor || null,
+      },
+      `Cloned fleet to ${copyName}`,
+    );
+  };
+
+  const createCrew = async () => {
+    if (!newCrewName.trim()) {
+      setErrorMessage("Crew name is required.");
+      return;
+    }
+    if (!hasPlacement) {
+      setErrorMessage("Crew placement is unresolved. Select Armada and Fleet.");
+      return;
+    }
+    const payload = {
+      crew_name: newCrewName.trim(),
+      crew_ulid: newCrewUlid.trim() || makeCrewUlid(),
+      members: [
+        {
+          member_id: "team-lead",
+          role: "captain",
+          ai_provider: "claude",
+          model: captainModel.trim() || "claude-opus",
+          startup_prompts: ["prompts/arch-startup.md", "prompts/pm-startup.md"],
+        },
+        {
+          member_id: "arch-cmux",
+          role: "mate",
+          ai_provider: "codex",
+          model: mateModel.trim() || "codex-high",
+          startup_prompts: ["prompts/arch-cmux-startup.md"],
+        },
+      ],
+      variants: [
+        {
+          host_id: 1,
+          root_path: newRootPath.trim() || "/tmp/scmux",
+        },
+      ],
+      placement: {
+        armada_id: selectedArmadaId,
+        fleet_id: selectedFleetId,
+        flotilla_id: FLOTILLA_V1_ENABLED ? selectedFlotillaId : null,
+      },
+    };
+
+    const ok = await submitJson(`${baseUrl}/editor/crews`, "POST", payload, `Crew created: ${newCrewName.trim()}`);
+    if (ok) {
+      setNewCrewName("");
+      setNewCrewUlid(makeCrewUlid());
+    }
+  };
+
+  const moveRef = async (refRow, nextArmadaId, nextFleetId) => {
+    if (!nextArmadaId || !nextFleetId) {
+      setErrorMessage("Move requires target armada and fleet.");
+      return;
+    }
+    await submitJson(`${baseUrl}/editor/crew-refs/${refRow.id}/move`, "POST", {
+      armada_id: Number(nextArmadaId),
+      fleet_id: Number(nextFleetId),
+      flotilla_id: null,
+    }, `Moved crew ref ${refRow.id}`);
+  };
+
+  const cloneCrew = async (crewId, crewName) => {
+    const copyName = `${crewName}-clone`;
+    await submitJson(`${baseUrl}/editor/crews/${crewId}/clone`, "POST", {
+      crew_name: copyName,
+      crew_ulid: makeCrewUlid(),
+      placement: {
+        armada_id: selectedArmadaId,
+        fleet_id: selectedFleetId,
+        flotilla_id: FLOTILLA_V1_ENABLED ? selectedFlotillaId : null,
+      },
+    }, `Cloned crew to ${copyName}`);
+  };
+
+  const unlinkRef = async (refId) => {
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    try {
+      const response = await fetch(`${baseUrl}/editor/crew-refs/${refId}`, { method: "DELETE" });
+      const body = await response.json();
+      if (!response.ok) {
+        throw new Error(body.message || `HTTP ${response.status}`);
+      }
+      setSuccessMessage(body.message || `Unlinked ref ${refId}`);
+      await loadState();
+      if (onSaved) {
+        onSaved(body.message || `Unlinked ref ${refId}`);
+      }
+    } catch (error) {
+      setErrorMessage(String(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.8)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 230,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          width: "min(1100px, 96vw)",
+          maxHeight: "92vh",
+          overflowY: "auto",
+          background: "#0d1117",
+          border: "1px solid #1e2535",
+          borderRadius: 10,
+          padding: 16,
+          display: "grid",
+          gap: 14,
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div>
+            <div style={{ fontSize: 10, color: "#475569", letterSpacing: "0.1em" }}>ORGANIZATION EDITOR</div>
+            <div style={{ fontSize: 13, color: "#cbd5e1" }}>
+              Armada / Fleet{FLOTILLA_V1_ENABLED ? " / Flotilla" : ""} / Crew
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              border: "1px solid #1e2535",
+              borderRadius: 5,
+              background: "transparent",
+              color: "#94a3b8",
+              padding: "6px 10px",
+              cursor: "pointer",
+            }}
+          >
+            Close
+          </button>
+        </div>
+
+        {!FLOTILLA_V1_ENABLED && (
+          <div style={{ fontSize: 11, color: "#f59e0b" }}>
+            Flotilla is currently behind feature flag. UI operates at Armada/Fleet scope.
+          </div>
+        )}
+
+        {loading ? (
+          <div style={{ fontSize: 12, color: "#64748b" }}>Loading editor state...</div>
+        ) : (
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 10 }}>
+            <div style={{ border: "1px solid #1e2535", borderRadius: 8, padding: 10, display: "grid", gap: 8 }}>
+              <div style={{ fontSize: 11, color: "#93c5fd" }}>Armada Editor</div>
+              <input
+                value={armadaName}
+                onChange={(event) => setArmadaName(event.target.value)}
+                placeholder="Armada name"
+                style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+              />
+              <button
+                onClick={createArmada}
+                disabled={saving}
+                style={{ border: "none", background: "#2563eb", color: "#fff", borderRadius: 5, padding: "6px 8px", cursor: "pointer", fontSize: 11 }}
+              >
+                + Create Armada
+              </button>
+              <div style={{ maxHeight: 130, overflowY: "auto", borderTop: "1px solid #131820", paddingTop: 6 }}>
+                {state.armadas.map((armada) => (
+                  <div
+                    key={armada.id}
+                    style={{ fontSize: 11, color: "#94a3b8", padding: "2px 0", display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}
+                  >
+                    <span>
+                      {armada.name} <span style={{ color: "#475569" }}>#{armada.id}</span>
+                    </span>
+                    <button
+                      onClick={() => cloneArmada(armada.id, armada.name)}
+                      disabled={saving}
+                      style={{ border: "1px solid #1e2535", background: "#1e293b", color: "#cbd5e1", borderRadius: 5, padding: "2px 7px", cursor: "pointer", fontSize: 10 }}
+                    >
+                      Clone
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div style={{ border: "1px solid #1e2535", borderRadius: 8, padding: 10, display: "grid", gap: 8 }}>
+              <div style={{ fontSize: 11, color: "#93c5fd" }}>Fleet Editor</div>
+              <select
+                value={selectedArmadaId || ""}
+                onChange={(event) => setSelectedArmadaId(Number(event.target.value))}
+                style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+              >
+                <option value="">Select armada</option>
+                {state.armadas.map((armada) => (
+                  <option key={armada.id} value={armada.id}>{armada.name}</option>
+                ))}
+              </select>
+              <input
+                value={fleetName}
+                onChange={(event) => setFleetName(event.target.value)}
+                placeholder="Fleet name"
+                style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+              />
+              <input
+                value={fleetColor}
+                onChange={(event) => setFleetColor(event.target.value)}
+                placeholder="#3b82f6"
+                style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+              />
+              <button
+                onClick={createFleet}
+                disabled={saving || !selectedArmadaId}
+                style={{ border: "none", background: "#0ea5e9", color: "#fff", borderRadius: 5, padding: "6px 8px", cursor: "pointer", fontSize: 11 }}
+              >
+                + Create Fleet
+              </button>
+              <div style={{ maxHeight: 130, overflowY: "auto", borderTop: "1px solid #131820", paddingTop: 6 }}>
+                {fleetsForSelectedArmada.map((fleet) => (
+                  <div
+                    key={fleet.id}
+                    style={{ fontSize: 11, color: "#94a3b8", padding: "2px 0", display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}
+                  >
+                    <span>
+                      {fleet.name} <span style={{ color: fleet.color || "#64748b" }}>{fleet.color || ""}</span>
+                    </span>
+                    <button
+                      onClick={() => cloneFleet(fleet.id, fleet.name, fleet.armada_id, fleet.color)}
+                      disabled={saving}
+                      style={{ border: "1px solid #1e2535", background: "#1e293b", color: "#cbd5e1", borderRadius: 5, padding: "2px 7px", cursor: "pointer", fontSize: 10 }}
+                    >
+                      Clone
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div style={{ border: "1px solid #1e2535", borderRadius: 8, padding: 10, display: "grid", gap: 8 }}>
+              <div style={{ fontSize: 11, color: "#93c5fd" }}>Crew Editor</div>
+              <input
+                value={newCrewName}
+                onChange={(event) => setNewCrewName(event.target.value)}
+                placeholder="Crew name"
+                style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+              />
+              <input
+                value={newCrewUlid}
+                onChange={(event) => setNewCrewUlid(event.target.value)}
+                placeholder="Crew ULID"
+                style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+              />
+              <input
+                value={newRootPath}
+                onChange={(event) => setNewRootPath(event.target.value)}
+                placeholder="root path"
+                style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+              />
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+                <input
+                  value={captainModel}
+                  onChange={(event) => setCaptainModel(event.target.value)}
+                  placeholder="Captain model"
+                  style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+                />
+                <input
+                  value={mateModel}
+                  onChange={(event) => setMateModel(event.target.value)}
+                  placeholder="Mate model"
+                  style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+                />
+              </div>
+              {FLOTILLA_V1_ENABLED && (
+                <select
+                  value={selectedFlotillaId || ""}
+                  onChange={(event) => setSelectedFlotillaId(Number(event.target.value))}
+                  style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "7px 9px" }}
+                >
+                  <option value="">No flotilla</option>
+                  {flotillasForSelectedFleet.map((item) => (
+                    <option key={item.id} value={item.id}>{item.name}</option>
+                  ))}
+                </select>
+              )}
+              {!hasPlacement && (
+                <div style={{ fontSize: 11, color: "#f59e0b" }}>
+                  Placement unresolved: create/select Armada and Fleet first.
+                </div>
+              )}
+              <button
+                onClick={createCrew}
+                disabled={saving || !hasPlacement}
+                style={{ border: "none", background: "#16a34a", color: "#fff", borderRadius: 5, padding: "6px 8px", cursor: "pointer", fontSize: 11 }}
+              >
+                + Create Crew
+              </button>
+            </div>
+          </div>
+        )}
+
+        {errorMessage && <div style={{ color: "#f87171", fontSize: 11 }}>{errorMessage}</div>}
+        {successMessage && <div style={{ color: "#34d399", fontSize: 11 }}>{successMessage}</div>}
+
+        <div style={{ borderTop: "1px solid #131820", paddingTop: 10 }}>
+          <div style={{ fontSize: 11, color: "#93c5fd", marginBottom: 8 }}>Crew Placement Controls</div>
+          <div style={{ display: "grid", gap: 8 }}>
+            {state.crew_refs.map((refRow) => {
+              const crew = state.crews.find((item) => item.id === refRow.crew_id);
+              const armada = state.armadas.find((item) => item.id === refRow.armada_id);
+              const fleet = state.fleets.find((item) => item.id === refRow.fleet_id);
+              return (
+                <div key={refRow.id} style={{ border: "1px solid #1e2535", borderRadius: 6, padding: 8, display: "grid", gap: 6 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+                    <div style={{ fontSize: 11, color: "#cbd5e1" }}>
+                      {crew?.crew_name || `crew-${refRow.crew_id}`} <span style={{ color: "#64748b" }}>ref#{refRow.id}</span>
+                    </div>
+                    <div style={{ fontSize: 10, color: "#64748b" }}>
+                      {armada?.name || "unknown"} / {fleet?.name || "unknown"}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                    <select id={`move-armada-${refRow.id}`} defaultValue={refRow.armada_id} style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "5px 8px", fontSize: 11 }}>
+                      {state.armadas.map((item) => (
+                        <option key={item.id} value={item.id}>{item.name}</option>
+                      ))}
+                    </select>
+                    <select id={`move-fleet-${refRow.id}`} defaultValue={refRow.fleet_id} style={{ background: "#060810", border: "1px solid #1e2535", borderRadius: 5, color: "#cbd5e1", padding: "5px 8px", fontSize: 11 }}>
+                      {state.fleets.map((item) => (
+                        <option key={item.id} value={item.id}>{item.name}</option>
+                      ))}
+                    </select>
+                    <button
+                      onClick={() => {
+                        const armadaValue = Number(document.getElementById(`move-armada-${refRow.id}`)?.value);
+                        const fleetValue = Number(document.getElementById(`move-fleet-${refRow.id}`)?.value);
+                        moveRef(refRow, armadaValue, fleetValue);
+                      }}
+                      style={{ border: "1px solid #1e2535", background: "#1e3a8a", color: "#bfdbfe", borderRadius: 5, padding: "5px 8px", cursor: "pointer", fontSize: 11 }}
+                    >
+                      Move
+                    </button>
+                    <button
+                      onClick={() => cloneCrew(refRow.crew_id, crew?.crew_name || `crew-${refRow.crew_id}`)}
+                      style={{ border: "1px solid #1e2535", background: "#312e81", color: "#c7d2fe", borderRadius: 5, padding: "5px 8px", cursor: "pointer", fontSize: 11 }}
+                    >
+                      Clone Crew
+                    </button>
+                    <button
+                      onClick={() => unlinkRef(refRow.id)}
+                      style={{ border: "1px solid #1e2535", background: "#3f1d1d", color: "#fca5a5", borderRadius: 5, padding: "5px 8px", cursor: "pointer", fontSize: 11 }}
+                    >
+                      Unlink
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function JumpModal({ baseUrl, defaultTerminal, session, onClose }) {
   const [submitting, setSubmitting] = useState(false);
   const [feedback, setFeedback] = useState(null);
@@ -1260,6 +1812,7 @@ export default function Dashboard() {
   const [search, setSearch] = useState("");
   const [jumpTarget, setJumpTarget] = useState(null);
   const [editorTarget, setEditorTarget] = useState(null);
+  const [orgEditorOpen, setOrgEditorOpen] = useState(false);
   const [hosts, setHosts] = useState([]);
   const [sessions, setSessions] = useState([]);
   const [discoveryRows, setDiscoveryRows] = useState([]);
@@ -1479,6 +2032,21 @@ export default function Dashboard() {
 
         <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
           <button
+            onClick={() => setOrgEditorOpen(true)}
+            style={{
+              border: "1px solid #1e2535",
+              borderRadius: 5,
+              background: "#111827",
+              color: "#93c5fd",
+              padding: "5px 10px",
+              fontSize: 10,
+              cursor: "pointer",
+              letterSpacing: "0.05em",
+            }}
+          >
+            Org Editor
+          </button>
+          <button
             onClick={() => setEditorTarget({ mode: "create" })}
             style={{
               border: "1px solid #1e2535",
@@ -1681,6 +2249,15 @@ export default function Dashboard() {
           setEditorTarget(null);
           setActionMessage(message);
           await refresh();
+        }}
+      />
+
+      <OrganizationEditorModal
+        baseUrl={baseUrl}
+        open={orgEditorOpen}
+        onClose={() => setOrgEditorOpen(false)}
+        onSaved={(message) => {
+          setActionMessage(message);
         }}
       />
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,206 +1,202 @@
-# scmux — Architecture
+# scmux Architecture (Target)
 
-## 1. Product Architecture (Target)
+Status: v0.5.0 planning baseline architecture.
 
-scmux is a multi-team operations dashboard and launcher for AI agent teams.
+## 1. Architecture summary
 
-Primary value: show all defined projects at once (running or stopped), expose per-agent runtime state, show CI health, and start/stop safely without requiring a terminal window.
+scmux uses a strict split:
+- Persistent definition plane: editor-driven only.
+- Runtime observation plane: pollers + in-memory projection.
 
-## 2. Hard Invariants
+This split exists to prevent accidental runtime writes and to keep launch/control robust for many concurrent AI sessions.
 
-1. SQLite is a definition store only.
-- Stores user-approved project/host/roster definitions.
-- Does not auto-ingest tmux discovery.
+## 2. System planes
 
-2. Exactly one persistent writer subsystem exists.
-- Multiple editor entry points are allowed (`New Project`, `Project Editor`, card-level `Edit`), but all persistent writes must route through the same writer subsystem.
-- Compile boundary is enforced via Rust visibility: persistent-write functions in `db.rs` are restricted (`pub(crate)`/`pub(super)`) and callable only from `definition_writer`.
-- All pollers and runtime loops are SQLite read-only.
+### 2.1 Definition plane (persistent)
 
-3. Approved-project write policy is mandatory.
-- Any persistent write must validate that target project is approved (`enabled = 1` and non-empty `config_json.panes[]` created via editor flow).
+Owned by one writer module only.
 
-4. Discovery is read-only.
-- Raw tmux discovery is informational and never mutates project definitions.
+Responsibilities:
+- Persist Armada/Fleet/Flotilla/Crew/CrewMember definitions.
+- Enforce write constraints and identity rules.
+- Validate save operations atomically.
 
-5. Safety-first session control.
-- Stop is graceful-first (ATM shutdown request), then scoped hard-stop only if needed.
-- Panic/error paths must not bulk-stop unrelated sessions.
+### 2.2 Runtime plane (ephemeral)
 
-6. Runtime state is live/ephemeral.
-- Runtime status is refreshed continuously for UI/CLI display.
-- Runtime status is not persisted as definition truth.
+Owned by read-only poller modules and projector.
 
-## 3. Runtime Data Flow
+Responsibilities:
+- Observe tmux runtime, host health, CI status, ATM member state.
+- Build in-memory session/crew projection.
+- Serve runtime APIs and UI cards without mutating persistent definitions.
 
-```text
-User Form/Edit Action
-  -> Definition Write Module (only persistent writer)
-  -> SQLite definitions (projects/hosts/approved roster)
+## 3. Hard boundaries
 
-Pollers (read-only persistence)
-  -> tmux_poller reads tmux runtime
-  -> atm_poller reads ATM socket runtime
-  -> ci_poller reads gh/az runtime
-  -> hosts_poller reads remote health/runtime
+1. Exactly one persistent writer module.
+- Proposed module: `definition_writer` (name can be finalized during implementation).
+- All persistence mutating handlers call this module only.
 
-Runtime projection
-  -> in-memory aggregate session/project view
-  -> HTTP API
-  -> Dashboard + CLI
-```
+2. Pollers are write-prohibited for definitions.
+- `tmux_poller`, `hosts`, `ci`, `atm` must not persist discovery as definitions.
 
-P6 decision: runtime cache tables (`session_status`, `session_ci`, `session_atm`) are replaced by in-memory projection for runtime display paths.
+3. Discovery is import-only.
+- Unregistered tmux discovery view does not write DB.
+- Explicit user import invokes `definition_writer`.
 
-## 4. Module Responsibilities
+4. Runtime failures are scoped.
+- Panic/error in one crew flow cannot stop unrelated running crews.
 
-### 4.1 `definition_writer` (new/central)
-- Only module allowed to persist project definitions.
-- Can be invoked by multiple editor UX entry points.
-- Handles create/edit/delete for projects/hosts/approved roster changes.
-- Enforces approved-project constraints.
+## 4. Module responsibilities
 
-### 4.2 `tmux_poller` (rename target for current `scheduler.rs`)
-- Reads tmux session/pane runtime state.
-- Computes runtime state (`stopped|starting|running|idle|done`) for API projection.
-- No persistent writes.
+### 4.1 `definition_writer`
+
+Only persistent writer.
+
+Responsibilities:
+- CRUD for Armada/Fleet/Flotilla/Crew/CrewMember.
+- Reference/link updates for organization membership and move operations.
+- Copy-on-write fork operations when user chooses split.
+- Atomic transaction boundaries for complex edits.
+- Validation at save/start boundaries.
+
+### 4.2 `tmux_poller` (current `scheduler.rs` rename target)
+
+Responsibilities:
+- Read tmux sessions/windows/panes.
+- Resolve runtime bind for CrewVariants.
+- Feed projector with runtime session state.
+
+Prohibited:
+- Writing definitions or reconstruction data to SQLite.
 
 ### 4.3 `hosts.rs`
-- Reads remote daemon health/runtime snapshots.
-- Aggregates reachability and stale status for dashboard.
-- No persistent writes from discovery.
-- In-memory projection retains last-known remote session snapshots across consecutive failed poll cycles.
-- `last_seen` is updated on each successful poll in-memory for display.
-- Runtime host projection data is lost on daemon restart (acceptable for P6).
+
+Responsibilities:
+- Read remote daemon reachability/health snapshots.
+- Feed host runtime status into projector.
+
+Prohibited:
+- Persistent definition mutation from runtime polling.
 
 ### 4.4 `ci.rs`
-- Reads CI status from `gh`/`az`.
-- Produces runtime snapshot list per project (PRs + run statuses).
-- No persistent writes from CI polling.
+
+Responsibilities:
+- Read CI state snapshots (provider adapters).
+- Feed per-crew/per-project status into projector.
+
+Prohibited:
+- Persisting CI runtime snapshots as definition truth.
 
 ### 4.5 `atm.rs`
-- Reads ATM socket runtime state per agent.
-- Maps per-pane state via canonical key (`pane.atm_team`, `pane.atm_agent`).
-- Permanent roster changes are editor-driven writes only.
+
+Responsibilities:
+- Read ATM daemon runtime member status per crew member.
+- Map runtime status by configured identity references.
+
+Prohibited:
+- Autonomous roster/team persistent writes.
 
 ### 4.6 `api.rs`
-- Read endpoints expose aggregated runtime + persisted definitions.
-- Action endpoints (`start/stop/jump`) control runtime only.
-- Persistent writes are only via definition-editor endpoints.
-- Discovery endpoint is explicit: `GET /discovery` for read-only raw tmux view.
 
-## 5. Session Lifecycle Model
+Responsibilities:
+- Read endpoints: definitions + runtime projection responses.
+- Runtime actions: start/stop/jump pathways.
+- Editor endpoints: call `definition_writer` for persistence.
 
-State machine:
+Constraint:
+- No direct persistence calls from non-editor routes.
 
-`stopped -> starting -> running -> idle -> done`
+## 5. Core data model
 
-Additional explicit stop edges:
-- `running -> stopped` via `POST /sessions/:name/stop`.
-- `idle -> stopped` via `POST /sessions/:name/stop`.
+Logical hierarchy:
+- Armada
+- Fleet
+- Flotilla (optional)
+- Crew
+- CrewMember
+- CrewVariant
 
-- `stopped`: entered when (1) project is defined but never started, or (2) session is stopped from `running`/`idle`.
-- `starting`: launch requested; tmux/agents being created.
-- `starting` failure edge: if tmux/session creation or pane launch fails, transition back to `stopped` with structured error details.
-- `running`: tmux exists and at least one pane agent is ATM-active.
-- `idle`: tmux exists; all pane agents idle/offline.
-- `done`: semantics and auto-teardown policy are intentionally unresolved; no transition-in path is required in P6 and behavior remains non-destructive by default.
+Hierarchy model:
 
-## 6. Key Flows
-
-### 6.1 Start
-`POST /sessions/:name/start`
-1. Read `config_json` definition from SQLite.
-2. Create tmux session/window/pane layout.
-3. Launch each pane command.
-4. Publish runtime transitions to API/dashboard.
-
-### 6.2 Stop
-`POST /sessions/:name/stop`
-1. Send ATM shutdown signal/message to configured agents.
-2. Wait configurable grace period.
-3. If still running, apply scoped hard-stop to target session only (exact retries/timeouts are product-configurable and pending finalization).
-4. Never kill unrelated sessions.
-
-### 6.3 Jump
-`POST /sessions/:name/jump`
-- Opens iTerm (or selected terminal) as a viewer.
-- Attach/detach does not control lifecycle.
-
-## 7. Views
-
-### 7.1 Primary View
-- All defined projects from SQLite.
-- Includes stopped projects with Start affordance.
-- Running projects show per-pane ATM + CI runtime status.
-
-### 7.2 Secondary View
-- Raw tmux discovery tab backed by `GET /discovery`.
-- Informational only, no persistence side effects.
-
-## 8. Definition Schema (`config_json`)
-
-```json
-{
-  "panes": [
-    {
-      "name": "team-lead",
-      "command": "claude --profile team-lead",
-      "atm_agent": "team-lead",
-      "atm_team": "scmux-dev"
-    },
-    {
-      "name": "arch-cmux",
-      "command": "codex --profile arch-cmux",
-      "atm_agent": "arch-cmux",
-      "atm_team": "scmux-dev"
-    }
-  ],
-  "repo": "/Users/randlee/Documents/github/scmux",
-  "window_layout": "even-horizontal",
-  "atm_team": "scmux-dev"
-}
+```text
+Armada
+  -> Fleet
+    -> Flotilla (optional)
+      -> Crew
+        -> CrewMember (role/model/prompt definition)
+        -> CrewVariant (host/path/branch runtime binding)
 ```
 
-## 9. Observability Direction
+Key identity notes:
+- Crew has immutable-by-default `crew_name` aligned with ATM naming.
+- Crew has stable `crew_ulid` for cross-host identity continuity.
+- CrewVariant binds concrete runtime context (`host_id`, repo metadata, branch/path dimensions, tmux coordinates).
 
-Current logging should remain structured and stable with OpenTelemetry in mind.
+## 6. Runtime binding model
 
-Required now:
-- Correlation identifiers on lifecycle/action events.
-- Consistent key/value fields for session/project/agent/host.
-- Log/event schema that can be mapped to OTel traces/spans without redesign.
+Every runnable CrewVariant must resolve to tmux coordinates:
+- `session`
+- `window`
+- `pane`
 
-## 10. Prohibited Behaviors
+Implications:
+- Armada/Fleet/Flotilla are organization/view layers.
+- Cloning Armada does not duplicate live runtime by default; shared references show same running sessions until explicit fork.
 
-- Auto-writing project definitions from tmux discovery.
-- Reconstructing deleted definitions from live tmux.
-- Poller-based persistent writes (tmux/hosts/ci/atm loops).
-- Session-level-only ATM model as final representation.
-- Panic/error bulk-stop behavior.
+## 7. Editing and validation model
 
-## 11. Refactor Scope (Code Conflicts to Remove)
+### 7.1 Save-time behavior
 
-Conflicting current modules and expected direction:
+- Forms may allow temporary invalid states while editing.
+- Save must be atomic.
+- If save cannot be applied atomically, it fails and client refreshes current DB state.
 
-- `scheduler.rs`
-  - Remove discovery-to-definition persistence and reconstruction logic.
-  - Rename responsibility toward read-only runtime polling (`tmux_poller`).
+### 7.2 Start-time behavior
 
-- `hosts.rs`
-  - Remove remote discovery persistence paths.
-  - Keep health/runtime aggregation only.
+- Start gate is strict: unresolved required references (e.g., missing prompt files) block start.
+- Already running crews are not force-killed solely because a later validation check fails.
 
-- `ci.rs`
-  - Remove CI snapshot persistence writes.
-  - Keep runtime CI projection only.
+### 7.3 Running edit restrictions
 
-- `atm.rs`
-  - Remove autonomous persistent runtime writes.
-  - Keep per-pane runtime mapping; route roster persistence through editor.
+Allowed while running:
+- move Crew between Armada/Fleet/Flotilla
+- organizational/view edits
 
-- `api.rs`
-  - Ensure only definition-editor routes can persist data.
-  - Keep start/stop/jump as runtime control paths.
+Disallowed while running:
+- Crew roster/prompt definition edits
 
-This architecture supersedes earlier discovery-first assumptions.
+## 8. Discovery/import architecture
+
+- `GET /discovery` (or equivalent read endpoint) exposes unregistered tmux runtime objects.
+- Discovery view is non-persistent.
+- Import action maps selected discovered runtime to Crew/CrewMember definition payload and persists via `definition_writer`.
+
+## 9. Launch and stop architecture
+
+### 9.1 Launch
+
+1. API resolves Crew/CrewVariant definition.
+2. Validate start prerequisites.
+3. Create/attach tmux session layout.
+4. Launch CrewMember commands by pane.
+5. Runtime projector reflects transitions (`stopped -> starting -> running/idle`).
+
+### 9.2 Stop
+
+- Full coordinated ATM shutdown orchestration is intentionally deferred.
+- Current phase allows stub behavior with explicit log/error reporting when shutdown command path is not implemented.
+- Any hard-stop fallback must stay scoped to the targeted crew runtime.
+
+## 10. Observability direction
+
+- Structured logs with consistent action/session/member identifiers.
+- Keep logging schema OpenTelemetry-ready for near-term integration.
+- `scmux doctor` is the primary operational surface for runtime diagnostics.
+
+## 11. Prohibited behaviors
+
+- Auto-registration of discovered tmux runtime into DB.
+- Poller-driven persistent definition writes.
+- Reconstruction of deleted definitions from live runtime.
+- Session-wide-only ATM status as final model (member-level is required).
+- Unscoped mass shutdown on panic/error.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,374 +1,135 @@
-# scmux — Project Plan
+# scmux Project Plan (Execution Reset)
 
-## Overview
+Status: Active v0.5.0 planning baseline.
 
-scmux is delivered in six phases with explicit integration branches and version targets.
+## 1. Objective
 
-| Phase | Theme | Target Version | Integration Branch |
-|-------|-------|----------------|--------------------|
-| 1 | Foundation + API | 0.1.0 | `integrate/phase-1` |
-| 2 | Multi-host + Dashboard | 0.2.0 | `integrate/phase-2` |
-| 3 | CI + CLI | 0.3.0 | `integrate/phase-3` |
-| 4 | Supervision + Release | 0.3.0 | `integrate/phase-4` |
-| 5 | Dashboard Embed + Release Automation + ATM Activity | 0.4.x | `integrate/phase-5` |
-| 6 | Definition-First Architecture Realignment | 0.5.0 | `integrate/phase-6` (planned) |
+Bring scmux to a stable MVP where users can reliably define, launch, and manage many AI crews with strict persistence controls.
 
-## Execution Model
+Top priorities:
+- Documentation and design language locked first.
+- Remove unsafe/legacy runtime-write behavior.
+- Implement editor-first definitions for Armada/Fleet/Flotilla/Crew/CrewMember.
+- Keep runtime state live and non-persistent.
 
-### Roles and ownership
+## 1.1 Phase map
 
-- `team-lead` owns sequencing, review, and merge decisions.
-- `arch-cmux` is the sole implementation agent for sprint delivery work.
-- `quality-mgr` runs dual QA tracks (`rust-qa-agent` + `scmux-qa-agent`) in parallel.
+| Phase | Theme | Target Branch |
+|---|---|---|
+| 1-6 | Historical delivery (foundation through architecture realignment) | `integrate/phase-1` ... `integrate/phase-6` |
+| 7 | Crew hierarchy, editor backend/UI, launch/import hardening | `integrate/phase-7` |
 
-### Branching and worktrees
+## 2. Scope boundaries
 
-- Main repo remains on `develop`.
-- Each sprint runs in a dedicated worktree at `/Users/randlee/Documents/github/scmux-worktrees/<branch>`.
-- Sprint PRs target the phase integration branch.
-- Phase integration branches merge to `develop` after phase completion.
+In scope for this plan:
+- `docs/requirements.md`, `docs/architecture.md`, `docs/project-plan.md` alignment.
+- Single persistent write gate implementation direction.
+- Editor flows above Crew editor (Armada/Fleet/Flotilla input/edit + CrewMember add/move).
+- Unregistered tmux discovery as view + explicit import.
+- tmux-bound launch/runtime model.
 
-### ATM communication protocol
+Out of scope for this cycle:
+- Full ATM shutdown orchestration implementation.
+- Heavy history/provenance subsystem.
+- Broad remote multi-daemon sync engine beyond stable identity direction.
+- Deferred issue set tracked for this cycle: GH `#31`, `#35`, `#36`, `#37`.
 
-- Assignment: `team-lead` sends direct ATM message to `arch-cmux`.
-- Ack: `arch-cmux` acknowledges receipt before coding.
-- Completion: `arch-cmux` reports commit/PR back via ATM.
-- Follow-up: QA findings are sent by `quality-mgr` to `team-lead`, then forwarded as fix tasks.
+## 3. Sprint roadmap
 
-## Sprint Status
+### Sprint P7-S1: Planning lock (docs + decision closure)
 
-| Sprint | Status |
-|--------|--------|
-| S0 | Complete (foundation: cargo build, workspace scaffold, env var rename) |
-| S1.1 | Complete |
-| S1.2 | Complete |
-| S2.1 | Complete |
-| S2.2 | Complete |
-| S3.1 | Complete |
-| S3.2 | Complete |
-| S4.1 | Complete |
-| S4.2 | Complete |
-| S5.1 | Complete |
-| S5.2 | Complete |
-| S5.3 | Complete |
-| S6.0 | Complete — PR #27 |
-| S6.1 | Complete — PR #28 |
-| S6.2 | Complete — PR #29 |
-| S6.3 | Complete — PR #38 |
-| S6.fix | Complete — PR #40 |
-| S6.cli | Complete — PR #41 |
+Deliverables:
+- Finalize `requirements.md`, `architecture.md`, `project-plan.md`.
+- Align terminology with `design-language.md`.
+- Record unresolved policy decisions explicitly.
 
-## Sprint S0 — Foundation (Complete)
+Exit criteria:
+- Docs are mutually consistent.
+- Team can execute implementation without redefining core behavior.
 
-**Status:** Complete as of initial repo setup (before formal sprint tracking began).
+### Sprint P7-S2: Runtime-write carve-out and safety gate
 
-**Delivered:**
-- `cargo build --workspace` clean with no errors
-- Workspace scaffold: `crates/scmux-daemon`, `crates/scmux`
-- `tms` → `scmux` rename throughout codebase
-- `SCMUX_DB` and `SCMUX_PORT` env vars established
+Deliverables:
+- Remove all persistent writes outside the writer gate.
+- Enforce visibility boundary so only writer module can mutate definitions.
+- Stub unsupported ATM send/shutdown paths with explicit error logs (no silent behavior).
+- Keep pollers read-only and projection-only.
+- Execute carve-out against explicit conflict inventory in [docs/refactor-scope-v0.5.md](./refactor-scope-v0.5.md).
 
-**Note:** Logging module (DG-08) was identified post-S0 and is assigned to Sprint S1.1.
+Exit criteria:
+- Grep/code review confirms no stray definition writes outside writer gate.
+- Existing runtime flows continue without DB reconstruction behavior.
 
-## Phase 1 — Foundation + API
+### Sprint P7-S3: Definition schema and editor backend
 
-**Goal:** daemon config/database foundations are compliant and the HTTP surface is complete.
-**Version:** `0.1.0`
-**Integration branch:** `integrate/phase-1`
+Deliverables:
+- Persisted model for Armada/Fleet/Flotilla/Crew/CrewMember/CrewVariant.
+- API endpoints for create/edit/clone/move/unlink across hierarchy.
+- Atomic save operations and reference-counted delete semantics.
+- Running-edit restrictions enforced (org moves allowed; roster/prompt edits blocked while running).
 
-### Sprint 1.1 — Foundation (Config + DB)
+Exit criteria:
+- Editor API coverage proves atomic updates and policy enforcement.
+- Copy-on-write fork path is explicit and testable.
 
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p1-s1-foundation`
-- Base branch: `integrate/phase-1`
-- PR target: `integrate/phase-1`
-- Context: build is clean, but config loading/host seeding/schema parity gaps remain.
-- Deliverables:
-  - `crates/scmux-daemon/src/config.rs` with `Config` model matching architecture section 6 (`daemon`, `polling`, `hosts`).
-  - `Config::load()` from `~/.config/scmux/scmux.toml` with defaults fallback.
-  - `crates/scmux-daemon/src/main.rs` uses config for `port`, `db_path`, intervals; `AppState` adds `config: Config`; default INFO logging.
-  - `crates/scmux-daemon/src/db.rs` adds `seed_hosts_from_config()`, `sessions_updated_at` trigger, schema index names matching `docs/schema.sql`.
-  - `scmux.toml.example` at repo root.
-  - `tests/db_tests.rs` for T-D-01..T-D-04.
-  - `tests/scheduler_tests.rs` for T-D-05..T-D-07 (`should_run_now` exposed as `pub(crate)`).
-- Acceptance criteria:
-  - daemon starts with defaults when config file is missing.
-  - config file values override defaults.
-  - host seeding is idempotent and inserts configured remote hosts.
-  - DB migration parity matches `docs/schema.sql` for trigger/index names.
-  - T-D-01..T-D-07 pass.
-- Requirement IDs: `DG-04`, `DG-05`, `DG-07`, `T-D-01..T-D-07`.
-- Detailed spec: [docs/sprint-specs/p1-s1-foundation.md](./sprint-specs/p1-s1-foundation.md)
+### Sprint P7-S4: UI editors and organization workflows
 
-### Sprint 1.2 — Full API Surface
+Deliverables:
+- Armada/Fleet editor screens, plus Flotilla editor screens when Flotilla is enabled for v1 (otherwise behind feature flag).
+- Basic edit controls above Crew editor (add/move crews and crew members as defined by policy).
+- Clone flows for Armada/Fleet/Crew with shared-by-default semantics.
+- Clear validation UX for unresolved references.
 
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p1-s2-api`
-- Base branch: `feature/p1-s1-foundation`
-- PR target: `integrate/phase-1`
-- Context: foundational daemon loop exists; API endpoints and jump/static serving are incomplete.
-- Deliverables:
-  - `crates/scmux-daemon/src/api.rs` adds `POST /sessions`, `PATCH /sessions/:name`, `DELETE /sessions/:name`, `GET /hosts`, `GET /dashboard-config.json`, `POST /sessions/:name/jump`, `GET /`.
-  - `crates/scmux-daemon/src/tmux.rs` / jump helper module implements iTerm2 AppleScript local+SSH launch.
-  - `crates/scmux-daemon/src/db.rs` and handler validation enforce session registration constraints (`SR-02`, soft delete behavior).
-  - event logging coverage for start/stop/jump actions (`API-16`).
-  - `tests/api_tests.rs` covering T-A-01..T-A-11.
-  - `tests/integration_tests.rs` covering T-I-01..T-I-07.
-- Acceptance criteria:
-  - full API routes respond with documented behavior/status.
-  - jump endpoint returns structured `{ok,message}` for success/failure.
-  - session CRUD flow works end-to-end with soft delete.
-  - integration/API tests listed above pass.
-- Requirement IDs: `API-08..API-16`, `TL-01..TL-08`, `DG-03`, `SR-02`, `SR-04`.
-- Detailed spec: [docs/sprint-specs/p1-s2-api.md](./sprint-specs/p1-s2-api.md)
+Exit criteria:
+- User can create full hierarchy and reorganize without direct DB manipulation.
+- Invalid definitions can be repaired via UI without dead-end validation traps.
 
-## Phase 2 — Multi-host + Dashboard
+### Sprint P7-S5: Launch/runtime and discovery import
 
-**Goal:** multi-host reachability is first-class and dashboard is live against daemon APIs.
-**Version:** `0.2.0`
-**Integration branch:** `integrate/phase-2`
+Deliverables:
+- Strict start validation and tmux binding from CrewVariant.
+- Runtime projection endpoints for dashboard/CLI.
+- Unregistered discovery view (sessions/windows/panes) and explicit import flow.
+- `scmux doctor` diagnostics surface for runtime visibility.
 
-### Sprint 2.1 — Multi-Host Reachability
+Exit criteria:
+- External tmux sessions can be imported into registered crews.
+- Launch/monitor workflows work without runtime persistence side effects.
 
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p2-s1-multihost`
-- Base branch: `integrate/phase-2`
-- PR target: `integrate/phase-2`
-- Context: hosts table exists, but active reachability model/last-seen behavior must be implemented.
-- Deliverables:
-  - `crates/scmux-daemon/src/hosts.rs` for host polling and in-memory reachability state.
-  - `crates/scmux-daemon/src/main.rs` adds host poll loop scheduling.
-  - `crates/scmux-daemon/src/api.rs` `/hosts` and dashboard config include `reachable` and `last_seen` fields.
-  - integration tests for unreachable/restore behavior.
-- Acceptance criteria:
-  - unreachable hosts are represented without daemon errors.
-  - last-known data remains available during outage.
-  - reachability auto-recovers within one poll cycle.
-- Requirement IDs: `MH-01..MH-09`, `T-I-10..T-I-12`.
-- Detailed spec: [docs/sprint-specs/p2-s1-multihost.md](./sprint-specs/p2-s1-multihost.md)
+### Sprint P7-S6: Hardening and release prep
 
-### Sprint 2.2 — Live Dashboard
+Deliverables:
+- Concurrency/race hardening around edit/save and runtime transitions.
+- Safety testing for panic/partial failure isolation.
+- Documentation final pass and release checklist updates.
 
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p2-s2-dashboard`
-- Base branch: `feature/p2-s1-multihost`
-- PR target: `integrate/phase-2`
-- Context: dashboard has static mock data and needs live integration + host-aware rendering.
-- Deliverables:
-  - `dashboard/team-dashboard.jsx` switched to live fetch across hosts.
-  - monochrome rendering for unreachable-host sessions.
-  - jump modal wired to daemon `POST /sessions/:name/jump` and feedback handling.
-  - grid/list/grouped + filters + header aggregate counts validated against API.
-  - dashboard manual test checklist coverage.
-- Acceptance criteria:
-  - dashboard renders live daemon data from all configured hosts.
-  - unreachable hosts are monochrome with `last seen` indicator.
-  - jump modal executes daemon jump and renders response.
-- Requirement IDs: `DV-01..DV-11`, `DC-01..DC-05`, `DJ-01..DJ-07`, `T-UI-01..T-UI-17`.
-- Detailed spec: [docs/sprint-specs/p2-s2-dashboard.md](./sprint-specs/p2-s2-dashboard.md)
+Exit criteria:
+- QA critical findings closed.
+- MVP acceptance checklist passes for create/edit/launch/manage/import flows.
 
-## Phase 3 — CI + CLI
+## 4. Policy decisions to finalize during execution
 
-**Goal:** CI signals are integrated and CLI is production-usable.
-**Version:** `0.3.0`
-**Integration branch:** `integrate/phase-3`
+1. Final persisted representation of Armada/Fleet/Flotilla (entity vs view-layer only where applicable).
+2. Precise clone matrix for “shared edit” vs “fork” by field category.
+3. Exact uniqueness constraints across `crew_ulid`, host, repo, branch, and path dimensions.
+4. Default UI organization mode and cross-host merge behavior.
+5. `crew_ulid` lifecycle ownership and conflict resolution.
+6. Import mapping rules from discovered tmux objects to Crew/CrewMember schema.
+7. Flotilla rollout mode (required in v1 vs feature flag).
 
-### Sprint 3.1 — CI Integration
+## 5. MVP acceptance checklist
 
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p3-s1-ci`
-- Base branch: `integrate/phase-3`
-- PR target: `integrate/phase-3`
-- Context: schema has `session_ci`; provider polling/tool-degradation behavior is not implemented.
-- Deliverables:
-  - `crates/scmux-daemon/src/ci.rs` for provider polling, parsing, persistence.
-  - `crates/scmux-daemon/src/main.rs` adds `ci_loop` with adaptive interval.
-  - tool discovery at startup for `gh`/`az`; `tool_unavailable` persisted to `session_ci`.
-  - API summaries expose provider status payloads.
-  - tests covering interval and tool-unavailable behavior.
-- Acceptance criteria:
-  - active sessions poll every 1 minute; idle/stopped every 5 minutes.
-  - unavailable provider tools yield persisted `tool_unavailable` status.
-  - provider payloads surface in API for dashboard display.
-- Requirement IDs: `CI-01..CI-13`, `T-D-10..T-D-13`.
-- Detailed spec: [docs/sprint-specs/p3-s1-ci.md](./sprint-specs/p3-s1-ci.md)
+MVP is considered successful when all are true:
+1. User can define Armada/Fleet/Flotilla/Crew/CrewMembers entirely from editors.
+2. User can add/move crew members and crews across organization layers per policy.
+3. Start launches tmux runtime from definitions with strict validation.
+4. Runtime state is visible and testable without writing runtime snapshots to DB.
+5. Unregistered tmux runtime can be discovered and imported explicitly.
+6. No persistent writes exist outside writer gate.
+7. Panic/error paths do not mass-stop unrelated crews.
 
-### Sprint 3.2 — CLI Binary
+## 6. Coordination and review cadence
 
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p3-s2-cli`
-- Base branch: `feature/p3-s1-ci`
-- PR target: `integrate/phase-3`
-- Context: CLI crate is only a stub and lacks network/command plumbing.
-- Deliverables:
-  - `crates/scmux/Cargo.toml` includes `reqwest`, `clap`, `tokio`.
-  - `crates/scmux/src/main.rs` implements command tree and dispatch.
-  - `crates/scmux/src/client.rs` HTTP client with `SCMUX_HOST`/`--host` support.
-  - command coverage for list/show/start/stop/jump/add/edit/disable/enable/remove/hosts/daemon status.
-- Acceptance criteria:
-  - all CLI commands map to daemon API routes and return actionable output.
-  - `scmux list` matches dashboard-visible state.
-  - `scmux jump` triggers daemon jump route successfully.
-- Requirement IDs: `CLI-01..CLI-14`.
-- Detailed spec: [docs/sprint-specs/p3-s2-cli.md](./sprint-specs/p3-s2-cli.md)
-
-## Phase 4 — Supervision + Release
-
-**Goal:** production hardening, end-to-end validation, and 1.0 release readiness.
-**Version:** `0.3.0`
-**Integration branch:** `integrate/phase-4`
-
-### Sprint 4.1 — Supervision + Performance
-
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p4-s1-supervision`
-- Base branch: `integrate/phase-4`
-- PR target: `integrate/phase-4`
-- Context: core features exist; service lifecycle and perf guarantees are not finalized.
-- Deliverables:
-  - launchd + systemd service assets and install/run docs.
-  - daemon status command and health telemetry refinements.
-  - profiling/optimization pass for poll/API latency constraints.
-- Acceptance criteria:
-  - boot supervision works on macOS and Linux.
-  - NF-03/NF-04 performance targets are measured and met.
-  - daemon remains resilient under partial-host/session failure.
-- Requirement IDs: `DH-04`, `DH-05`, `NF-01..NF-05`, `NF-08`.
-- Detailed spec: [docs/sprint-specs/p4-s1-supervision.md](./sprint-specs/p4-s1-supervision.md)
-
-### Sprint 4.2 — E2E Tests + Release
-
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p4-s2-release`
-- Base branch: `feature/p4-s1-supervision`
-- PR target: `integrate/phase-4`
-- Context: all feature work merged; final verification and release packaging required.
-- Deliverables:
-  - complete end-to-end suite T-E-01..T-E-11.
-  - acceptance criteria validation report.
-  - release artifacts/versioning to `0.3.0` and Homebrew publish steps.
-- Acceptance criteria:
-  - all E2E tests pass consistently.
-  - section 7 acceptance criteria in requirements are fully satisfied.
-  - release checklist complete for binary/crate/Homebrew channels.
-- Requirement IDs: `T-E-01..T-E-11`, `AC-1..AC-10`.
-- Detailed spec: [docs/sprint-specs/p4-s2-release.md](./sprint-specs/p4-s2-release.md)
-
-## Phase 5 — Dashboard Embed + Release Automation + ATM Activity (Complete)
-
-**Goal:** make dashboard self-contained for packaging, automate Homebrew updates, and add ATM activity visibility.
-**Version:** `0.4.x`
-**Integration branch:** `integrate/phase-5`
-
-### Sprint 5.1 — Dashboard Embed + crates.io
-- Status: Complete
-- Primary outcomes: embedded dashboard assets, release publish order fixes, CI dashboard drift checks.
-
-### Sprint 5.2 — Homebrew Release Automation
-- Status: Complete
-- Primary outcomes: `update-homebrew` workflow, formula patch automation and docs alignment.
-
-### Sprint 5.3 — ATM Integration
-- Status: Complete
-- Primary outcomes: ATM daemon polling, API/CLI/dashboard activity display, follow-up artifact sync fixes.
-
-## Phase 6 — Definition-First Architecture Realignment (Current)
-
-**Goal:** replace discovery-first assumptions with definition-first architecture and writer-subsystem constraints.
-**Version:** `0.5.0` (planned)
-**Integration branch:** `integrate/phase-6` (planned; current docs work targets `develop`)
-
-### Sprint 6.0 — Requirements + Architecture Rewrite
-
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p6-requirements-revision`
-- Base branch: `develop`
-- PR target: `develop`
-- Status: In Progress
-- Scope:
-  - hard-replace `docs/requirements.md` and `docs/architecture.md` to definition-first model
-  - define writer subsystem boundaries and prohibited poller writes
-  - define in-memory runtime projection approach and discovery endpoint contract
-  - capture refactor scope for conflicting runtime-write paths
-- Acceptance criteria:
-  - requirements + architecture reflect the definition-first model with no conflicting discovery-first language
-  - writer subsystem boundary is specified (including compile-boundary enforcement notes)
-  - in-memory runtime projection is explicitly defined for runtime API views
-  - discovery endpoint contract (`GET /discovery`) is defined
-  - refactor-scope document includes Must Remove, Must Constrain, and Must Implement sections
-  - QA re-review reports no blocking findings for Sprint 6.0 docs
-- Related PR: `#27`
-
-### Sprint 6.1 — Writer Gate + Runtime Projection
-
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p6-s1-writer-gate`
-- Base branch: `integrate/phase-6`
-- PR target: `integrate/phase-6`
-- Status: Complete — merged PR #28 (6ddcdfb)
-- Scope:
-  - `definition_writer` module — sole persistent writer; `pub(crate)` visibility boundary on `db.rs` write functions
-  - In-memory runtime projection replacing poller writes to `session_status`, `session_ci`, `session_atm`
-  - `scheduler.rs` → `tmux_poller.rs` rename; cron logic in separate module
-  - Graceful stop: ATM shutdown → grace period → scoped hard-stop
-  - API host CRUD (POST/PATCH/DELETE /hosts) via definition_writer
-  - GET /discovery endpoint (read-only raw tmux discovery)
-- Acceptance criteria: all met — cargo clippy clean, 78 tests pass, writer-gate T-WG-01..T-WG-04 verified
-- Related PR: #28
-- Deferred findings (tracked as GH issues): #30, #31, #32, #33, #34
-
-### Sprint 6.2 — Dashboard Wiring + Per-Pane ATM + CI View
-
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p6-s2-runtime-projection`
-- Base branch: `feature/p6-s1-writer-gate`
-- PR target: `integrate/phase-6`
-- Status: Complete — merged PR #29 (d13d1dc)
-- Scope:
-  - Dashboard primary view: all defined projects (running + stopped)
-  - Per-pane ATM state on project cards (active/idle/stuck/offline/unknown)
-  - CI run color indicators (green/yellow/red) per project card
-  - Secondary discovery tab wired to GET /discovery
-  - Start/Stop buttons wired to POST /sessions/:name/start and /stop
-  - New Project + card Edit flows via POST/PATCH /sessions
-  - dashboard.js recompiled
-- Related PR: #29
-
-### Sprint 6.3 — Cleanup + Lifecycle Tests + Deferred Findings
-
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p6-s3-cleanup-tests`
-- Base branch: `feature/p6-s2-runtime-projection`
-- PR target: `integrate/phase-6`
-- Status: Complete — merged PR #38 (956a389 + 155ee50)
-- Scope:
-  - #30 SCMUX-QA-P6S1-004: Remove deprecated table DDL (session_status, session_ci, session_atm) from db::migrate()
-  - #31 SCMUX-QA-P6S1-006: Explicit per-pane ATM field in API response (ATM-03)
-  - #32 SCMUX-QA-P6S1-007: Add approval policy comment to validate_approved_project
-  - #33 SCMUX-QA-P6S1-008: Tag/name T-LC-01..T-LC-06 lifecycle tests; add T-LC-03
-  - #34 SCMUX-QA-P6S1-009: Populate or remove recent_events field in GET /sessions/:name
-  - Any deferred findings from S6.2 QA
-- Acceptance criteria:
-  - cargo clippy clean, cargo test passes
-  - No deprecated table DDL in migrate()
-  - T-LC-01..T-LC-06 named and passing
-  - recent_events populated or removed
-  - GH issues #30–34 closed
-
-### Critical Review Fix Pass
-
-- Worktree: `/Users/randlee/Documents/github/scmux-worktrees/feature/p6-critical-review-fixes`
-- Base branch: `integrate/phase-6`
-- PR target: `integrate/phase-6`
-- Status: In Progress — assigned to arch-cmux
-- Sprint spec: `docs/sprint-specs/p6-critical-review-fixes.md`
-- Scope: B-01..B-10 + `scmux doctor` CLI command (see sprint spec for full details)
-- Design decisions: ATM auto-discovery removed; daemon_health moved to in-memory; ATM opt-in config
-- Pending: B-11 (CLI write commands) — owner decision required
-
-## Dependencies Across Sprints
-
-- `1.1` must merge before `1.2`.
-- `1.2` must merge before any phase 2 sprint.
-- `2.1` must merge before `2.2`.
-- `2.2` should merge before phase 3 UI-facing CI badge validation.
-- `3.1` must merge before `3.2`.
-- `3.2` must merge before any phase 4 sprint.
-- `4.1` must merge before `4.2`.
-- `4.2` must merge before phase 5 implementation sprints.
-- phase 5 completion is a prerequisite for phase 6 realignment implementation.
-
-## Current Phase Entry Point
-
-- Active planning baseline: `Phase 6`.
-- All sprints 6.0–6.3 complete and merged to `integrate/phase-6`.
-- Fix pass in progress (`feature/p6-critical-review-fixes`).
-- After fix pass merges: final PR `integrate/phase-6 → develop` for v0.5.0.
+- Team-lead owns sprint assignment/acceptance and policy decisions.
+- Implementation reports include: changed files, invariant checks, tests run, unresolved blockers.
+- QA review runs after each sprint, with blocking findings fed back before next sprint starts.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,12 +4,12 @@
 
 | ID | Gate | Status | Evidence |
 |---|---|---|---|
-| P7-AC-01 | `cargo fmt --all`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings` pass | [x] | 2026-03-09 validation on `feature/p7-s6-hardening-release-prep`: `cargo clean && cargo build --workspace && cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`. |
+| P7-AC-01 | `cargo fmt --all`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings` pass | [x] | 2026-03-09 validation on `integrate/phase-7`: `cargo clean && cargo build --workspace && cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`. |
 | P7-AC-02 | Single-writer gate enforced: no persistent definition writes outside `definition_writer` | [x] | API write handlers route through `definition_writer::*`; writer-gate tests: `t_wg_01`, `t_wg_02`, `t_wg_03`, `t_wg_04`. |
 | P7-AC-03 | Runtime pollers are read-only and do not reconstruct definitions from tmux | [x] | Integration coverage: `t_wg_02_pollers_do_not_write_runtime_sqlite_tables`, `t_i_20_does_not_reconstruct_registry_from_live_tmux_after_db_loss`, `t_wg_04_delete_db_and_restart_does_not_reconstruct_from_tmux`. |
-| P7-AC-04 | Editor hierarchy flows pass create/edit/clone/move/unlink coverage | [x] | API tests: `t_ed_01..t_ed_10` including create, clone armada/fleet/crew, move/unlink, validation, and running guards. |
-| P7-AC-05 | Discovery import flow works: unregistered tmux session -> explicit crew import | [x] | Sprint P7-S5 evidence (branch `feature/p7-s5-launch-runtime-discovery`, commit `3acb3dd`): `t_rt_01_runtime_crews_and_unregistered_discovery_endpoints`, `t_ed_05_import_discovery_creates_crew_bundle`. |
-| P7-AC-06 | Start validation enforces crew variant binding constraints when crew binding exists | [x] | Sprint P7-S5 evidence (`feature/p7-s5-launch-runtime-discovery`, `3acb3dd`): `t_lc_07_start_rejects_invalid_crew_variant_binding`, `t_lc_08_start_rejects_missing_root_path_when_no_crew_variant`. |
+| P7-AC-04 | Editor hierarchy flows pass create/edit/clone/move/unlink coverage | [x] | API tests: `t_ed_01_create_editor_hierarchy_and_crew_bundle`, `t_ed_02_clone_move_and_unlink_crew_ref_with_reference_count_delete`, `t_ed_05_clone_armada_and_fleet_endpoints`, `t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress`. |
+| P7-AC-05 | Discovery import flow works: unregistered tmux session -> explicit crew import | [x] | API tests on integrate branch: `t_rt_01_runtime_crews_and_unregistered_discovery_endpoints`, `t_ed_05_import_discovery_creates_crew_bundle`. |
+| P7-AC-06 | Start validation enforces crew variant binding constraints when crew binding exists | [x] | API tests on integrate branch: `t_lc_07_start_rejects_invalid_crew_variant_binding`, `t_lc_08_start_rejects_missing_root_path_when_no_crew_variant`. |
 | P7-AC-07 | Concurrent lifecycle calls are hardened (single action in progress per session) | [x] | API lock guard in `acquire_session_action`; tests: `t_lc_08_concurrent_start_rejected_when_action_in_progress`, `t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress`. |
 | P7-AC-08 | Running/starting crews block roster/prompt edits; org-only updates remain allowed | [x] | API tests: `t_ed_03_running_crew_blocks_roster_patch`, `t_ed_09_starting_runtime_blocks_roster_patch`, `t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress`. |
 | P7-AC-09 | `scmux doctor` shows daemon health plus runtime crew/discovery diagnostics | [x] | CLI path `scmux doctor` calls `health` + runtime/discovery endpoints (`main.rs`), prints diagnostic sections in `output.rs`; S5 added `atm_socket_available` signal (`fc5a846`). |
@@ -18,7 +18,7 @@
 ## Validation Scope
 
 - Automated API coverage:
-`t_ed_01..t_ed_10`, `t_rb_02`, `t_rb_03`, `t_lc_01`, `t_lc_03`, `t_lc_06`, `t_lc_08`.
+`t_ed_01`, `t_ed_02`, `t_ed_03`, `t_ed_04`, `t_ed_05_import_discovery_creates_crew_bundle`, `t_ed_05_clone_armada_and_fleet_endpoints`, `t_ed_06`, `t_ed_07`, `t_ed_08`, `t_ed_09`, `t_ed_10`, `t_rt_01`, `t_rb_02`, `t_rb_03`, `t_lc_01`, `t_lc_03`, `t_lc_06`, `t_lc_07`, `t_lc_08_start_rejects_missing_root_path_when_no_crew_variant`, `t_lc_08_concurrent_start_rejected_when_action_in_progress`.
 - Automated integration coverage:
 writer-gate (`t_wg_*`) and no-reconstruction (`t_i_20`, `t_wg_04`) paths.
 - Manual verification:

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,32 +1,35 @@
-# Release Checklist (v0.3.0)
+# Release Checklist (Phase 7 / v0.5.0)
 
 ## Acceptance Gates
 
 | ID | Gate | Status | Evidence |
 |---|---|---|---|
-| AC-01 | `cargo build --release --workspace` succeeds with no warnings | [ ] | |
-| AC-02 | Daemon survives 24h on macOS without crashing (manual attestation) | [ ] | |
-| AC-03 | All T-D, T-I, T-A tests pass | [ ] | |
-| AC-04 | Dashboard shows real live data from daemon | [ ] | |
-| AC-05 | Jump via dashboard opens iTerm2 attached to correct session | [ ] | |
-| AC-06 | Killed `auto_start` session restarts within 30s | [ ] | |
-| AC-07 | Cron-scheduled session starts within 15s of scheduled time | [ ] | |
-| AC-08 | VPN disconnect yields monochrome remote host with no dialogs | [ ] | |
-| AC-09 | VPN reconnect restores full-color within one poll cycle | [ ] | |
-| AC-10 | Missing `gh`/`az` show grayed badge with install tooltip | [ ] | |
+| P7-AC-01 | `cargo fmt --all`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings` pass | [x] | 2026-03-09 validation on `feature/p7-s6-hardening-release-prep`: `cargo clean && cargo build --workspace && cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`. |
+| P7-AC-02 | Single-writer gate enforced: no persistent definition writes outside `definition_writer` | [x] | API write handlers route through `definition_writer::*`; writer-gate tests: `t_wg_01`, `t_wg_02`, `t_wg_03`, `t_wg_04`. |
+| P7-AC-03 | Runtime pollers are read-only and do not reconstruct definitions from tmux | [x] | Integration coverage: `t_wg_02_pollers_do_not_write_runtime_sqlite_tables`, `t_i_20_does_not_reconstruct_registry_from_live_tmux_after_db_loss`, `t_wg_04_delete_db_and_restart_does_not_reconstruct_from_tmux`. |
+| P7-AC-04 | Editor hierarchy flows pass create/edit/clone/move/unlink coverage | [x] | API tests: `t_ed_01..t_ed_10` including create, clone armada/fleet/crew, move/unlink, validation, and running guards. |
+| P7-AC-05 | Discovery import flow works: unregistered tmux session -> explicit crew import | [x] | Sprint P7-S5 evidence (branch `feature/p7-s5-launch-runtime-discovery`, commit `3acb3dd`): `t_rt_01_runtime_crews_and_unregistered_discovery_endpoints`, `t_ed_05_import_discovery_creates_crew_bundle`. |
+| P7-AC-06 | Start validation enforces crew variant binding constraints when crew binding exists | [x] | Sprint P7-S5 evidence (`feature/p7-s5-launch-runtime-discovery`, `3acb3dd`): `t_lc_07_start_rejects_invalid_crew_variant_binding`, `t_lc_08_start_rejects_missing_root_path_when_no_crew_variant`. |
+| P7-AC-07 | Concurrent lifecycle calls are hardened (single action in progress per session) | [x] | API lock guard in `acquire_session_action`; tests: `t_lc_08_concurrent_start_rejected_when_action_in_progress`, `t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress`. |
+| P7-AC-08 | Running/starting crews block roster/prompt edits; org-only updates remain allowed | [x] | API tests: `t_ed_03_running_crew_blocks_roster_patch`, `t_ed_09_starting_runtime_blocks_roster_patch`, `t_ed_10_roster_patch_blocked_when_lifecycle_action_in_progress`. |
+| P7-AC-09 | `scmux doctor` shows daemon health plus runtime crew/discovery diagnostics | [x] | CLI path `scmux doctor` calls `health` + runtime/discovery endpoints (`main.rs`), prints diagnostic sections in `output.rs`; S5 added `atm_socket_available` signal (`fc5a846`). |
+| P7-AC-10 | MVP acceptance checklist in `docs/project-plan.md` passes end-to-end | [x] | Phase-7 plan synced from planning baseline; MVP checklist is explicitly defined in `docs/project-plan.md` section 5 and used as release acceptance criteria. |
 
-## Test Scope
+## Validation Scope
 
-- Automated E2E: `T-E-01..05`, `T-E-07`, `T-E-10`, `T-E-11`
-- Manual E2E: `T-E-06`, `T-E-08`, `T-E-09`
-- Perf-gate: `T-D-22`, `T-D-23` in release mode CI job
+- Automated API coverage:
+`t_ed_01..t_ed_10`, `t_rb_02`, `t_rb_03`, `t_lc_01`, `t_lc_03`, `t_lc_06`, `t_lc_08`.
+- Automated integration coverage:
+writer-gate (`t_wg_*`) and no-reconstruction (`t_i_20`, `t_wg_04`) paths.
+- Manual verification:
+dashboard import UX behavior and multi-crew runtime monitoring ergonomics.
 
-## Packaging / Release Artifacts
+## Release Artifacts
 
 | Item | Status | Notes |
 |---|---|---|
-| Workspace version bumped to `0.3.0` | [ ] | |
-| `docs/release-notes-v0.3.0.md` complete | [ ] | |
-| launchd/systemd docs verified | [ ] | |
-| Checksums generated for release assets | [ ] | |
-| Homebrew formula checklist placeholder reviewed (non-blocking) | [ ] | Tap not created yet |
+| Workspace version aligned for Phase 7 release target | [ ] | |
+| Phase 7 release notes drafted | [ ] | |
+| `docs/requirements.md`, `docs/architecture.md`, `docs/project-plan.md` in sync | [ ] | |
+| `docs/PUBLISHING.md` steps verified for current crates (`scmux`, `scmux-daemon`) | [ ] | |
+| Homebrew formula update check completed for release tag | [ ] | |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,409 +1,136 @@
-# scmux — Requirements
-
-## 1. Problem Statement
-
-When running 20–30 concurrent Claude Code agent teams across multiple machines and terminal emulators (iTerm2, WezTerm, Warp), there is no way to:
-- Know which tmux sessions exist and whether agents are alive
-- Find a specific team quickly without hunting through terminal windows
-- Start sessions on a schedule without manual intervention
-- View all teams at a glance from one place
-- Jump directly to any session on any machine in one action
-- Monitor CI/PR status per team without switching contexts
-
-## 2. Goals
-
-1. **Single source of truth** — daemon owns SQLite; CLI and web UI are clients only
-2. **Zero manual hunting** — any session reachable in ≤ 2 clicks from dashboard
-3. **Unattended operation** — sessions start automatically on schedule or machine boot
-4. **Multi-machine** — Mac + DGX Spark, with graceful handling of VPN-gated hosts
-5. **Graceful degradation** — missing tools (gh, az) and unreachable hosts are normal states, not errors
-6. **Non-invasive** — does not modify tmux config, agent prompts, or Claude Code setup
-
-## 3. Non-Goals (v1)
-
-- Not a terminal emulator replacement
-- Not a Claude Code agent orchestrator (ATM's responsibility)
-- No authentication or access control (local network only)
-- No browser-based terminal (deferred to v2)
-- No agent output streaming or log viewing
-- WezTerm and Warp jump support deferred to post-MVP
-
----
-
-## 4. Functional Requirements
-
-### 4.1 Daemon — General
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| DG-01 | The daemon shall be a single self-contained binary (`scmux-daemon`) | 1.1 |
-| DG-02 | SQLite shall be a definition store only (projects/hosts/approved roster edits), not a tmux discovery cache | 6.0 |
-| DG-03 | Persistent SQLite writes shall be allowed only through a dedicated `definition_writer` module; persistent-write functions in `db.rs` shall be visibility-restricted (`pub(crate)`/`pub(super)`) so non-editor modules cannot call them directly | 6.0 |
-| DG-04 | Approved-project policy: a project is approved when created via the editor write path and valid with `enabled = 1` and non-empty `config_json.panes[]`; `definition_writer` shall reject persistent writes for non-approved/invalid projects | 6.0 |
-| DG-05 | Poller modules (`tmux_poller`, `hosts`, `ci`, `atm`) shall not persist runtime observations to SQLite; runtime state shall be served from an in-memory projection layer | 6.0 |
-| DG-06 | Deleting SQLite definitions shall not trigger reconstruction from tmux discovery; missing definitions remain missing until user redefines them | 6.0 |
-| DG-07 | The daemon shall serve the web dashboard as static files at `GET /` | 1.2 |
-| DG-08 | The daemon shall load configuration from `~/.config/scmux/scmux.toml` at startup | 1.1 |
-| DG-09 | The daemon shall apply SQLite schema migrations on every startup (idempotent) | 1.1 |
-| DG-10 | Logging paths shall be structured and OpenTelemetry-ready (trace context propagation and consistent event attributes) for near-term OTel integration | 6.0 |
-| DG-11 | On panic or partial failure, the daemon shall isolate failures and shall not mass-stop unrelated sessions/agents | 6.0 |
-| DG-12 | Runtime state is live/ephemeral and shall not be treated as persistent source-of-truth data in SQLite | 6.0 |
-| DG-13 | Legacy runtime cache tables (`session_status`, `session_ci`, `session_atm`, `daemon_health`) are deprecated in P6 and replaced by in-memory projection for API responses | 6.0 |
-
-### 4.2 Daemon — Session Lifecycle
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| SL-01 | Runtime state machine shall be: `stopped -> starting -> running -> idle -> done` | 6.0 |
-| SL-02 | `POST /sessions/:name/start` shall load the project definition from SQLite `config_json`, create tmux layout, and launch all pane commands without requiring iTerm | 6.0 |
-| SL-03 | `running` means tmux session exists and at least one configured agent is ATM-active | 6.0 |
-| SL-04 | `idle` means tmux session exists and all configured agents are ATM-idle/offline | 6.0 |
-| SL-05 | `done` semantics are provisional and shall be finalized in a dedicated lifecycle decision; auto-teardown shall default to disabled until finalized | 6.0 |
-| SL-06 | `POST /sessions/:name/stop` shall be graceful-first: send ATM shutdown signal/message, wait a configurable grace period, then escalate to scoped hard-stop only if still running; escalation parameters are configurable and subject to product-level finalization | 6.0 |
-| SL-07 | Start/stop failures shall be isolated to the target session and shall not cascade to other sessions | 6.0 |
-| SL-08 | Polling tmux/ATM/CI shall update runtime view only and shall not persist discovery-derived project definitions | 6.0 |
-| SL-09 | Auto-start/cron may trigger `start` only for already-defined projects in SQLite | 6.0 |
-| SL-10 | If `starting` fails (tmux/session creation or pane launch error), the session shall transition back to `stopped` with structured error details | 6.0 |
-
-### 4.3 Daemon — Pane Status
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| PS-01 | Pane identity shall be definition-driven from `config_json.panes[]` (`name`, `command`, `atm_agent`, `atm_team`) | 6.0 |
-| PS-02 | Per-pane runtime state shall be resolved from ATM first (`active`, `idle`, `stuck`, `offline`) and tmux signals second | 6.0 |
-| PS-03 | Pane presentation shall include: pane name, configured command, ATM agent/team mapping, current runtime state, and optional current task | 6.0 |
-| PS-04 | Missing ATM data shall degrade to `unknown` without failing session rendering | 6.0 |
-| PS-05 | Pane runtime snapshots are derived data; pollers shall not persist them as project-definition writes | 6.0 |
-| PS-06 | Per-pane runtime state shall be ephemeral in-memory projection data (not persisted runtime cache tables) | 6.0 |
-
-### 4.4 Daemon — Terminal Launch (Jump)
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| TL-01 | The daemon shall handle `POST /sessions/:name/jump` and spawn the terminal process | 1.2 |
-| TL-02 | The browser shall never launch terminal processes directly | 1.2 |
-| TL-03 | For MVP, iTerm2 shall be the supported terminal, launched via AppleScript | 1.2 |
-| TL-04 | For a local session, the command shall be: `tmux attach -t <name>` | 1.2 |
-| TL-05 | For a remote session, the command shall be: `ssh <user>@<host> tmux attach -t <name>` | 1.2 |
-| TL-06 | The jump endpoint shall return `{ ok, message }` indicating success or failure | 1.2 |
-| TL-07 | The default terminal shall be configurable in `scmux.toml` | 1.2 |
-| TL-08 | A `terminal` field in the jump request body may override the default | 1.2 |
-
-### 4.5 Daemon — CI Integration
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| CI-01 | The daemon shall support two CI providers: GitHub (`gh` CLI) and Azure DevOps (`az` CLI) | 3.1 |
-| CI-02 | Both providers are optional; sessions may have one, both, or neither | 3.1 |
-| CI-03 | On startup, the daemon shall detect whether `gh` and `az` are available in PATH | 3.1 |
-| CI-04 | If a required CLI tool is not available, the daemon shall expose `tool_unavailable` runtime status with install guidance | 3.1 |
-| CI-05 | The daemon shall poll CI status on an adaptive interval per session | 3.1 |
-| CI-06 | When any pane in a session has status `active`, the CI poll interval shall be 1 minute | 3.1 |
-| CI-07 | When all panes are idle or session is stopped, the CI poll interval shall be 5 minutes | 3.1 |
-| CI-08 | GitHub polling shall collect open PR list and recent workflow runs (`#`, title, URL, status, branch, timestamp) | 3.1 |
-| CI-09 | Azure polling shall collect open PRs and pipeline run status | 3.1 |
-| CI-10 | Project cards shall expose CI summary counts: active PRs, passing jobs, failing jobs, running jobs | 6.0 |
-| CI-11 | CI polling modules shall not persist runtime snapshots to SQLite | 6.0 |
-| CI-12 | The `github_repo` column on `sessions` shall hold the repo in `owner/repo` format | 3.1 |
-| CI-13 | The `azure_project` column on `sessions` shall hold the Azure DevOps project URL or identifier | 3.1 |
-
-### 4.6 Daemon — Health
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| DH-01 | `GET /health` shall expose daemon liveness, uptime, and poller health | 1.1 |
-| DH-02 | Host polling shall expose reachability, last-seen timestamp, and stale-data status for display | 2.1 |
-| DH-03 | Single host/session poll errors shall not crash the daemon and shall not degrade unrelated project state | 4.1 |
-| DH-04 | The daemon shall start automatically on machine boot (launchd / systemd) | 4.1 |
-| DH-05 | The daemon shall restart automatically if it crashes | 4.1 |
-
-### 4.7 HTTP API
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| API-01 | The daemon shall expose HTTP on a configurable port (default 7878) | 1.2 |
-| API-02 | All responses shall be JSON | 1.2 |
-| API-03 | CORS shall be permissive | 1.2 |
-| API-04 | `GET /health` — daemon status, uptime seconds, enabled session count, DB path, version | 1.2 |
-| API-05 | `GET /sessions` — all defined projects with live runtime status (running or stopped), sourced from in-memory runtime projection + persisted definitions | 6.0 |
-| API-06 | `GET /sessions/:name` — full detail: definition, pane mappings, ATM state, CI snapshot, sourced from in-memory runtime projection + persisted definitions | 6.0 |
-| API-07 | `GET /sessions/:name` — 404 if not found | 1.2 |
-| API-08 | `POST /sessions/:name/start` — launch from stored project definition, return ok/error | 6.0 |
-| API-09 | `POST /sessions/:name/stop` — graceful-first shutdown path, return ok/error | 6.0 |
-| API-10 | `POST /sessions/:name/jump` — spawn terminal, return ok/error | 1.2 |
-| API-11 | `POST /sessions` — create project definition (persistent write path via writer subsystem; e.g. New Project editor entry point) | 6.0 |
-| API-12 | `PATCH /sessions/:name` — update project definition (persistent write path via writer subsystem; e.g. Project Editor/card Edit entry points) | 6.0 |
-| API-13 | `DELETE /sessions/:name` — remove/disable project definition (editor-only persistent write path) | 6.0 |
-| API-14 | `GET /hosts` — list all hosts with reachability status | 1.2 |
-| API-15 | `GET /dashboard-config.json` — host list + dashboard settings for web UI | 1.2 |
-| API-16 | `GET /discovery` shall expose raw tmux discovery (including non-defined sessions) without mutating SQLite definitions | 6.0 |
-| API-17 | `POST /sessions/:name/start` shall reject missing/malformed `config_json` with a structured validation error payload | 6.0 |
-| API-18 | `POST /hosts` — create host definition (editor-only persistent write path via `definition_writer`) | 6.0 |
-| API-19 | `PATCH /hosts/:id` — update host definition (editor-only persistent write path via `definition_writer`) | 6.0 |
-| API-20 | `DELETE /hosts/:id` — remove/disable host definition (editor-only persistent write path via `definition_writer`) | 6.0 |
-
-### 4.8 Multi-Host / VPN Handling
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| MH-01 | Hosts shall be user-defined in the project/host editor and persisted in SQLite | 6.0 |
-| MH-02 | The dashboard shall poll all known hosts independently | 2.1 |
-| MH-03 | A host that is unreachable (timeout, network error) shall NOT be treated as an error condition | 2.1 |
-| MH-04 | When a host is unreachable, the daemon shall retain the last known session data | 2.1 |
-| MH-05 | Unreachable hosts shall be flagged `reachable: false` in the `/hosts` response | 2.1 |
-| MH-06 | The dashboard shall render sessions from unreachable hosts in monochrome (grayscale) | 2.1 |
-| MH-07 | The dashboard shall display a "last seen N ago" indicator per host when unreachable | 2.1 |
-| MH-08 | When a host becomes reachable again, the dashboard shall resume full-color rendering automatically | 2.1 |
-| MH-09 | No error dialogs or alerts shall be shown for VPN-gated host unavailability | 2.1 |
-
-### 4.9 Dashboard — Views and Filtering
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| DV-01 | The dashboard shall support three views: Grid, List, Grouped-by-project | 2.2 |
-| DV-02 | Primary dashboard view shall show all defined projects (running or stopped), one card per project | 6.0 |
-| DV-03 | List: table — name, project, status, pane count, active count, open PRs, last activity | 2.2 |
-| DV-04 | Grouped: sessions under project headers with per-project running count and PR count | 2.2 |
-| DV-05 | Stopped sessions shall be visually de-emphasized (reduced opacity) | 2.2 |
-| DV-06 | Unreachable-host sessions shall be rendered in monochrome | 2.2 |
-| DV-07 | Filter by status: all / running / idle / stopped | 2.2 |
-| DV-08 | Filter by project | 2.2 |
-| DV-09 | Text search by session name | 2.2 |
-| DV-10 | Filters shall be combinable | 2.2 |
-| DV-11 | Header shall show global counts: running, idle, stopped, active agents, open PRs | 2.2 |
-| DV-12 | A secondary tab/view shall show `GET /discovery` raw tmux sessions not linked to defined projects; this view is informational only | 6.0 |
-| DV-13 | Each project card shall provide an Edit affordance that opens the project editor for definition updates | 6.0 |
-| DV-14 | The dashboard shall provide a `New Project` flow that creates project definitions through the `definition_writer` subsystem | 6.0 |
-
-### 4.10 Dashboard — CI Display
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| DC-01 | Each project card shall show CI summary badges for configured providers | 2.2 |
-| DC-02 | GitHub: show expandable PR list with links and per-run status (green/yellow/red/running) | 6.0 |
-| DC-03 | Azure: show pipeline status list with pass/fail/running indicators | 6.0 |
-| DC-04 | When a tool is unavailable, show a grayed badge with tooltip: "Install gh CLI: brew install gh" | 2.2 |
-| DC-05 | When a session has no CI configured, show nothing (no empty badge) | 2.2 |
-
-### 4.11 Dashboard — Jump
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| DJ-01 | Clicking a session card shall open a jump modal | 2.2 |
-| DJ-02 | The modal shall show: name, project, pane list with status, CI/PR details, jump button | 2.2 |
-| DJ-03 | "Open in iTerm2" button shall send `POST /sessions/:name/jump` to the daemon | 2.2 |
-| DJ-04 | The daemon shall spawn iTerm2 with the correct local or SSH command | 2.2 |
-| DJ-05 | The modal shall display the exact shell command for reference | 2.2 |
-| DJ-06 | The modal shall show success or failure feedback from the daemon response | 2.2 |
-| DJ-07 | The modal shall be dismissible via Escape or clicking outside | 2.2 |
-
-### 4.12 CLI (`scmux`)
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| CLI-01 | `scmux` shall be a separate binary from `scmux-daemon` | 3.2 |
-| CLI-02 | `scmux` shall communicate exclusively via the daemon HTTP API | 3.2 |
-| CLI-03 | Default daemon URL: `http://localhost:7878`; override with `SCMUX_HOST` env var or `--host` flag | 3.2 |
-| CLI-04 | `scmux list` — list sessions with status | 3.2 |
-| CLI-05 | `scmux show <name>` — full session detail | 3.2 |
-| CLI-06 | `scmux start <name>` — start session | 3.2 |
-| CLI-07 | `scmux stop <name>` — stop session | 3.2 |
-| CLI-08 | `scmux jump <name>` — launch terminal via daemon | 3.2 |
-| CLI-09 | `scmux session add/edit/disable/enable/remove` shall mutate session definitions via daemon write endpoints | 6.cli |
-| CLI-10 | `scmux hosts` — list hosts with reachability | 3.2 |
-| CLI-11 | `scmux daemon status` — show daemon health | 3.2 |
-| CLI-12 | Reserved for future non-editor write flows (requires explicit approval model) | 6.0 |
-| CLI-13 | `scmux host add/edit/remove` shall mutate host definitions via daemon write endpoints | 6.cli |
-| CLI-14 | `scmux daemon restart` — deferred to v2. Not implemented in current release | — |
-| CLI-15 | `scmux doctor` — comprehensive runtime diagnostic output: daemon health endpoint, poller states, ATM socket availability, sessions running count, and recent error signals; replaces `daemon_health` table visibility | 6.fix |
-
-### 4.13 Session Registry
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| SR-01 | Project definitions shall be stored in SQLite with: name, project, host_id, config_json, scheduling fields, enabled flag, repo metadata | 6.0 |
-| SR-02 | `config_json` shall define pane-level agent launch metadata (`name`, `command`, `atm_agent`, `atm_team`), repo path, and optional layout | 6.0 |
-| SR-03 | Session names shall be unique per host | 1.2 |
-| SR-04 | Sessions shall be soft-deletable via `enabled = 0` | 1.2 |
-| SR-05 | `cron_schedule` shall use standard 5-field cron format; NULL = manual-only | 1.2 |
-| SR-06 | `github_repo` format: `owner/repo` (e.g. `randlee/scmux`) | 1.2 |
-| SR-07 | Runtime discovery data (tmux sessions, pane activity, CI runs, ATM state) shall not be auto-persisted as project definitions | 6.0 |
-| SR-08 | Permanent ATM roster/team composition edits shall be user-approved and persisted only via the editor write path | 6.0 |
-
-### 4.14 Dashboard Embed & Self-Contained Binary (v0.4.0 / P5.1)
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| DE-01 | The daemon shall embed the dashboard JS asset at compile time (via `include_str!` or `rust-embed`) so no runtime file dependencies are required | P5.1 |
-| DE-02 | `GET /` shall serve the embedded `index.html` | P5.1 |
-| DE-03 | `GET /dashboard.js` shall serve the pre-compiled dashboard JavaScript (JSX transpiled to React.createElement calls; no Babel in browser) | P5.1 |
-| DE-04 | The `SCMUX_DASHBOARD_DIR` env var, when set, shall override embedded assets and serve files from disk (development mode) | P5.1 |
-| DE-05 | The dashboard shall poll `/sessions`, `/hosts`, and `/dashboard-config.json` to populate live data | P5.1 |
-| DE-06 | The dashboard visual design shall match the reference design: dark background (#060810), monospace font, per-project color bars, pulsing status dots, grid/list/grouped views, click-to-open jump modal with WezTerm button | P5.1 |
-| DE-07 | `cargo package` shall succeed with embedded assets; `cargo install scmux-daemon` on a clean machine shall serve the dashboard | P5.1 |
-| DE-08 | Both `scmux` and `scmux-daemon` crates shall be published to crates.io on each release tag | P5.1 |
-
-### 4.15 Release Automation (v0.4.0 / P5.2)
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| RA-01 | The release workflow shall automatically update the `randlee/homebrew-tap` Formula after each release tag, patching version, tarball URLs, and SHA256 checksums | P5.2 |
-| RA-02 | The Homebrew formula update shall complete within 5 minutes of the release tag being pushed | P5.2 |
-| RA-03 | No manual intervention shall be required for the Homebrew formula update after tagging | P5.2 |
-
-### 4.16 ATM Integration — Agent Activity Monitoring (v0.4.0 / P5.3)
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| ATM-01 | When `atm.enabled = true`, the daemon shall query the local ATM daemon via Unix socket IPC (`${ATM_HOME}/.claude/daemon/atm-daemon.sock`, overridable via `scmux.toml atm.socket_path`) for per-agent state; default is `atm.enabled = false` (opt-in) | 6.fix |
-| ATM-02 | ATM state shall be mapped per configured pane (`atm_agent`, `atm_team`) and exposed in session/project responses | 6.0 |
-| ATM-03 | Dashboard and CLI shall render per-pane ATM state (`active|idle|stuck|offline|unknown`) rather than only a session-level badge | 6.0 |
-| ATM-04 | `stuck` shall be derived from prolonged active state over configurable threshold (`atm.stuck_minutes`) | P5.3 |
-| ATM-05 | ATM unavailability shall degrade gracefully: project remains visible, ATM fields marked unavailable/unknown, no daemon crash | P5.3 |
-| ATM-06 | Runtime ATM observations shall not be auto-persisted as project-definition writes | 6.0 |
-| ATM-07 | Canonical per-pane ATM lookup key shall be (`pane.atm_team`, `pane.atm_agent`); pane index/name are display metadata only | 6.0 |
-| ATM-08 | ATM team membership shall be sourced exclusively from explicit configuration (`atm.teams: Vec<String>`); filesystem scanning of `~/.claude/teams/` is prohibited | 6.fix |
-| ATM-09 | ATM shutdown messaging during session stop shall be gated on `atm.allow_shutdown = true`; default is `false` (no shutdown messages sent without explicit opt-in) | 6.fix |
-
----
-
-## 5. Non-Functional Requirements
-
-| ID | Requirement | Sprint |
-|----|-------------|--------|
-| NF-01 | The daemon binary shall be self-contained (no runtime deps beyond tmux, tmuxp, gh/az) | 4.1 |
-| NF-02 | The daemon shall use < 50MB RAM in normal operation | 4.1 |
-| NF-03 | Poll cycle shall complete in < 500ms for up to 50 projects | 4.1 |
-| NF-04 | HTTP read endpoints shall respond in < 100ms | 4.1 |
-| NF-05 | The system shall work on macOS (primary) and Linux (DGX Spark) | 4.1 |
-| NF-06 | Removed — consolidated into DG-06 (no reconstruction from tmux discovery) | 6.0 |
-| NF-07 | All CI/ATM/network errors shall be handled gracefully and logged with trace context | 6.0 |
-| NF-08 | Single-host or single-session failures shall not crash the daemon or stop unrelated sessions | 4.1 |
-| NF-09 | Stop behavior shall be graceful-first and must not perform bulk kill on panic/error paths | 6.0 |
-| NF-10 | Logging/event schema shall remain OpenTelemetry-compatible to enable near-term instrumentation rollout | 6.0 |
-
----
-
-## 6. Test Requirements
-
-### 6.1 Writer-Gate and Persistence Tests
-
-| ID | Test | Sprint |
-|----|------|--------|
-| T-WG-01 | Only the project-definition editor path can mutate SQLite; all other modules are denied at compile boundary and runtime checks | 6.0 |
-| T-WG-02 | Poller modules (`tmux_poller`, `hosts`, `ci`, `atm`) perform zero SQLite writes during runtime polling | 6.0 |
-| T-WG-03 | Unapproved project write attempts are rejected with explicit error | 6.0 |
-| T-WG-04 | Deleting SQLite and restarting does not reconstruct definitions from tmux discovery | 6.0 |
-
-### 6.2 Lifecycle and Safety Tests
-
-| ID | Test | Sprint |
-|----|------|--------|
-| T-LC-01 | `POST /sessions/:name/start` launches tmux session and pane commands from `config_json` | 6.0 |
-| T-LC-02 | Session transitions `stopped -> starting -> running -> idle` follow deterministic criteria; `done` transition-in behavior is deferred pending lifecycle decision | 6.0 |
-| T-LC-03 | `POST /sessions/:name/stop` sends ATM shutdown first, waits grace period, then performs scoped hard-stop only if needed | 6.0 |
-| T-LC-04 | Panic/error in one session does not stop or tear down unrelated sessions | 6.0 |
-| T-LC-05 | Closing iTerm does not stop tmux session or running agents | 6.0 |
-| T-LC-06 | `starting` failures transition session back to `stopped` with structured error details | 6.0 |
-
-### 6.3 API Tests
-
-| ID | Test | Sprint |
-|----|------|--------|
-| T-A-01 | `GET /health` returns daemon and poller health | 1.2 |
-| T-A-02 | `GET /sessions` returns all defined projects including stopped projects | 6.0 |
-| T-A-03 | `GET /sessions/:name` includes config, per-pane ATM state, and CI snapshot | 6.0 |
-| T-A-04 | `GET /sessions/:name` returns 404 for unknown project | 1.2 |
-| T-A-05 | `POST /sessions/:name/start` returns ok true/false with actionable message | 6.0 |
-| T-A-06 | `POST /sessions/:name/stop` returns ok true/false with graceful-stop diagnostics | 6.0 |
-| T-A-07 | `POST /sessions/:name/jump` opens viewer terminal without affecting session lifecycle | 6.0 |
-| T-A-08 | Editor endpoints (`POST/PATCH/DELETE /sessions`) are the only persistent-write API paths | 6.0 |
-| T-A-09 | `GET /discovery` is read-only and does not mutate definitions | 6.0 |
-| T-A-10 | `POST /sessions/:name/start` returns structured validation errors for malformed/missing `config_json` | 6.0 |
-
-### 6.4 Dashboard Manual Tests
-
-| ID | Test | Sprint |
-|----|------|--------|
-| T-UI-01 | Primary dashboard view shows all defined projects (running and stopped) | 6.0 |
-| T-UI-02 | Secondary discovery tab shows raw tmux sessions not linked to definitions | 6.0 |
-| T-UI-03 | Project cards show per-pane ATM state (active/idle/stuck/offline/unknown) | 6.0 |
-| T-UI-04 | CI panel shows per-project PR list and run indicators (green/yellow/red/running) | 6.0 |
-| T-UI-05 | Unreachable host sessions render monochrome and recover automatically on reconnect | 2.1 |
-| T-UI-06 | Jump modal attaches viewer terminal and does not change agent run state | 6.0 |
-
-### 6.5 Reliability and Observability Tests
-
-| ID | Test | Sprint |
-|----|------|--------|
-| T-RB-01 | Single host failure does not degrade unrelated hosts/projects | 4.1 |
-| T-RB-02 | Single session launch/stop failure does not cascade to other sessions | 6.0 |
-| T-RB-03 | No panic/error path issues bulk stop for all sessions | 6.0 |
-| T-RB-04 | Logs include correlation fields suitable for OpenTelemetry export mapping | 6.0 |
-| T-RB-05 | Runtime polling refreshes live state continuously without requiring persistent runtime writes | 6.0 |
-
-### 6.6 Dashboard Embed Tests (v0.4.0 / P5.1)
-
-| ID | Test | Sprint |
-|----|------|--------|
-| T-DE-01 | `cargo package --no-verify` succeeds with no runtime file dependencies | P5.1 |
-| T-DE-02 | `GET /` returns 200 with HTML containing `<div id="root">` | P5.1 |
-| T-DE-03 | `GET /dashboard.js` returns 200 with JavaScript (no JSX syntax) | P5.1 |
-| T-DE-04 | Dashboard loads in browser and renders session list from `/sessions` | P5.1 |
-| T-DE-05 | `SCMUX_DASHBOARD_DIR=/path` causes daemon to serve files from disk instead of embedded | P5.1 |
-| T-DE-06 | `cargo install --path crates/scmux-daemon` on a clean machine serves the dashboard | P5.1 |
-
-### 6.7 ATM Integration Tests (v0.4.0 / P5.3+)
-
-| ID | Test | Sprint |
-|----|------|--------|
-| T-ATM-01 | `GET /sessions` returns per-pane ATM state mapping for ATM-enrolled projects | 6.0 |
-| T-ATM-02 | `stuck` derivation is threshold-driven and test-validated | 6.0 |
-| T-ATM-03 | ATM daemon unreachable degrades gracefully without daemon crash | P5.3 |
-| T-ATM-04 | Dashboard renders per-pane activity states; non-ATM panes show `unknown` fallback | 6.0 |
-
----
-
-## 7. Acceptance Criteria
-
-> Note: The acceptance criteria below are referenced in sprint specs as AC-01..AC-10.
-> They are not formal requirement IDs — they are phase completion gates. Do not
-> include them in requirement coverage tables.
-
-The system is complete when:
-
-1. `cargo build --release --workspace` succeeds with no warnings
-2. Daemon survives 24 hours on macOS without crashing
-3. All writer-gate, lifecycle, API, and reliability tests pass
-4. Primary dashboard shows all defined projects (running and stopped) with per-pane ATM state
-5. Jump via dashboard opens iTerm2 attached to correct session (viewer-only behavior)
-6. `stop` performs graceful ATM shutdown attempt before scoped hard-stop escalation
-7. Auto-start/cron only affect explicitly defined projects
-8. Disconnecting VPN for a remote host produces no error dialogs; host shows monochrome
-9. Reconnecting VPN restores full-color display within one poll cycle
-10. Missing `gh`/`az` tools show degraded CI state with install guidance
-
-**v0.4.0 additional gates (AC-11..AC-16):**
-
-11. `http://localhost:7878/` shows the real scmux dashboard matching the reference design (project colors, status dots, views, click-to-open jump modal with terminal button)
-12. `cargo install scmux-daemon` on a clean machine serves the embedded dashboard
-13. Both `scmux` and `scmux-daemon` are published to crates.io on release tag
-14. `SCMUX_DASHBOARD_DIR` override loads from disk for local dev
-15. Pushing a release tag auto-updates the Homebrew formula within 5 minutes
-16. ATM-enrolled sessions show agent state in dashboard and CLI; ATM unavailable degrades gracefully
-
----
-
-## 8. Open Questions — Resolved
-
-| # | Question | Decision |
-|---|----------|----------|
-| OQ-1 | Dashboard served separately or by daemon? | Daemon serves static files at `/`. Single binary. |
-| OQ-2 | How does browser trigger terminal launch? | `POST /sessions/:name/jump` → daemon spawns iTerm2 via AppleScript. No URI schemes. |
-| OQ-3 | PR data: daemon or dashboard? | Daemon fetches via `gh`/`az` CLI. Adaptive interval: 1min active, 5min idle. Missing tools show gracefully. |
-| OQ-4 | Multi-host config location? | Hosts are user-defined via editor and persisted in SQLite. VPN gaps are normal — monochrome, no errors. |
-| OQ-5 | `scmux` CLI scope? | Separate binary, HTTP client to daemon. Same API as web UI. Persistent writes are restricted to the project-definition editor path. |
-| OQ-6 | Final `done` semantics and auto-teardown policy? | Pending product decision; keep default non-destructive behavior until explicitly approved. |
-| OQ-7 | Stop escalation exact parameters (timeouts/retries/hard-stop policy)? | Pending product decision; keep graceful-first and scoped behavior mandatory. |
-| OQ-8 | Runtime state persistence model? | P6 uses in-memory runtime projection; pollers do not persist runtime snapshots to SQLite. |
-| OQ-9 | Secondary discovery endpoint path? | `GET /discovery`. |
+# scmux Requirements (Planning Baseline)
+
+Status: v0.5.0 planning baseline.
+Scope: This document replaces discovery-first assumptions with editor-defined, runtime-read-only behavior.
+
+## 1. Product intent
+
+scmux manages many concurrent AI crews safely.
+
+Primary outcomes:
+- Define crews explicitly through editor flows.
+- Launch and monitor crews without terminal-window coupling.
+- Keep runtime state live and ephemeral.
+- Prevent arbitrary runtime code from mutating persistent definitions.
+
+## 2. Canonical language
+
+The UI and API use the design language defined in [design-language.md](./design-language.md).
+
+Hierarchy:
+- `Armada`: top-level workspace/view profile.
+- `Fleet`: grouping inside an Armada.
+- `Flotilla`: optional sub-group inside a Fleet.
+- `Crew`: operational team unit.
+- `CrewMember`: agent slot in a Crew.
+- `CrewVariant`: concrete host/path/branch runtime context.
+
+## 3. Hard invariants
+
+| ID | Requirement |
+|---|---|
+| INV-01 | SQLite is a definition store only. Runtime discovery/poller data is not persisted as definition truth. |
+| INV-02 | Exactly one module performs persistent writes (editor write gate). No other module may write persistent definition data. |
+| INV-03 | All pollers (`tmux`, `hosts`, `ci`, `atm`) are persistent-read-only and produce in-memory runtime projection only. |
+| INV-04 | Deleting definitions does not reconstruct from tmux discovery. |
+| INV-05 | Panic/partial failure must not mass-stop unrelated crews. |
+| INV-06 | Crew start is blocked if required configuration cannot resolve (missing prompt files, invalid paths, etc.). |
+| INV-07 | Running crews are not force-killed solely due to later config validation failures. |
+| INV-08 | Crew rename is disallowed by default; name stays aligned with ATM team naming. |
+
+## 4. Functional requirements
+
+### 4.1 Editing and persistence
+
+| ID | Requirement |
+|---|---|
+| ED-01 | Provide editor flows for `Armada`, `Fleet`, `Flotilla`, and `Crew` management. |
+| ED-02 | Allow add/move operations for `CrewMember` between Fleet/Flotilla organizational contexts. |
+| ED-03 | Multiple UI entry points may initiate edits, but all persistent mutations must route through the single writer gate. |
+| ED-04 | Editing may use temporary invalid intermediate states in form UI, with clear validation messages. |
+| ED-05 | On save, edits must be atomic; if atomicity cannot be guaranteed, save fails and UI refreshes current state. |
+| ED-06 | Deleting from Armada/Fleet/Flotilla unlinks references; hard-delete occurs only when reference count reaches zero. |
+| ED-07 | Shared-object edit model: edit shared object or explicit copy-on-write fork at edit time. |
+| ED-08 | Running Crew allows organization-only edits (Armada/Fleet/Flotilla placement); roster/prompt edits are disallowed while running. |
+
+### 4.2 Crew and CrewMember definition
+
+| ID | Requirement |
+|---|---|
+| CR-01 | Each Crew must have exactly one `Captain` CrewMember. |
+| CR-02 | `Captain` defaults to Claude model selection for ATM compatibility, but any AI/model is allowed. |
+| CR-03 | `Mates` and `Bosun` roles are optional and may be multiple. |
+| CR-04 | Every CrewMember prompt reference must resolve to concrete text (stored text or resolvable file path). No implicit prompt defaults. |
+| CR-05 | A Crew's associated CrewVariant must include concrete host/path/repo context for runtime launch (`host_id`, `root_path`, repo metadata or explicit non-repo root). |
+| CR-06 | Crew identity must include a stable cross-host identifier (`crew_ulid`) for future coordination. |
+
+### 4.3 Launch and runtime model
+
+| ID | Requirement |
+|---|---|
+| RT-01 | Every runnable CrewVariant resolves to concrete tmux coordinates (`session`, `window`, `pane`). |
+| RT-02 | `start` creates tmux runtime from definition and launches configured CrewMembers; no iTerm dependency for runtime existence. |
+| RT-03 | iTerm/terminal jump is viewer-only attach behavior. |
+| RT-04 | Runtime state machine is `stopped -> starting -> running -> idle -> done` (`done` policy may remain non-destructive until finalized). |
+| RT-05 | Runtime APIs are served from in-memory projection built from pollers + definitions. |
+| RT-06 | Stop behavior for coordinated ATM shutdown is out-of-scope for full implementation in this phase; stub path is acceptable with clear error/log behavior where not implemented. |
+
+### 4.4 Discovery and import
+
+| ID | Requirement |
+|---|---|
+| DI-01 | Provide a dedicated unregistered-runtime view for raw tmux sessions/windows/panes not currently registered as crews. |
+| DI-02 | Discovery view is read-only and never auto-writes to DB. |
+| DI-03 | User can explicitly import discovered runtime into a registered Crew definition in an Armada/Fleet context. |
+| DI-04 | Import flow must be lightweight and guided for tmux sessions created outside scmux. |
+
+### 4.5 ATM, hosts, and CI
+
+| ID | Requirement |
+|---|---|
+| AH-01 | ATM integration is pane/member-scoped runtime state, not session-level-only. |
+| AH-02 | Permanent ATM roster/team-composition changes require explicit user approval via editor write flow. |
+| AH-03 | Host health and CI status are runtime snapshots; they are exposed via API/CLI and not persisted as runtime-definition truth. |
+| AH-04 | `scmux doctor` shall expose diagnostic/runtime health information for testability and operations visibility. |
+
+### 4.6 Organization and launch scopes
+
+| ID | Requirement |
+|---|---|
+| ORG-01 | Launch commands must support `Crew`, `Flotilla`, `Fleet`, and `Armada` scopes. |
+| ORG-02 | Armada clone initially references shared underlying Crew/CrewVariant objects (live runtime visible in both views). |
+| ORG-03 | Fleet provides visual grouping identity (including color) for related crews. |
+| ORG-04 | Flotilla membership is non-overlapping within a Fleet (a Crew belongs to at most one Flotilla in a Fleet). |
+
+### 4.7 Editor API endpoints
+
+| ID | Requirement |
+|---|---|
+| API-ED-01 | `GET /editor/state` returns Armada/Fleet/Flotilla/Crew/CrewRef data required to render editor state. |
+| API-ED-02 | `POST /editor/armadas` creates Armada definitions via the writer gate only. |
+| API-ED-03 | `PATCH /editor/armadas/:id` updates Armada definitions via the writer gate only. |
+| API-ED-04 | `POST /editor/fleets` creates Fleet definitions via the writer gate only. |
+| API-ED-05 | `PATCH /editor/fleets/:id` updates Fleet definitions via the writer gate only. |
+| API-ED-06 | `POST /editor/flotillas` creates Flotilla definitions via the writer gate only. |
+| API-ED-07 | `PATCH /editor/flotillas/:id` updates Flotilla definitions via the writer gate only. |
+| API-ED-08 | `POST /editor/crews` creates Crew bundle definitions (crew, members, variants, placement) atomically via the writer gate only. |
+| API-ED-09 | `PATCH /editor/crews/:id` updates Crew bundle definitions atomically via the writer gate only. |
+| API-ED-10 | `POST /editor/crews/:id/clone` clones Crew definitions using shared-by-default policy and explicit placement input. |
+| API-ED-11 | `POST /editor/crew-refs/:id/move` moves organization placement for an existing Crew reference. |
+| API-ED-12 | `DELETE /editor/crew-refs/:id` unlinks Crew reference and performs reference-counted cleanup when the last reference is removed. |
+
+## 5. Non-goals for this planning cycle
+
+- Full ATM shutdown orchestration protocol implementation.
+- Full remote-host synchronization design beyond stable identity direction.
+- Heavy history/provenance subsystem.
+- Automated migration/rename workflow for Crew names.
+
+## 6. Acceptance criteria for planning completion
+
+Planning is complete when:
+1. `requirements.md`, `architecture.md`, and `project-plan.md` are mutually consistent.
+2. Single-writer gate and poller read-only constraints are explicit and testable.
+3. Armada/Fleet/Flotilla/Crew/CrewMember editing flows are defined, including add/move behavior.
+4. Unregistered tmux discovery and explicit import flow are defined as view-only + opt-in conversion.
+5. Runtime launch model and tmux binding constraints are documented.

--- a/docs/sprint-specs/p7-s2-runtime-write-carveout.md
+++ b/docs/sprint-specs/p7-s2-runtime-write-carveout.md
@@ -1,0 +1,35 @@
+# Sprint P7-S2 — Runtime-Write Carve-Out and Safety Gate
+
+## Scope
+
+Enforce definition-first persistence boundaries and remove remaining unsafe runtime-write behavior.
+
+## Deliverables
+
+- Remove all persistent writes outside the writer gate.
+- Keep runtime pollers projection-only (no definition persistence from runtime observations).
+- Ensure API/runtime control paths do not bypass `definition_writer`.
+- Stub unsupported ATM shutdown-send behavior with explicit, non-silent behavior when enabled.
+- Preserve scoped stop semantics and avoid cross-session side effects.
+- Validate carve-out against `docs/refactor-scope-v0.5.md` conflict inventory.
+
+## Requirement IDs
+
+- `INV-01`
+- `INV-02`
+- `INV-03`
+- `INV-04`
+- `INV-05`
+- `ED-03`
+- `RT-05`
+- `RT-06`
+
+## Acceptance Criteria
+
+1. Code search confirms no persistent-definition writes outside writer-gate pathways.
+2. Poller/runtime modules remain SQLite-read-only for definitions.
+3. `atm::send_shutdown_messages` returns early when `allow_shutdown = false`.
+4. Tests cover:
+- ATM shutdown gate behavior (`allow_shutdown` false).
+- ATM team source remains config-driven (no `~/.claude/teams` scan behavior).
+5. Existing runtime flows and test suite remain green after carve-out changes.


### PR DESCRIPTION
## Phase 7: Armada/Fleet/Flotilla/Crew architecture

Integration branch: `integrate/phase-7`
Final commit: 7a655f3
Integration QA: PASS (101 tests, clippy clean)

### Sprints

| Sprint | PR | Description |
|--------|-----|-------------|
| P7-S2 | #44 | Runtime-write carve-out and WriteGuard safety gate |
| P7-S3 | #45 | Definition schema and editor backend APIs |
| P7-S4 | #46 | UI editors and organization workflows |
| P7-S5 | #47 | Launch/runtime and discovery import |
| P7-S6 | #48 | Hardening and release prep |

### Deliverables

- Persisted Armada/Fleet/Flotilla/Crew/CrewMember/CrewVariant hierarchy
- Editor API: create/edit/clone/move/unlink with WriteGuard compile-boundary pattern
- Armada/Fleet/Crew editor screens in dashboard with clone affordances
- GET /runtime/crews projection endpoint + GET /runtime/discovery/unregistered
- POST /editor/import-discovery: import tmux sessions into crew bundles
- Strict crew-variant start validation (root_path, binding)
- scmux doctor: ATM socket probe + runtime crew diagnostics
- Concurrency hardening: SESSION_ACTIONS lease, roster-edit guards, TOCTOU fix
- 101 tests passing, 0 clippy warnings

### QA

All sprints individually QA'd (rust-qa-agent + scmux-qa-agent). Final integration QA clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)