### PR TITLE
feat(rmux): TOML-driven tmux session launcher + v0.6.0 cargo fix

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -1,3 +1,34 @@
 [core]
 default_team = "scmux-dev"
 identity = "team-lead"
+
+[plugins.gh_monitor]
+team = "scmux-dev"
+repo = "randlee/scmux"
+notify_target = ["team-lead@scmux-dev"]
+
+# ── rmux: tmux session launcher ──────────────────────────────────────
+[rmux]
+session = "scmux-dev"
+
+[[rmux.windows]]
+name = "agents"
+layout = "even-horizontal"
+
+[[rmux.windows.panes]]
+name = "team-lead"
+model = "sonnet"
+env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "scmux-dev" }
+
+[[rmux.windows.panes]]
+name = "arch-ctm"
+command = "codex --yolo"
+env = { ATM_IDENTITY = "arch-ctm", ATM_TEAM = "scmux-dev" }
+
+[[rmux.windows]]
+name = "monitoring"
+layout = "even-vertical"
+
+[[rmux.windows.panes]]
+name = "logs"
+command = "tail -f /tmp/atm.log"

--- a/.claude/scripts/poll-and-merge-prs.sh
+++ b/.claude/scripts/poll-and-merge-prs.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Poll PR #9 and PR #11 until both green, then merge sequence.
+# Usage: bash poll-and-merge-prs.sh
+
+set -euo pipefail
+
+REPO_DIR="/Users/randlee/Documents/github/scmux"
+MAX_ATTEMPTS=10
+INTERVAL=60
+
+log() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+checks_green() {
+  local pr="$1"
+  local output
+  output=$(gh pr checks "$pr" --repo randlee/scmux 2>&1)
+  echo "$output"
+  # Green = no lines containing 'pending' or 'fail'
+  if echo "$output" | grep -qiE '^\S.*\s+(pending|fail)\s'; then
+    return 1
+  fi
+  return 0
+}
+
+log "Starting poll loop for PR #9 and PR #11 (max $MAX_ATTEMPTS attempts, every ${INTERVAL}s)"
+
+attempt=0
+both_green=false
+
+while [ $attempt -lt $MAX_ATTEMPTS ]; do
+  attempt=$((attempt + 1))
+  log "=== Attempt $attempt/$MAX_ATTEMPTS ==="
+
+  pr9_out=$(gh pr checks 9 --repo randlee/scmux 2>&1)
+  pr11_out=$(gh pr checks 11 --repo randlee/scmux 2>&1)
+
+  log "PR #9 checks:"
+  echo "$pr9_out"
+  log "PR #11 checks:"
+  echo "$pr11_out"
+
+  pr9_pending=$(echo "$pr9_out" | grep -iE '^\S.*\s+(pending|fail)\s' || true)
+  pr11_pending=$(echo "$pr11_out" | grep -iE '^\S.*\s+(pending|fail)\s' || true)
+
+  if [ -z "$pr9_pending" ] && [ -z "$pr11_pending" ]; then
+    log "Both PR #9 and PR #11 are fully green!"
+    both_green=true
+    break
+  else
+    [ -n "$pr9_pending" ] && log "PR #9 still has pending/failed checks."
+    [ -n "$pr11_pending" ] && log "PR #11 still has pending/failed checks."
+  fi
+
+  if [ $attempt -lt $MAX_ATTEMPTS ]; then
+    log "Sleeping ${INTERVAL}s before next poll..."
+    sleep $INTERVAL
+  fi
+done
+
+if [ "$both_green" = false ]; then
+  log "ERROR: PRs #9 and #11 did not go green within $MAX_ATTEMPTS attempts."
+  exit 1
+fi
+
+# --- Merge sequence ---
+
+log "Merging PR #11 (integrate/phase-2 fixes into integrate/phase-3) with squash..."
+gh pr merge 11 --squash --repo randlee/scmux --yes 2>&1
+log "PR #11 merged."
+
+log "Merging PR #9 (S3.2 fixes into integrate/phase-3) with squash..."
+gh pr merge 9 --squash --repo randlee/scmux --yes 2>&1
+log "PR #9 merged."
+
+log "Waiting 30s for CI to re-trigger on PR #8..."
+sleep 30
+
+log "Starting poll loop for PR #8 (max $MAX_ATTEMPTS attempts, every ${INTERVAL}s)"
+
+attempt=0
+pr8_green=false
+
+while [ $attempt -lt $MAX_ATTEMPTS ]; do
+  attempt=$((attempt + 1))
+  log "=== PR #8 Attempt $attempt/$MAX_ATTEMPTS ==="
+
+  pr8_out=$(gh pr checks 8 --repo randlee/scmux 2>&1)
+  log "PR #8 checks:"
+  echo "$pr8_out"
+
+  pr8_pending=$(echo "$pr8_out" | grep -iE '^\S.*\s+(pending|fail)\s' || true)
+
+  if [ -z "$pr8_pending" ]; then
+    log "PR #8 is fully green!"
+    pr8_green=true
+    break
+  else
+    log "PR #8 still has pending/failed checks."
+  fi
+
+  if [ $attempt -lt $MAX_ATTEMPTS ]; then
+    log "Sleeping ${INTERVAL}s before next poll..."
+    sleep $INTERVAL
+  fi
+done
+
+if [ "$pr8_green" = false ]; then
+  log "ERROR: PR #8 did not go green within $MAX_ATTEMPTS attempts after merging #9 and #11."
+  exit 2
+fi
+
+log "Merging PR #8 (integrate/phase-3 into develop) with squash..."
+gh pr merge 8 --squash --repo randlee/scmux --yes 2>&1
+log "PR #8 merged."
+
+log "=== ALL DONE: PRs #9, #11, and #8 successfully merged ==="

