### PR TITLE
rmux: add fable agent type; restore hermes support

### DIFF
--- a/scripts/rmux
+++ b/scripts/rmux
@@ -6,14 +6,17 @@
 # Install: cp scripts/rmux ~/.local/bin/rmux && chmod +x ~/.local/bin/rmux
 # Usage:   rmux [--config <path>] [--dry-run] [-v] [-h]
 #          rmux launch <pane-name> [--config <path>] [--dry-run] [-v]
-#          rmux codex|claude|sonnet|haiku|opus|gemini <name> [OPTIONS]
+#          rmux codex|claude|sonnet|haiku|opus|fable|gemini|hermes <n> [OPTIONS]
 
 setopt ERR_EXIT PIPE_FAIL NO_UNSET
+
+# ── Error trap: print line number on unexpected exit ──────────────────
+trap '(( $? )) && echo "rmux: error — run with -v for details" >&2' EXIT
 
 # ── Spawn subcommand ──────────────────────────────────────────────────
 # Detect: first arg is a known agent type and second arg is a name
 typeset -a KNOWN_AGENT_TYPES
-KNOWN_AGENT_TYPES=(codex claude sonnet haiku opus gemini)
+KNOWN_AGENT_TYPES=(codex claude sonnet haiku opus fable gemini hermes)
 
 if [[ $# -ge 2 && ${KNOWN_AGENT_TYPES[(I)$1]} -gt 0 ]]; then
   SPAWN_TYPE="$1"
@@ -72,6 +75,7 @@ print(json.dumps({'session': rmux.get('session', 'default'), 'team': core.get('d
     claude|sonnet) [[ -z "$SPAWN_MODEL" ]] && SPAWN_MODEL="sonnet" ;;
     haiku)         [[ -z "$SPAWN_MODEL" ]] && SPAWN_MODEL="haiku" ;;
     opus)          [[ -z "$SPAWN_MODEL" ]] && SPAWN_MODEL="opus" ;;
+    fable)         [[ -z "$SPAWN_MODEL" ]] && SPAWN_MODEL="fable" ;;
   esac
 
   # Read parent session ID from team config
@@ -89,6 +93,7 @@ except Exception:
   fi
 
   SPAWN_CLAUDE_BIN=$(whence -p claude 2>/dev/null || echo "claude")
+  SPAWN_HERMES_BIN=$(whence -p hermes 2>/dev/null || echo "hermes")
 
   # Build init + agent command
   SPAWN_INIT_CMD="cd ${(q)SPAWN_DIR}"
@@ -104,7 +109,13 @@ except Exception:
     gemini)
       SPAWN_FULL_CMD="gemini"
       ;;
-    claude|sonnet|haiku|opus)
+    hermes)
+      SPAWN_FULL_CMD="${SPAWN_HERMES_BIN} --profile ${(q)SPAWN_NAME}"
+      if [[ -n "$SPAWN_MODEL" ]]; then
+        SPAWN_FULL_CMD+=" -m ${(q)SPAWN_MODEL}"
+      fi
+      ;;
+    claude|sonnet|haiku|opus|fable)
       SPAWN_FULL_CMD="${SPAWN_CLAUDE_BIN} --model ${SPAWN_MODEL}"
       SPAWN_FULL_CMD+=" --dangerously-skip-permissions"
       SPAWN_FULL_CMD+=" --teammate-mode tmux"