--- a/.github/workflows/publish-crates-manual.yml
+++ b/.github/workflows/publish-crates-manual.yml
@@ -1,0 +1,29 @@
+name: Publish Crates (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to publish from (tag, branch, or SHA)'
+        required: true
+        default: 'v0.6.0'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish crates.io packages
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          cargo publish -p scmux-daemon
+          echo "Waiting 60s for crates.io indexing..."
+          sleep 60
+          cargo publish -p scmux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,9 +121,9 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
-          cargo publish -p scmux-daemon --locked
+          cargo publish -p scmux-daemon
           sleep 60
-          cargo publish -p scmux --locked
+          cargo publish -p scmux
 
   update-homebrew:
     needs: [release]

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ target
 # Temporary / scratch files (not committed)
 .tmp/
 .temp/
+.prompts/
 
 # macOS
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,9 +856,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "scmux"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "scmux-daemon"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2356,18 +2356,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/scripts/rmux
+++ b/scripts/rmux
@@ -1,13 +1,171 @@
 #!/usr/bin/env zsh
-# rmux — TOML-driven tmux session launcher
+# rmux — TOML-driven tmux session launcher + runtime agent spawner
 # Reads [rmux] section from .atm.toml (or --config) and .env in CWD,
 # then creates a named tmux session with multiple windows and panes.
 #
 # Install: cp scripts/rmux ~/.local/bin/rmux && chmod +x ~/.local/bin/rmux
 # Usage:   rmux [--config <path>] [--dry-run] [-v] [-h]
 #          rmux launch <pane-name> [--config <path>] [--dry-run] [-v]
+#          rmux codex|claude|sonnet|haiku|opus|gemini <name> [OPTIONS]
 
 setopt ERR_EXIT PIPE_FAIL NO_UNSET
+
+# ── Spawn subcommand ──────────────────────────────────────────────────
+# Detect: first arg is a known agent type and second arg is a name
+typeset -a KNOWN_AGENT_TYPES
+KNOWN_AGENT_TYPES=(codex claude sonnet haiku opus gemini)
+
+if [[ $# -ge 2 && ${KNOWN_AGENT_TYPES[(I)$1]} -gt 0 ]]; then
+  SPAWN_TYPE="$1"
+  SPAWN_NAME="$2"
+  shift 2
+
+  SPAWN_CONFIG=".atm.toml"
+  SPAWN_TEAM=""
+  SPAWN_MODEL=""
+  SPAWN_WINDOW="spare"
+  SPAWN_DRY_RUN=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config)  SPAWN_CONFIG="$2"; shift 2 ;;
+      --team)    SPAWN_TEAM="$2";   shift 2 ;;
+      --model)   SPAWN_MODEL="$2";  shift 2 ;;
+      --window)  SPAWN_WINDOW="$2"; shift 2 ;;
+      --dry-run) SPAWN_DRY_RUN=true; shift ;;
+      *) echo "rmux: unknown spawn option '$1'" >&2; exit 1 ;;
+    esac
+  done
+
+  if [[ ! -f "$SPAWN_CONFIG" ]]; then
+    echo "rmux: config not found: $SPAWN_CONFIG" >&2; exit 1
+  fi
+
+  SPAWN_JSON=$(python3 -c "
+import json, sys
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+with open(sys.argv[1], 'rb') as f:
+    data = tomllib.load(f)
+rmux = data.get('rmux') or {}
+core = data.get('core') or {}
+print(json.dumps({'session': rmux.get('session', 'default'), 'team': core.get('default_team', '')}))
+" "$SPAWN_CONFIG") || exit 1
+
+  SPAWN_SESSION=$(echo "$SPAWN_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['session'])")
+  [[ -z "$SPAWN_TEAM" ]] && SPAWN_TEAM=$(echo "$SPAWN_JSON" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['team'])")
+  [[ -z "$SPAWN_TEAM" && -n "${ATM_TEAM:-}" ]] && SPAWN_TEAM="$ATM_TEAM"
+
+  if [[ -z "$SPAWN_TEAM" ]]; then
+    echo "rmux: cannot determine ATM_TEAM — set [core] default_team in .atm.toml or pass --team" >&2; exit 1
+  fi
+
+  SPAWN_DIR="${SPAWN_CONFIG:h}"
+  [[ "$SPAWN_DIR" == "." ]] && SPAWN_DIR="$(pwd)"
+  SPAWN_ENV_FILE="${SPAWN_DIR}/.env"
+
+  # Resolve model for claude agents
+  case "$SPAWN_TYPE" in
+    codex|gemini) ;;
+    claude|sonnet) [[ -z "$SPAWN_MODEL" ]] && SPAWN_MODEL="sonnet" ;;
+    haiku)         [[ -z "$SPAWN_MODEL" ]] && SPAWN_MODEL="haiku" ;;
+    opus)          [[ -z "$SPAWN_MODEL" ]] && SPAWN_MODEL="opus" ;;
+  esac
+
+  # Read parent session ID from team config
+  PARENT_SESSION_ID=""
+  TEAM_CONFIG="${HOME}/.claude/teams/${SPAWN_TEAM}/config.json"
+  if [[ -f "$TEAM_CONFIG" ]]; then
+    PARENT_SESSION_ID=$(python3 -c "
+import json, sys
+try:
+    d = json.loads(open(sys.argv[1]).read())
+    print(d.get('leadSessionId', ''))
+except Exception:
+    print('')
+" "$TEAM_CONFIG" 2>/dev/null || true)
+  fi
+
+  SPAWN_CLAUDE_BIN=$(whence -p claude 2>/dev/null || echo "claude")
+
+  # Build init + agent command
+  SPAWN_INIT_CMD="cd ${(q)SPAWN_DIR}"
+  if [[ -f "$SPAWN_ENV_FILE" ]]; then
+    SPAWN_INIT_CMD="${SPAWN_INIT_CMD}; set -a; source ${(q)SPAWN_ENV_FILE}; set +a; hash -r"
+  fi
+  SPAWN_INIT_CMD="${SPAWN_INIT_CMD}; export ATM_IDENTITY=${(q)SPAWN_NAME}; export ATM_TEAM=${(q)SPAWN_TEAM}"
+
+  case "$SPAWN_TYPE" in
+    codex)
+      SPAWN_FULL_CMD="codex --yolo"
+      ;;
+    gemini)
+      SPAWN_FULL_CMD="gemini"
+      ;;
+    claude|sonnet|haiku|opus)
+      SPAWN_FULL_CMD="${SPAWN_CLAUDE_BIN} --model ${SPAWN_MODEL}"
+      SPAWN_FULL_CMD+=" --dangerously-skip-permissions"
+      SPAWN_FULL_CMD+=" --teammate-mode tmux"
+      SPAWN_FULL_CMD+=" --agent-id ${(q)SPAWN_NAME}@${(q)SPAWN_TEAM}"
+      SPAWN_FULL_CMD+=" --agent-name ${(q)SPAWN_NAME}"
+      SPAWN_FULL_CMD+=" --team-name ${(q)SPAWN_TEAM}"
+      if [[ -n "$PARENT_SESSION_ID" ]]; then
+        SPAWN_FULL_CMD+=" --parent-session-id ${(q)PARENT_SESSION_ID}"
+      fi
+      ;;
+  esac
+
+  if $SPAWN_DRY_RUN; then
+    echo "=== rmux spawn dry-run ==="
+    echo "  session: $SPAWN_SESSION"
+    echo "  window:  $SPAWN_WINDOW"
+    echo "  pane:    $SPAWN_NAME"
+    echo "  type:    $SPAWN_TYPE"
+    echo "  team:    $SPAWN_TEAM"
+    [[ -n "$SPAWN_MODEL" ]] && echo "  model:   $SPAWN_MODEL"
+    [[ -n "$PARENT_SESSION_ID" ]] && echo "  parent:  $PARENT_SESSION_ID"
+    echo "  init:    $SPAWN_INIT_CMD"
+    echo "  cmd:     $SPAWN_FULL_CMD"
+    exit 0
+  fi
+
+  if ! tmux has-session -t "$SPAWN_SESSION" 2>/dev/null; then
+    echo "rmux: session '$SPAWN_SESSION' not running — start it with: rmux" >&2; exit 1
+  fi
+
+  # Create spare window if needed
+  SPARE_IS_NEW=false
+  if ! tmux list-windows -t "$SPAWN_SESSION" -F '#{window_name}' 2>/dev/null | grep -qx "$SPAWN_WINDOW"; then
+    tmux new-window -t "${SPAWN_SESSION}:" -n "$SPAWN_WINDOW"
+    SPARE_IS_NEW=true
+  fi
+
+  typeset SPAWN_PANE_ID
+  if $SPARE_IS_NEW; then
+    SPAWN_PANE_ID=$(tmux list-panes -t "${SPAWN_SESSION}:${SPAWN_WINDOW}" -F '#{pane_id}' | head -1)
+  else
+    SPAWN_PANE_ID=$(tmux split-window -t "${SPAWN_SESSION}:${SPAWN_WINDOW}" -P -F '#{pane_id}')
+  fi
+
+  tmux select-pane -t "$SPAWN_PANE_ID" -T "$SPAWN_NAME" || true
+
+  tmux set-buffer -- "$SPAWN_INIT_CMD"
+  tmux paste-buffer -t "$SPAWN_PANE_ID"
+  tmux send-keys -t "$SPAWN_PANE_ID" Enter
+
+  tmux set-buffer -- "$SPAWN_FULL_CMD"
+  tmux paste-buffer -t "$SPAWN_PANE_ID"
+  tmux send-keys -t "$SPAWN_PANE_ID" Enter
+
+  if command -v atm &>/dev/null; then
+    atm teams add-member "$SPAWN_TEAM" "$SPAWN_NAME" --agent-type "$SPAWN_NAME" --pane-id "$SPAWN_PANE_ID" 2>/dev/null || true
+  fi
+
+  echo "Spawned '${SPAWN_NAME}' (${SPAWN_TYPE}) in ${SPAWN_SESSION}:${SPAWN_WINDOW} pane ${SPAWN_PANE_ID}"
+  exit 0
+fi
 
 # ── Defaults ──────────────────────────────────────────────────────────
 CONFIG_FILE=".atm.toml"