@@ -179,7 +190,7 @@ usage() {
   cat <<'EOF'
 Usage: rmux [OPTIONS]
        rmux launch <pane-name> [OPTIONS]
-       rmux <agent-type> <name> [OPTIONS]
+       rmux <agent-type> <n> [OPTIONS]
 
 Create a tmux session from [rmux] config in .atm.toml, or launch a
 single agent pane into an existing session.
@@ -189,7 +200,7 @@ Commands:
   launch <pane-name>  Launch a single pane by name into the running session.
                       If the pane exists (by title), re-use it.
                       If the pane is missing, create it in the correct window.
-  codex|claude|sonnet|haiku|opus|gemini <name>
+  codex|claude|sonnet|haiku|opus|fable|gemini|hermes <n>
                       Spawn a new agent in the spare window of the running session.
 
 Options:
@@ -199,9 +210,9 @@ Options:
   -h, --help        Show this help
 
 Spawn options:
-  --team <name>     Override ATM_TEAM (default: [core] default_team)
-  --model <name>    Override model (claude agents only)
-  --window <name>   Target window name (default: spare)
+  --team <n>     Override ATM_TEAM (default: [core] default_team)
+  --model <n>    Override model (claude, hermes, and fable agents)
+  --window <n>   Target window name (default: spare)
 EOF
   exit 0
 }
@@ -275,6 +286,7 @@ if rmux is None:
     print('rmux: no [rmux] section in config', file=sys.stderr)
     sys.exit(1)
 
+rmux['_atm_default_team'] = data.get('atm', {}).get('default_team', '')
 print(json.dumps(rmux))
 " "$CONFIG_FILE") || exit 1
 
@@ -291,10 +303,13 @@ typeset CLAUDE_BIN
 CLAUDE_BIN=$(whence -p claude 2>/dev/null || echo "claude")
 log "Claude binary: $CLAUDE_BIN"
 
-# ── Extract ATM_TEAM from .env for agent expansion ──────────────────
+# ── Extract ATM_TEAM from .env (or fall back to [atm].default_team) ──
 typeset ATM_TEAM_DEFAULT=""
 if [[ -f "$ENV_FILE" ]]; then
-  ATM_TEAM_DEFAULT=$(grep -E '^ATM_TEAM=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d "'" | tr -d '"')
+  ATM_TEAM_DEFAULT=$(grep -E '^ATM_TEAM=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d "'" | tr -d '"' || true)
+fi
+if [[ -z "$ATM_TEAM_DEFAULT" ]]; then
+  ATM_TEAM_DEFAULT=$(echo "$RMUX_JSON" | jq -r '._atm_default_team // ""')
 fi
 
 # ── Extract session config ────────────────────────────────────────────

--- a/scripts/rmux.md
+++ b/scripts/rmux.md
@@ -58,15 +58,17 @@ rmux codex   my-agent          # spawn codex --yolo pane named my-agent
 rmux sonnet  my-agent          # spawn claude --model sonnet pane
 rmux haiku   my-agent          # spawn claude --model haiku pane
 rmux opus    my-agent          # spawn claude --model opus pane
+rmux fable   my-agent          # spawn claude --model fable pane
 rmux claude  my-agent          # alias for sonnet
 rmux gemini  my-agent          # spawn gemini pane
+rmux hermes  my-agent          # spawn hermes --profile pane
 ```
 
 **Options:**
 ```
 --config <path>   Config file to read (default: .atm.toml in CWD)
 --team <name>     Override ATM_TEAM
---model <name>    Override model for claude agents
+--model <name>    Override model for claude and hermes agents (claude: sonnet, haiku, opus, fable)
 --window <name>   Target window name (default: spare)
 --dry-run         Preview without executing
 ```
@@ -198,7 +200,7 @@ env = { ATM_IDENTITY = "quality-mgr", ATM_TEAM = "schook" }
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | string | Pane display name and tmux pane title |
-| `model` | string | Claude model: `sonnet`, `haiku`, `opus`. When set, launches claude |
+| `model` | string | Claude model: `sonnet`, `haiku`, `opus`, `fable`. When set, launches claude |
 | `command` | string | Raw shell command (used when `model` is not set) |
 | `agent` | string | Named agent identity (overrides `ATM_IDENTITY` for team flags) |
 | `prompt` | string | Appended as a positional arg to the claude command (e.g. a prompt file path) |


### PR DESCRIPTION
Adds `fable` as a spawnable agent type alongside sonnet/haiku/opus, and restores `hermes` support that existed locally on one machine but was never pushed. Updates rmux.md docs to match.