@@ -21,6 +179,7 @@ usage() {
   cat <<'EOF'
 Usage: rmux [OPTIONS]
        rmux launch <pane-name> [OPTIONS]
+       rmux <agent-type> <name> [OPTIONS]
 
 Create a tmux session from [rmux] config in .atm.toml, or launch a
 single agent pane into an existing session.
@@ -30,12 +189,19 @@ Commands:
   launch <pane-name>  Launch a single pane by name into the running session.
                       If the pane exists (by title), re-use it.
                       If the pane is missing, create it in the correct window.
+  codex|claude|sonnet|haiku|opus|gemini <name>
+                      Spawn a new agent in the spare window of the running session.
 
 Options:
   --config <path>   Path to TOML config (default: .atm.toml in CWD)
   --dry-run         Print planned tmux commands without executing
   -v, --verbose     Log each tmux command to stderr
   -h, --help        Show this help
+
+Spawn options:
+  --team <name>     Override ATM_TEAM (default: [core] default_team)
+  --model <name>    Override model (claude agents only)
+  --window <name>   Target window name (default: spare)
 EOF
   exit 0
 }

--- a/scripts/rmux
+++ b/scripts/rmux
@@ -1,0 +1,472 @@
+#!/usr/bin/env zsh
+# rmux — TOML-driven tmux session launcher
+# Reads [rmux] section from .atm.toml (or --config) and .env in CWD,
+# then creates a named tmux session with multiple windows and panes.
+#
+# Install: cp scripts/rmux ~/.local/bin/rmux && chmod +x ~/.local/bin/rmux
+# Usage:   rmux [--config <path>] [--dry-run] [-v] [-h]
+#          rmux launch <pane-name> [--config <path>] [--dry-run] [-v]
+
+setopt ERR_EXIT PIPE_FAIL NO_UNSET
+
+# ── Defaults ──────────────────────────────────────────────────────────
+CONFIG_FILE=".atm.toml"
+DRY_RUN=false
+VERBOSE=false
+LAUNCH_PANE=""
+MODE="session"   # "session" or "launch"
+
+# ── Argument parsing ──────────────────────────────────────────────────
+usage() {
+  cat <<'EOF'
+Usage: rmux [OPTIONS]
+       rmux launch <pane-name> [OPTIONS]
+
+Create a tmux session from [rmux] config in .atm.toml, or launch a
+single agent pane into an existing session.
+
+Commands:
+  (none)              Create full tmux session with all windows/panes
+  launch <pane-name>  Launch a single pane by name into the running session.
+                      If the pane exists (by title), re-use it.
+                      If the pane is missing, create it in the correct window.
+
+Options:
+  --config <path>   Path to TOML config (default: .atm.toml in CWD)
+  --dry-run         Print planned tmux commands without executing
+  -v, --verbose     Log each tmux command to stderr
+  -h, --help        Show this help
+EOF
+  exit 0
+}
+
+# Check for subcommand first
+if [[ ${1:-} == "launch" ]]; then
+  MODE="launch"
+  shift
+  if [[ $# -eq 0 ]]; then
+    echo "rmux launch: pane name required" >&2
+    echo "Usage: rmux launch <pane-name> [OPTIONS]" >&2
+    exit 1
+  fi
+  LAUNCH_PANE="$1"
+  shift
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)   CONFIG_FILE="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=true; shift ;;
+    -v|--verbose) VERBOSE=true; shift ;;
+    -h|--help)  usage ;;
+    *)          echo "rmux: unknown option '$1'" >&2; exit 1 ;;
+  esac
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────
+log()  { if $VERBOSE; then echo "  [rmux] $*" >&2; fi }
+info() { echo "$*" }
+err()  { echo "rmux: $*" >&2 }
+
+run_tmux() {
+  log "tmux $*"
+  if ! $DRY_RUN; then
+    tmux "$@"
+  fi
+}
+
+# ── Dependency checks ─────────────────────────────────────────────────
+for cmd in tmux jq python3; do
+  if ! command -v $cmd &>/dev/null; then
+    err "$cmd is required but not found in PATH"
+    exit 1
+  fi
+done
+
+# ── Config loading ────────────────────────────────────────────────────
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  err "config not found: $CONFIG_FILE"
+  exit 1
+fi
+
+# Parse [rmux] section from TOML → JSON via Python
+RMUX_JSON=$(python3 -c "
+import json, sys
+try:
+    import tomllib
+except ImportError:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        print('rmux: neither tomllib nor tomli available', file=sys.stderr)
+        sys.exit(1)
+
+with open(sys.argv[1], 'rb') as f:
+    data = tomllib.load(f)
+
+rmux = data.get('rmux')
+if rmux is None:
+    print('rmux: no [rmux] section in config', file=sys.stderr)
+    sys.exit(1)
+
+print(json.dumps(rmux))
+" "$CONFIG_FILE") || exit 1
+
+# ── Resolve repo env file for pane initialization ────────────────────
+typeset ENV_DIR ENV_FILE
+ENV_DIR="${CONFIG_FILE:h}"
+[[ "$ENV_DIR" == "." ]] && ENV_DIR="$(pwd)"
+ENV_FILE="${ENV_DIR}/.env"
+
+log "Using repo env file: $ENV_FILE"
+
+# ── Resolve claude binary path (aliases not available in fresh panes) ─
+typeset CLAUDE_BIN
+CLAUDE_BIN=$(whence -p claude 2>/dev/null || echo "claude")
+log "Claude binary: $CLAUDE_BIN"
+
+# ── Extract ATM_TEAM from .env for agent expansion ──────────────────
+typeset ATM_TEAM_DEFAULT=""
+if [[ -f "$ENV_FILE" ]]; then
+  ATM_TEAM_DEFAULT=$(grep -E '^ATM_TEAM=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d "'" | tr -d '"')
+fi
+
+# ── Extract session config ────────────────────────────────────────────
+local session num_windows
+session=$(echo "$RMUX_JSON" | jq -r '.session // "default"')
+num_windows=$(echo "$RMUX_JSON" | jq '.windows | length')
+
+if [[ "$num_windows" -eq 0 ]]; then
+  err "no windows defined in [rmux] config"
+  exit 1
+fi
+
+# ── Build pane init command ───────────────────────────────────────────
+build_init_command() {
+  local pane_env_json="$1"
+  local pane_dir="${2:-}"
+  local cmd_parts=()
+  local work_dir="${pane_dir:-$ENV_DIR}"
+
+  cmd_parts+=("cd ${(q)work_dir}")
+  if [[ -f "$ENV_FILE" ]]; then
+    cmd_parts+=("set -a")
+    cmd_parts+=("source ${(q)ENV_FILE}")
+    cmd_parts+=("set +a")
+    cmd_parts+=("hash -r")
+  fi
+
+  if [[ "$pane_env_json" != "null" && "$pane_env_json" != "{}" ]]; then
+    local kv_line key val
+    while IFS= read -r kv_line; do
+      [[ -z "$kv_line" ]] && continue
+      key="${kv_line%%=*}"
+      val="${kv_line#*=}"
+      cmd_parts+=("export ${key}=${(q)val}")
+    done < <(echo "$pane_env_json" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
+  fi
+
+  echo "${(j:; :)cmd_parts}"
+}
+
+# ── Build pane commands (shared by session + launch modes) ────────────
+# Sets: R_INIT_CMD, R_FULL_CMD, R_PANE_NAME, R_PANE_DIR, R_PANE_MODEL,
+#       R_PANE_AGENT, R_PANE_ENV_JSON, R_PANE_PROMPT
+build_pane_commands() {
+  local w="$1" p="$2"
+
+  R_PANE_NAME=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].name // \"pane-$p\"")
+  local pane_cmd=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].command // \"\"")
+  R_PANE_ENV_JSON=$(echo "$RMUX_JSON" | jq ".windows[$w].panes[$p].env // {}")
+  R_PANE_AGENT=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].agent // \"\"")
+  R_PANE_PROMPT=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].prompt // \"\"")
+  R_PANE_MODEL=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].model // \"\"")
+  R_PANE_DIR=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].dir // \"\"")
+
+  local full_cmd="" agent_name="" pane_identity="" atm_team=""
+
+  if [[ -n "$R_PANE_MODEL" ]]; then
+    full_cmd="${CLAUDE_BIN} --model ${R_PANE_MODEL} --dangerously-skip-permissions --teammate-mode tmux"
+
+    # Determine agent identity for team flags:
+    #   - Primary agent (team-lead): no trio flags, starts the team
+    #   - Secondary agents: need --agent-id/--agent-name/--team-name for team comms
+    #   - Agent name from: explicit 'agent' field → ATM_IDENTITY from env
+    agent_name=""
+    if [[ -n "$R_PANE_AGENT" ]]; then
+      agent_name="$R_PANE_AGENT"
+    else
+      pane_identity=$(echo "$R_PANE_ENV_JSON" | jq -r '.ATM_IDENTITY // ""')
+      if [[ -n "$pane_identity" && "$pane_identity" != "team-lead" ]]; then
+        agent_name="$pane_identity"
+      fi
+    fi
+
+    if [[ -n "$agent_name" ]]; then
+      atm_team=$(echo "$R_PANE_ENV_JSON" | jq -r '.ATM_TEAM // ""')
+      [[ -z "$atm_team" ]] && atm_team="$ATM_TEAM_DEFAULT"
+      if [[ -n "$atm_team" ]]; then
+        full_cmd="${full_cmd} --agent-id ${agent_name}@${atm_team} --agent-name ${agent_name} --team-name ${atm_team}"
+      else
+        err "agent '${agent_name}' needs ATM_TEAM but none found in pane env or .env"
+      fi
+    fi
+
+    if [[ -n "$R_PANE_PROMPT" ]]; then
+      full_cmd="${full_cmd} ${R_PANE_PROMPT}"
+    fi
+  else
+    full_cmd="$pane_cmd"
+    if [[ -n "$R_PANE_PROMPT" ]]; then
+      full_cmd="${full_cmd} ${R_PANE_PROMPT}"
+    fi
+  fi
+
+  R_INIT_CMD=$(build_init_command "$R_PANE_ENV_JSON" "$R_PANE_DIR")
+  R_FULL_CMD="$full_cmd"
+}
+
+# ── Paste commands into a pane ────────────────────────────────────────
+paste_commands_to_pane() {
+  local pane_id="$1"
+
+  if [[ -n "$R_INIT_CMD" ]]; then
+    log "paste → $pane_id: $R_INIT_CMD"
+    tmux set-buffer -- "$R_INIT_CMD"
+    tmux paste-buffer -t "$pane_id"
+    tmux send-keys -t "$pane_id" Enter
+  fi
+  if [[ -n "$R_FULL_CMD" ]]; then
+    log "paste → $pane_id: $R_FULL_CMD"
+    tmux set-buffer -- "$R_FULL_CMD"
+    tmux paste-buffer -t "$pane_id"
+    tmux send-keys -t "$pane_id" Enter
+  fi
+}
+
+# ── Print dry-run info for a pane ─────────────────────────────────────
+print_pane_dry_run() {
+  local indent="${1:-  }"
+  echo "${indent}Pane: \"$R_PANE_NAME\""
+  if [[ -n "$R_PANE_DIR" ]]; then
+    echo "${indent}  dir: $R_PANE_DIR"
+  fi
+  if [[ -n "$R_INIT_CMD" ]]; then
+    echo "${indent}  init: $R_INIT_CMD"
+  fi
+  if [[ -n "$R_PANE_MODEL" ]]; then
+    echo "${indent}  model: $R_PANE_MODEL"
+  fi
+  if [[ -n "$R_PANE_AGENT" ]]; then
+    echo "${indent}  agent: $R_PANE_AGENT (explicit)"
+  elif [[ -n "$R_PANE_MODEL" ]]; then
+    local dry_identity
+    dry_identity=$(echo "$R_PANE_ENV_JSON" | jq -r '.ATM_IDENTITY // ""')
+    if [[ -n "$dry_identity" && "$dry_identity" != "team-lead" ]]; then
+      echo "${indent}  agent: $dry_identity (from ATM_IDENTITY)"
+    elif [[ -n "$dry_identity" && "$dry_identity" == "team-lead" ]]; then
+      echo "${indent}  role: primary (team-lead, no agent trio)"
+    fi
+  fi
+  if [[ -n "$R_PANE_PROMPT" ]]; then
+    echo "${indent}  prompt: $R_PANE_PROMPT"
+  fi
+  if [[ -n "$R_FULL_CMD" ]]; then
+    echo "${indent}  cmd: $R_FULL_CMD"
+  fi
+}
+
+# ══════════════════════════════════════════════════════════════════════
+# MODE: launch — launch a single pane by name
+# ══════════════════════════════════════════════════════════════════════
+if [[ "$MODE" == "launch" ]]; then
+
+  # Find the pane in config
+  local found_w=-1 found_p=-1
+  for (( w=0; w<num_windows; w++ )); do
+    local np=$(echo "$RMUX_JSON" | jq ".windows[$w].panes | length")
+    for (( p=0; p<np; p++ )); do
+      local name=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].name // \"\"")
+      if [[ "$name" == "$LAUNCH_PANE" ]]; then
+        found_w=$w
+        found_p=$p
+        break 2
+      fi
+    done
+  done
+
+  if [[ $found_w -eq -1 ]]; then
+    err "pane '$LAUNCH_PANE' not found in config"
+    exit 1
+  fi
+
+  local win_name win_layout
+  win_name=$(echo "$RMUX_JSON" | jq -r ".windows[$found_w].name // \"win-$found_w\"")
+  win_layout=$(echo "$RMUX_JSON" | jq -r ".windows[$found_w].layout // \"tiled\"")
+
+  # Build commands for this pane
+  build_pane_commands $found_w $found_p
+
+  if $DRY_RUN; then
+    echo "=== rmux launch dry-run: $LAUNCH_PANE ==="
+    echo "  session: $session"
+    echo "  window: $win_name (layout: $win_layout)"
+    echo
+    print_pane_dry_run "  "
+    echo
+    echo "Run without --dry-run to launch pane."
+    exit 0
+  fi
+
+  # Session must be running
+  if ! tmux has-session -t "$session" 2>/dev/null; then
+    err "session '$session' not running — use 'rmux' to create it first"
+    exit 1
+  fi
+
+  # Check if pane already exists by title
+  local existing_pane_id=""
+  existing_pane_id=$(tmux list-panes -s -t "$session" -F '#{pane_title}	#{pane_id}' 2>/dev/null | \
+    awk -F'\t' -v name="$LAUNCH_PANE" '$1 == name { print $2; exit }') || true
+
+  local pane_id=""
+  if [[ -n "$existing_pane_id" ]]; then
+    log "Found existing pane '$LAUNCH_PANE' → $existing_pane_id"
+    pane_id="$existing_pane_id"
+    info "Launching '$LAUNCH_PANE' in existing pane $pane_id"
+  else
+    log "Pane '$LAUNCH_PANE' not found — creating in window '$win_name'"
+
+    # Ensure the window exists
+    if ! tmux list-windows -t "$session" -F '#{window_name}' 2>/dev/null | grep -qx "$win_name"; then
+      log "Window '$win_name' not found — creating it"
+      tmux new-window -t "${session}:" -n "$win_name"
+    fi
+
+    # Split to create new pane
+    pane_id=$(tmux split-window -t "${session}:${win_name}" -P -F '#{pane_id}')
+    tmux select-pane -t "$pane_id" -T "$LAUNCH_PANE" || true
+
+    # Reapply layout
+    tmux select-layout -t "${session}:${win_name}" "$win_layout" || true
+
+    info "Created pane '$LAUNCH_PANE' → $pane_id in window '$win_name'"
+  fi
+
+  # Paste init + cmd
+  paste_commands_to_pane "$pane_id"
+
+  exit 0
+fi
+
+# ══════════════════════════════════════════════════════════════════════
+# MODE: session — create full tmux session (original behavior)
+# ══════════════════════════════════════════════════════════════════════
+
+# ── Check for existing session ────────────────────────────────────────
+if ! $DRY_RUN && tmux has-session -t "$session" 2>/dev/null; then
+  if [[ -n "${TMUX:-}" ]]; then
+    err "Session '$session' already exists, but you are inside tmux."
+    err "Cannot attach from a nested session. From outside tmux, run:"
+    err "  tmux attach -t $session"
+    exit 1
+  fi
+  info "Session '$session' already exists — attaching."
+  exec tmux attach-session -t "$session"
+fi
+
+# ── Dry-run header ────────────────────────────────────────────────────
+if $DRY_RUN; then
+  echo "=== rmux dry-run: $session ==="
+  echo
+  if [[ -f "$ENV_FILE" ]]; then
+    echo "Repo env file: $ENV_FILE"
+  else
+    echo "Repo env file missing: $ENV_FILE"
+  fi
+  echo
+fi
+
+# ── Create session, windows, panes ────────────────────────────────────
+local w p win_name win_layout num_panes pane_id first_win_name
+
+for (( w=0; w<num_windows; w++ )); do
+  win_name=$(echo "$RMUX_JSON" | jq -r ".windows[$w].name // \"win-$w\"")
+  win_layout=$(echo "$RMUX_JSON" | jq -r ".windows[$w].layout // \"tiled\"")
+  num_panes=$(echo "$RMUX_JSON" | jq ".windows[$w].panes | length")
+
+  if [[ "$num_panes" -eq 0 ]]; then
+    log "Window '$win_name' has no panes — skipping"
+    continue
+  fi
+
+  if $DRY_RUN; then
+    echo "Window $w: \"$win_name\" (layout: $win_layout)"
+  fi
+
+  # Create window (first window comes with the session)
+  if [[ $w -eq 0 ]]; then
+    first_win_name="$win_name"
+    run_tmux new-session -d -s "$session" -n "$win_name" -x 200 -y 50
+  else
+    run_tmux new-window -t "${session}:" -n "$win_name"
+  fi
+
+  for (( p=0; p<num_panes; p++ )); do
+    build_pane_commands $w $p
+
+    if $DRY_RUN; then
+      print_pane_dry_run "  "
+      continue
+    fi
+
+    # Create pane and capture its actual ID (handles any pane-base-index)
+    if [[ $p -eq 0 ]]; then
+      pane_id=$(tmux list-panes -t "${session}:${win_name}" -F '#{pane_id}' | head -1)
+    else
+      pane_id=$(tmux split-window -t "${session}:${win_name}" -P -F '#{pane_id}')
+    fi
+    log "pane '$R_PANE_NAME' → $pane_id"
+
+    # Set pane title (non-fatal if tmux version lacks -T)
+    run_tmux select-pane -t "$pane_id" -T "$R_PANE_NAME" || true
+
+    # Paste init + cmd
+    paste_commands_to_pane "$pane_id"
+  done
+
+  # Apply layout after all panes exist
+  if [[ "$num_panes" -gt 1 ]]; then
+    run_tmux select-layout -t "${session}:${win_name}" "$win_layout" || {
+      err "select-layout '$win_layout' failed for window '$win_name' — continuing"
+    }
+  fi
+
+  if $DRY_RUN; then
+    echo
+  fi
+done
+
+# Select first window
+if ! $DRY_RUN; then
+  run_tmux select-window -t "${session}:${first_win_name}"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────
+if $DRY_RUN; then
+  echo "Run without --dry-run to create session."
+else
+  echo "Session '$session' created."
+  echo
+  for (( w=0; w<num_windows; w++ )); do
+    win_name=$(echo "$RMUX_JSON" | jq -r ".windows[$w].name // \"win-$w\"")
+    num_panes=$(echo "$RMUX_JSON" | jq ".windows[$w].panes | length")
+    echo "  Window: $win_name"
+    for (( p=0; p<num_panes; p++ )); do
+      local pane_name=$(echo "$RMUX_JSON" | jq -r ".windows[$w].panes[$p].name // \"pane-$p\"")
+      echo "    Pane: $pane_name ($session:$win_name.$p)"
+    done
+  done
+  echo
+  echo "  Attach: tmux attach -t $session"
+fi

--- a/scripts/rmux
+++ b/scripts/rmux
@@ -99,7 +99,7 @@ except Exception:
 
   case "$SPAWN_TYPE" in
     codex)
-      SPAWN_FULL_CMD="codex --yolo"
+      SPAWN_FULL_CMD="codex -c features.codex_hooks=true --yolo"
       ;;
     gemini)
       SPAWN_FULL_CMD="gemini"

--- a/scripts/rmux.md
+++ b/scripts/rmux.md
@@ -323,6 +323,30 @@ tmux attach -t myteam
 
 ---
 
+## Configurations on Disk
+
+All `.atm.toml` files with `[rmux]` sections currently configured on this machine:
+
+| Path | Session | Team(s) | Agents |
+|------|---------|---------|--------|
+| `~/Documents/github/agent-team-mail/.atm.toml` | `atm-dev` | atm-dev, schook, scterm, sc-compose, sc-observability | team-lead, arch-ctm, quality-mgr, arch-ctask, chook, cterm, comp, cobs |
+| `~/Documents/github/scmux/.atm.toml` | `scmux-dev` | scmux-dev | team-lead, arch-ctm |
+| `~/Documents/github-radiant/data-sourcegenerators/.atm.toml` | `src-gen` | src-gen | team-lead (gen), arch-data, arch-ann, quality-mgr |
+| `~/Documents/github-radiant/unsafe/.atm.toml` | `unsafe-dev` | unsafe-dev | team-lead, cus, arch-math, arch-ann |
+| `~/Documents/github-radiant/io/.atm.toml` | `io-dev` | io-dev | team-lead, arch-cio, arch-udp, cin, arch-in |
+| `~/Documents/github-radiant/XCore/.atm.toml` | `nuget-x` | nuget-x | team-lead, cx, arch-ann |
+| `~/Documents/p3-documentation/.atm.toml` | `p3-doc` | p3-doc | arch-p3, codex-p3, qa-p3, nuget-p3 |
+
+To launch any session:
+```bash
+cd <path containing .atm.toml>
+rmux
+# or from anywhere:
+rmux --config <path-to-.atm.toml>
+```
+
+---
+
 ## Tips
 
 **Preview before launching:**

--- a/scripts/rmux.md
+++ b/scripts/rmux.md
@@ -1,0 +1,350 @@
+# rmux — TOML-driven tmux Session Launcher
+
+`rmux` reads an `[rmux]` section from `.atm.toml` and launches a fully configured tmux session with named windows and panes. It handles environment setup, agent identity, and team registration automatically.
+
+---
+
+## Installation
+
+```bash
+# From the scmux repo:
+cp scripts/rmux ~/.local/bin/rmux && chmod +x ~/.local/bin/rmux
+```
+
+**Dependencies** (must be in PATH):
+- `tmux`
+- `jq`
+- `python3` with `tomllib` (built-in ≥ 3.11) or `tomli` (`pip install tomli`)
+
+---
+
+## Commands
+
+### `rmux` — Create session
+
+Reads `.atm.toml` in the current directory and creates a tmux session with all configured windows and panes.
+
+```bash
+rmux                          # create session from .atm.toml in CWD
+rmux --config ~/myproject/.atm.toml
+rmux --dry-run                # preview without executing
+rmux -v                       # verbose: log every tmux command
+```
+
+If the session already exists and you are **outside** tmux, it attaches. If you are **inside** tmux, it prints the attach command and exits.
+
+---
+
+### `rmux launch <pane-name>` — Re-launch a named pane
+
+Finds a pane by name in the config and launches it into the running session. If the pane already exists (matched by tmux pane title), it re-sends the commands to that pane. If the pane is missing, it creates it in the correct window.
+
+```bash
+rmux launch team-lead
+rmux launch quality-mgr --config /path/to/.atm.toml
+rmux launch cobs --dry-run
+```
+
+Useful for restarting a crashed agent without rebuilding the entire session.
+
+---
+
+### `rmux <agent-type> <name>` — Spawn agent at runtime
+
+Adds a new agent pane to the running session's `spare` window (created if it doesn't exist). Team and session are read from the local `.atm.toml`.
+
+```bash
+rmux codex   my-agent          # spawn codex --yolo pane named my-agent
+rmux sonnet  my-agent          # spawn claude --model sonnet pane
+rmux haiku   my-agent          # spawn claude --model haiku pane
+rmux opus    my-agent          # spawn claude --model opus pane
+rmux claude  my-agent          # alias for sonnet
+rmux gemini  my-agent          # spawn gemini pane
+```
+
+**Options:**
+```
+--config <path>   Config file to read (default: .atm.toml in CWD)
+--team <name>     Override ATM_TEAM
+--model <name>    Override model for claude agents
+--window <name>   Target window name (default: spare)
+--dry-run         Preview without executing
+```
+
+**Examples:**
+```bash
+# From inside a schook pane — spawns into schook's spare window
+rmux codex spare-dev
+
+# Override team and window
+rmux sonnet reviewer --team schook --window overflow
+
+# Preview what would run
+rmux haiku triage --dry-run
+```
+
+Agent identity is set via `ATM_IDENTITY=<name>` and `ATM_TEAM=<team>` env vars. Claude agents additionally receive `--agent-id`, `--agent-name`, `--team-name`, and `--parent-session-id` flags for team communication.
+
+---
+
+## `.atm.toml` Reference
+
+### Minimal example
+
+```toml
+[rmux]
+session = "myteam"
+
+[[rmux.windows]]
+name = "agents"
+layout = "even-horizontal"
+
+[[rmux.windows.panes]]
+name = "team-lead"
+model = "sonnet"
+env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "myteam" }
+
+[[rmux.windows.panes]]
+name = "cdev"
+command = "codex --yolo"
+env = { ATM_IDENTITY = "cdev", ATM_TEAM = "myteam" }
+
+[[rmux.windows.panes]]
+name = "quality-mgr"
+model = "sonnet"
+env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "myteam" }
+```
+
+### Full example — multi-team monorepo
+
+```toml
+[core]
+default_team = "atm-dev"
+identity = "team-lead"
+
+[plugins.gh_monitor]
+team = "atm-dev"
+repo = "myorg/myrepo"
+notify_target = ["quality-mgr@atm-dev", "team-lead@atm-dev"]
+poll_interval_secs = 300
+
+# ── rmux: tmux session launcher ──────────────────────────────────────
+[rmux]
+session = "atm-dev"
+
+# ── Primary team window ───────────────────────────────────────────────
+[[rmux.windows]]
+name = "agents"
+layout = "even-horizontal"
+
+[[rmux.windows.panes]]
+name = "team-lead"
+model = "sonnet"
+env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "atm-dev" }
+
+[[rmux.windows.panes]]
+name = "arch-ctm"
+command = "codex --yolo"
+env = { ATM_IDENTITY = "arch-ctm", ATM_TEAM = "atm-dev" }
+
+[[rmux.windows.panes]]
+name = "quality-mgr"
+model = "sonnet"
+env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "atm-dev" }
+
+# ── Monitoring window ─────────────────────────────────────────────────
+[[rmux.windows]]
+name = "monitoring"
+layout = "even-vertical"
+
+[[rmux.windows.panes]]
+name = "logs"
+command = "tail -f /tmp/atm.log"
+
+[[rmux.windows.panes]]
+name = "atm-monitor"
+model = "haiku"
+agent = "atm-monitor"
+
+[[rmux.windows.panes]]
+name = "atm-term"
+
+# ── Sub-team: schook (separate team, separate repo) ───────────────────
+[[rmux.windows]]
+name = "schook"
+layout = "even-horizontal"
+
+[[rmux.windows.panes]]
+name = "team-lead"
+model = "sonnet"
+dir = "/Users/me/github/schook"
+env = { ATM_IDENTITY = "team-lead", ATM_TEAM = "schook" }
+
+[[rmux.windows.panes]]
+name = "chook"
+command = "codex --yolo"
+dir = "/Users/me/github/schook"
+env = { ATM_IDENTITY = "chook", ATM_TEAM = "schook" }
+
+[[rmux.windows.panes]]
+name = "quality-mgr"
+model = "sonnet"
+dir = "/Users/me/github/schook"
+env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "schook" }
+```
+
+### Pane field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Pane display name and tmux pane title |
+| `model` | string | Claude model: `sonnet`, `haiku`, `opus`. When set, launches claude |
+| `command` | string | Raw shell command (used when `model` is not set) |
+| `agent` | string | Named agent identity (overrides `ATM_IDENTITY` for team flags) |
+| `prompt` | string | Appended as a positional arg to the claude command (e.g. a prompt file path) |
+| `dir` | string | Working directory for the pane (defaults to config file directory) |
+| `env` | table | Environment variables exported before the command runs |
+| `color` | string | Reserved for agent color — flag name TBD |
+
+### Window field reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Window name in tmux |
+| `layout` | string | tmux layout: `even-horizontal`, `even-vertical`, `tiled`, `main-horizontal`, `main-vertical` |
+| `panes` | array | List of pane definitions |
+
+---
+
+## How agent identity works
+
+rmux distinguishes two roles based on `ATM_IDENTITY`:
+
+**`team-lead`** — the primary agent that starts and owns the team. Gets no `--agent-id/--agent-name/--team-name` flags, which causes claude to create a new team session.
+
+**All other claude panes** — secondary agents. Get the full trio of flags so they join the team-lead's session:
+```
+claude --model sonnet \
+  --dangerously-skip-permissions \
+  --teammate-mode tmux \
+  --agent-id quality-mgr@schook \
+  --agent-name quality-mgr \
+  --team-name schook
+```
+
+**Codex and gemini panes** receive identity only via environment variables (`ATM_IDENTITY`, `ATM_TEAM`), not CLI flags.
+
+---
+
+## Environment setup per pane
+
+For every pane, rmux runs this init sequence before the agent command:
+
+```bash
+cd <dir>
+set -a; source .env; set +a; hash -r   # if .env exists
+export ATM_IDENTITY=<value>             # from pane env table
+export ATM_TEAM=<value>                 # from pane env table
+```
+
+The `.env` file is sourced from the config file's directory (or the `dir` field if set). Any secrets, API keys, or shared variables belong in `.env`.
+
+---
+
+## Setting up on a new machine
+
+### 1. Clone scmux and install rmux
+
+```bash
+git clone https://github.com/randlee/scmux.git ~/github/scmux
+cp ~/github/scmux/scripts/rmux ~/.local/bin/rmux
+chmod +x ~/.local/bin/rmux
+```
+
+Ensure `~/.local/bin` is in your PATH:
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+### 2. Install dependencies
+
+```bash
+brew install tmux jq          # macOS
+# or: sudo apt install tmux jq  (Ubuntu/Debian)
+
+# Python tomllib is built-in with Python 3.11+
+# For older Python:
+pip install tomli
+```
+
+### 3. Clone your project repos
+
+```bash
+mkdir -p ~/github
+git clone https://github.com/myorg/myrepo.git ~/github/myrepo
+# ... repeat for each repo that has a sub-team window
+```
+
+### 4. Create or copy `.atm.toml`
+
+Either copy from another machine or create from scratch. Update `dir` paths to match the new machine's layout.
+
+```bash
+# Option A: copy and edit
+scp oldmachine:~/github/agent-team-mail/.atm.toml ~/github/agent-team-mail/
+# then edit dir paths
+
+# Option B: create fresh — see examples above
+```
+
+### 5. Create `.env` (if needed)
+
+```bash
+cat > ~/github/myrepo/.env <<'EOF'
+ATM_TEAM=myteam
+GITHUB_TOKEN=ghp_...
+EOF
+```
+
+### 6. Launch
+
+```bash
+cd ~/github/myrepo
+rmux              # creates the session
+# or from anywhere:
+rmux --config ~/github/myrepo/.atm.toml
+```
+
+Attach from outside tmux:
+```bash
+tmux attach -t myteam
+```
+
+---
+
+## Tips
+
+**Preview before launching:**
+```bash
+rmux --dry-run
+rmux sonnet my-agent --dry-run
+```
+
+**Restart a crashed pane without rebuilding the session:**
+```bash
+rmux launch quality-mgr
+```
+
+**Add a temporary agent to investigate something:**
+```bash
+rmux sonnet investigator --window scratch
+```
+
+**Use a different config file:**
+```bash
+rmux --config /path/to/other/.atm.toml
+rmux launch team-lead --config /path/to/other/.atm.toml
+```
+
+**Multiple teams on one machine:** Each team's `.atm.toml` defines its own `session` name, so sessions don't conflict. You can run them all simultaneously in the same tmux server.


### PR DESCRIPTION
## Summary

- Adds `rmux` — a TOML-driven tmux session launcher for multi-agent Claude Code teams
- Adds `spawn` subcommand for runtime agent creation
- Adds usage/setup guide and Configurations on Disk docs
- Adds rmux session config, gitignore update, and poll-merge script
- Enables codex hooks flag in all codex launch commands
- Fixes `--locked` flag removed from `cargo publish` in release workflow
- Bumps Cargo.lock to v0.6.0

## Test plan

- [ ] `rmux` launches tmux session from `.atm.toml` config
- [ ] `rmux spawn` creates agents at runtime
- [ ] `cargo publish` workflow succeeds without `--locked`
- [ ] No daemon/CLI/dashboard regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)