### PR TITLE
daemon: launch.command seam + safe terminal jump (no iTerm2/TCC dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ tmux session manager for multi-agent Claude Code teams.
 
 ## What it does
 
-- **Declarative session configs** stored in SQLite (tmuxp JSON format)
+- **Declarative session configs** stored in SQLite (tmuxp JSON by default,
+  with an optional external-launcher adapter)
 - **Per-machine daemon** (`scmux-daemon`) polls tmux, auto-starts scheduled sessions, serves HTTP status API
 - **Web dashboard** shows all teams across all hosts — agent status, open PRs, jump-to-session via iTerm2
 
@@ -58,6 +59,49 @@ VALUES (
 ```
 
 See `docs/example-session.json` for a full tmuxp config example.
+
+### External launchers
+
+Teams that must perform lifecycle work beyond tmux creation can keep scmux as
+their dashboard and launch surface while delegating startup to an argv-based
+adapter:
+
+```json
+{
+  "session_name": "aidw-platform",
+  "start_directory": "~/git-checkouts/AIDevWorkspace",
+  "launch": {
+    "command": [
+      "scripts/aidw",
+      "--config-dir",
+      "config/aidw-platform",
+      "team",
+      "start"
+    ]
+  },
+  "panes": []
+}
+```
+
+`launch.command` is an argv array and never a shell string. `{team_name}` may
+be used in an argument. The command runs from `launch.working_directory`,
+`root_path`, or `start_directory` (in that order), with home-directory
+expansion on macOS/Linux and Windows. Definitions without `launch.command`
+continue to start through tmuxp.
+
+The dashboard labels external sessions as `Launch`/`Managed`. Their stop
+lifecycle stays with the external launcher; scmux refuses a direct stop rather
+than bypassing launcher-owned cleanup or registration.
+
+### Host-qualified jump names
+
+Dashboard jump actions accept host routing in the registered team name. Use
+`<session>@local` for a session on the dashboard computer, or
+`<session>@<ssh-user>@<computer-id>` for a session that may live on another
+computer. For example, `aidw-dev@aidwlead@HITL2` attaches directly when the
+dashboard runs on `HITL2`; otherwise it opens
+`ssh aidwlead@HITL2 tmux attach -t aidw-dev`. SSH key exchange must already be
+configured. Existing unqualified names continue to use their scmux host record.
 
 ## Architecture
 

--- a/crates/scmux-daemon/assets/dashboard.js
+++ b/crates/scmux-daemon/assets/dashboard.js
@@ -273,6 +273,22 @@ function ciRunTone(run) {
   };
 }
 function buildJumpCommand(session, host) {
+  const localMatch = session.name.match(/^([^@]+)@local$/i);
+  if (localMatch) {
+    return `tmux attach -t ${localMatch[1]}`;
+  }
+  const remoteMatch = session.name.match(/^(.+)@([^@]+)@([^@]+)$/);
+  if (remoteMatch) {
+    const [, tmuxSession, sshUser, computerId] = remoteMatch;
+    const computerLiteral = computerId.toLowerCase().replace(/\.$/, "");
+    const normalizedComputer = computerLiteral.split(".")[0];
+    const localNames = [host?.name, host?.address].filter(Boolean).map(value => value.toLowerCase().split(".")[0]);
+    const loopback = ["local", "localhost", "127.0.0.1", "::1"].includes(computerLiteral);
+    if (loopback || localNames.includes(normalizedComputer)) {
+      return `tmux attach -t ${tmuxSession}`;
+    }
+    return `ssh ${sshUser}@${computerId} tmux attach -t ${tmuxSession}`;
+  }
   if (!host || host.is_local) {
     return `tmux attach -t ${session.name}`;
   }
@@ -298,7 +314,9 @@ function SessionActionButtons({
   onEdit
 }) {
   const canStart = session.status === "stopped";
-  const actionLabel = canStart ? "Start" : "Stop";
+  const externallyManaged = session.launch_mode === "external";
+  const canAct = canStart || !externallyManaged;
+  const actionLabel = canStart ? externallyManaged ? "Launch" : "Start" : externallyManaged ? "Managed" : "Stop";
   return /*#__PURE__*/React.createElement("div", {
     style: {
       display: "flex",
@@ -309,7 +327,7 @@ function SessionActionButtons({
       event.stopPropagation();
       onStartStop(session);
     },
-    disabled: busy,
+    disabled: busy || !canAct,
     style: {
       border: "1px solid #1e2535",
       borderRadius: 4,
@@ -317,7 +335,8 @@ function SessionActionButtons({
       padding: "2px 8px",
       background: canStart ? "#102b1f" : "#2b1212",
       color: canStart ? "#34d399" : "#fca5a5",
-      cursor: busy ? "default" : "pointer"
+      cursor: busy || !canAct ? "default" : "pointer",
+      opacity: canAct ? 1 : 0.65
     }
   }, busy ? "..." : actionLabel), /*#__PURE__*/React.createElement("button", {
     onClick: event => {
@@ -461,7 +480,7 @@ function GridCard({
       color: pc,
       opacity: 0.8
     }
-  }, (session.project || "unassigned") + " | " + hostLabel(session.host))), /*#__PURE__*/React.createElement("div", {
+  }, (session.project || "unassigned") + " | " + hostLabel(session.host) + (session.launch_mode === "external" ? " | external launcher" : ""))), /*#__PURE__*/React.createElement("div", {
     style: {
       display: "flex",
       flexDirection: "column",

--- a/crates/scmux-daemon/src/api.rs
+++ b/crates/scmux-daemon/src/api.rs
@@ -17,7 +17,7 @@ use tower_http::cors::CorsLayer;
 use crate::atm::ShutdownTarget;
 use crate::runtime::{AtmRuntimeSummary, CiRuntimeSummary};
 use crate::tmux::{self, HostTarget};
-use crate::{atm, db, definition_writer, AppState};
+use crate::{atm, db, definition_writer, launcher, AppState};
 
 pub fn router(state: Arc<AppState>) -> Router {
     let middleware_state = Arc::clone(&state);
@@ -117,6 +117,7 @@ struct SessionSummary {
     status: String,
     cron_schedule: Option<String>,
     auto_start: bool,
+    launch_mode: &'static str,
     panes: serde_json::Value,
     polled_at: Option<String>,
     session_ci: Vec<SessionCiSummary>,
@@ -616,6 +617,7 @@ async fn list_sessions(
                     status: runtime_row.status,
                     cron_schedule: row.cron_schedule,
                     auto_start: row.auto_start,
+                    launch_mode: launcher::launch_mode(&row.config_json).as_str(),
                     panes: serde_json::to_value(runtime_row.panes).unwrap_or(serde_json::json!([])),
                     polled_at: runtime_row.polled_at,
                     session_ci: ci,
@@ -681,6 +683,7 @@ async fn get_session(
             status: runtime_row.status,
             cron_schedule: row.cron_schedule,
             auto_start: row.auto_start,
+            launch_mode: launcher::launch_mode(&row.config_json).as_str(),
             panes: serde_json::to_value(runtime_row.panes).unwrap_or(serde_json::json!([])),
             polled_at: runtime_row.polled_at,
             session_ci: ci,
@@ -837,6 +840,10 @@ async fn start_session(
             return Err(bad_request("invalid_crew_variant_binding", message));
         }
         binding.root_path
+    } else if let Some(path) = launcher::external_working_directory(&definition.config_json)
+        .map_err(|err| bad_request("invalid_launcher", err.to_string()))?
+    {
+        path.to_string_lossy().to_string()
     } else {
         validate_config_root_path_binding(&definition.config_json)
             .map_err(|message| bad_request("invalid_crew_variant_binding", message))?
@@ -851,11 +858,11 @@ async fn start_session(
         runtime.mark_starting(&name);
     }
 
-    let action = tmux::start_session(&name, &definition.config_json).await;
+    let action = launcher::start_session(&name, &definition.config_json).await;
     match action {
-        Ok(()) => Ok(Json(ActionResponse {
+        Ok(mode) => Ok(Json(ActionResponse {
             ok: true,
-            message: format!("session '{name}' started"),
+            message: format!("session '{name}' started via {}", mode.as_str()),
         })),
         Err(err) => {
             let mut runtime = state.runtime.lock().expect("runtime lock");
@@ -898,6 +905,19 @@ async fn stop_session(
             }),
         )
     })?;
+
+    if launcher::launch_mode(&definition.config_json) == launcher::LaunchMode::External {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                ok: false,
+                code: "external_lifecycle".to_string(),
+                message: format!(
+                    "session '{name}' uses an external launcher; stop it through that launcher"
+                ),
+            }),
+        ));
+    }
 
     let targets = extract_shutdown_targets(&definition.config_json);
     if let Err(err) = atm::send_shutdown_messages(state.as_ref(), &targets).await {

--- a/crates/scmux-daemon/src/launcher.rs
+++ b/crates/scmux-daemon/src/launcher.rs
@@ -1,0 +1,212 @@
+//! Session launch dispatch.
+//!
+//! Existing definitions continue to use tmuxp. Definitions may opt into an
+//! argv-based external launcher when that launcher must perform additional
+//! lifecycle work (for example, registering pane identities with ATM).
+
+use anyhow::{bail, Context};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchMode {
+    Tmuxp,
+    External,
+}
+
+impl LaunchMode {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Tmuxp => "tmuxp",
+            Self::External => "external",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExternalLaunch {
+    argv: Vec<String>,
+    working_directory: PathBuf,
+}
+
+pub fn launch_mode(config_json: &str) -> LaunchMode {
+    if matches!(external_launch(config_json, ""), Ok(Some(_))) {
+        LaunchMode::External
+    } else {
+        LaunchMode::Tmuxp
+    }
+}
+
+pub fn external_working_directory(config_json: &str) -> anyhow::Result<Option<PathBuf>> {
+    Ok(external_launch(config_json, "")?.map(|launch| launch.working_directory))
+}
+
+pub async fn start_session(name: &str, config_json: &str) -> anyhow::Result<LaunchMode> {
+    let Some(launch) = external_launch(config_json, name)? else {
+        crate::tmux::start_session(name, config_json).await?;
+        return Ok(LaunchMode::Tmuxp);
+    };
+
+    let (program, arguments) = launch
+        .argv
+        .split_first()
+        .context("launch.command must contain an executable")?;
+    let program = resolve_program(program, &launch.working_directory);
+    let output = Command::new(program)
+        .args(arguments)
+        .current_dir(&launch.working_directory)
+        .output()
+        .await
+        .context("external launcher could not be executed")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        bail!(
+            "external launcher failed with status {}{}",
+            output.status,
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        );
+    }
+
+    Ok(LaunchMode::External)
+}
+
+fn external_launch(config_json: &str, name: &str) -> anyhow::Result<Option<ExternalLaunch>> {
+    let value: Value = serde_json::from_str(config_json).context("invalid session config JSON")?;
+    let Some(command) = value.pointer("/launch/command") else {
+        return Ok(None);
+    };
+    let command = command
+        .as_array()
+        .context("launch.command must be an argv array")?;
+    if command.is_empty() {
+        bail!("launch.command must contain at least one item");
+    }
+
+    let mut argv = Vec::with_capacity(command.len());
+    for item in command {
+        let item = item
+            .as_str()
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+            .context("launch.command items must be non-empty strings")?;
+        argv.push(item.replace("{team_name}", name));
+    }
+
+    let configured_root = value
+        .pointer("/launch/working_directory")
+        .or_else(|| value.get("root_path"))
+        .or_else(|| value.get("start_directory"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|root| !root.is_empty())
+        .context(
+            "launch.working_directory, root_path, or start_directory is required for launch.command",
+        )?;
+    let working_directory = expand_home(configured_root)?;
+    if !working_directory.is_dir() {
+        bail!(
+            "external launcher working directory does not exist: {}",
+            working_directory.display()
+        );
+    }
+
+    Ok(Some(ExternalLaunch {
+        argv,
+        working_directory,
+    }))
+}
+
+fn expand_home(value: &str) -> anyhow::Result<PathBuf> {
+    if value == "~" || value.starts_with("~/") || value.starts_with("~\\") {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .context("cannot expand launcher home directory")?;
+        let suffix = value
+            .strip_prefix("~/")
+            .or_else(|| value.strip_prefix("~\\"))
+            .unwrap_or("");
+        return Ok(PathBuf::from(home).join(suffix));
+    }
+    Ok(PathBuf::from(value))
+}
+
+fn resolve_program(program: &str, working_directory: &Path) -> PathBuf {
+    let path = Path::new(program);
+    if path.is_absolute() || path.components().count() == 1 {
+        path.to_path_buf()
+    } else {
+        working_directory.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn defaults_to_tmuxp_without_launch_command() {
+        assert_eq!(
+            launch_mode(r#"{"session_name":"alpha"}"#),
+            LaunchMode::Tmuxp
+        );
+    }
+
+    #[tokio::test]
+    async fn external_launcher_receives_team_substitution_and_working_directory() {
+        let root = tempfile::tempdir().expect("temp root");
+        let output_path = root.path().join("proof.txt");
+        let script_path = root.path().join("launcher.sh");
+        let mut script = std::fs::File::create(&script_path).expect("create launcher");
+        writeln!(
+            script,
+            "#!/bin/sh\nprintf '%s|%s' \"$1\" \"$PWD\" > '{}'",
+            output_path.display()
+        )
+        .expect("write launcher");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = script.metadata().expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&script_path, permissions).expect("chmod launcher");
+        }
+
+        let config = serde_json::json!({
+            "session_name": "alpha",
+            "root_path": root.path(),
+            "launch": {"command": [script_path, "{team_name}"]},
+            "panes": [{"name": "agent"}]
+        });
+        let mode = start_session("alpha", &config.to_string())
+            .await
+            .expect("external launch");
+        assert_eq!(mode, LaunchMode::External);
+        let proof = std::fs::read_to_string(output_path).expect("read proof");
+        let (team, cwd) = proof.split_once('|').expect("proof fields");
+        assert_eq!(team, "alpha");
+        assert_eq!(
+            std::fs::canonicalize(cwd).expect("canonical proof cwd"),
+            root.path().canonicalize().expect("canonical temp root")
+        );
+    }
+
+    #[test]
+    fn rejects_shell_string_launch_commands() {
+        let config = serde_json::json!({
+            "session_name": "alpha",
+            "root_path": "/tmp",
+            "launch": {"command": "echo unsafe"}
+        });
+        let error = external_launch(&config.to_string(), "alpha").expect_err("reject string");
+        assert!(error.to_string().contains("argv array"));
+    }
+}

--- a/crates/scmux-daemon/src/lib.rs
+++ b/crates/scmux-daemon/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod db;
 pub mod definition_writer;
 pub mod hosts;
+pub mod launcher;
 pub mod logging;
 pub mod runtime;
 mod start_cycle;

--- a/crates/scmux-daemon/src/start_cycle.rs
+++ b/crates/scmux-daemon/src/start_cycle.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{info, warn};
 
-use crate::{db::SessionDefinition, tmux, AppState};
+use crate::{db::SessionDefinition, launcher, tmux, AppState};
 
 /// Returns true if the cron expression should fire within the current 15s window.
 pub fn should_run_now(expr: &str, now: &chrono::DateTime<Utc>) -> bool {
@@ -65,9 +65,9 @@ pub async fn run_start_cycle(
         }
 
         info!("starting session '{}' trigger={}", name, trigger);
-        match tmux::start_session(&name, &config_json).await {
-            Ok(()) => {
-                info!("session '{}' start submitted", name);
+        match launcher::start_session(&name, &config_json).await {
+            Ok(mode) => {
+                info!("session '{}' start submitted mode={}", name, mode.as_str());
             }
             Err(err) => {
                 warn!("failed to start session '{}': {}", name, err);

--- a/crates/scmux-daemon/src/tmux.rs
+++ b/crates/scmux-daemon/src/tmux.rs
@@ -11,10 +11,16 @@ pub struct PaneInfo {
     pub current_command: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HostTarget {
     Local,
     Remote { user: String, host: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct JumpDestination {
+    session: String,
+    host: HostTarget,
 }
 
 /// Returns set of live tmux session names mapped to their panes.
@@ -128,7 +134,7 @@ pub async fn jump_session(
     session: &str,
     terminal: &str,
 ) -> anyhow::Result<String> {
-    if !terminal.eq_ignore_ascii_case("iterm2") {
+    if !terminal.eq_ignore_ascii_case("iterm2") && !terminal.eq_ignore_ascii_case("terminal") {
         anyhow::bail!("unsupported terminal '{terminal}'");
     }
 
@@ -141,8 +147,9 @@ pub async fn jump_session(
 
     #[cfg(target_os = "macos")]
     {
-        let escaped_session = shell_escape(session);
-        let command = match host {
+        let destination = resolve_jump_destination(host, session, &local_host_aliases());
+        let escaped_session = shell_escape(&destination.session);
+        let command = match destination.host {
             HostTarget::Local => format!("tmux attach -t {escaped_session}"),
             HostTarget::Remote { user, host } => {
                 format!(
@@ -152,28 +159,145 @@ pub async fn jump_session(
                 )
             }
         };
-        let script = format!(
-            "tell application \"iTerm2\"\n  create window with default profile\n  tell current session of current window\n    write text \"{}\"\n  end tell\nend tell",
-            apple_script_escape(&command)
-        );
+        let escaped_command = apple_script_escape(&command);
+        if terminal.eq_ignore_ascii_case("iterm2") {
+            let script = format!(
+                "tell application \"iTerm2\"\n  create window with default profile\n  tell current session of current window\n    write text \"{escaped_command}\"\n  end tell\nend tell"
+            );
+            let iterm = run_applescript(&script).await?;
+            if iterm.status.success() {
+                return Ok("launched iTerm2".to_string());
+            }
 
-        let out = Command::new(osascript_bin())
-            .args(["-e", script.as_str()])
-            .output()
-            .await?;
-
-        if !out.status.success() {
-            let err = String::from_utf8_lossy(&out.stderr).trim().to_string();
-            let message = if err.is_empty() {
-                "osascript failed to launch iTerm2".to_string()
-            } else {
-                format!("osascript failed: {err}")
-            };
-            anyhow::bail!(message);
+            let terminal_script = format!(
+                "tell application \"Terminal\"\n  activate\n  do script \"{escaped_command}\"\nend tell"
+            );
+            let fallback = run_applescript(&terminal_script).await?;
+            if fallback.status.success() {
+                return Ok("launched Terminal (iTerm2 unavailable)".to_string());
+            }
+            anyhow::bail!(
+                "failed to launch iTerm2 ({}) and Terminal fallback ({})",
+                applescript_error(&iterm, "iTerm2"),
+                applescript_error(&fallback, "Terminal")
+            );
         }
 
-        Ok("launched iTerm2".to_string())
+        let script = format!(
+            "tell application \"Terminal\"\n  activate\n  do script \"{escaped_command}\"\nend tell"
+        );
+        let output = run_applescript(&script).await?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "failed to launch Terminal ({})",
+                applescript_error(&output, "Terminal")
+            );
+        }
+        Ok("launched Terminal".to_string())
     }
+}
+
+#[cfg(target_os = "macos")]
+async fn run_applescript(script: &str) -> anyhow::Result<std::process::Output> {
+    Ok(Command::new(osascript_bin())
+        .args(["-e", script])
+        .output()
+        .await?)
+}
+
+#[cfg(target_os = "macos")]
+fn applescript_error(output: &std::process::Output, application: &str) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        format!("osascript could not launch {application}")
+    } else {
+        stderr
+    }
+}
+
+/// Resolve an optional host-qualified team name.
+///
+/// Supported forms are `<session>@local` and `<session>@<ssh-user>@<host>`.
+/// The qualifier is routing metadata only and is removed from the tmux session
+/// name. Unqualified names retain the host selected from the scmux registry.
+fn resolve_jump_destination(
+    configured_host: HostTarget,
+    qualified_name: &str,
+    local_aliases: &[String],
+) -> JumpDestination {
+    if let Some(session) = qualified_name.strip_suffix("@local") {
+        if !session.is_empty() && !session.contains('@') {
+            return JumpDestination {
+                session: session.to_string(),
+                host: HostTarget::Local,
+            };
+        }
+    }
+
+    if let Some((session_and_user, host)) = qualified_name.rsplit_once('@') {
+        if let Some((session, user)) = session_and_user.rsplit_once('@') {
+            if !session.is_empty() && !user.is_empty() && !host.is_empty() {
+                let host_target = if host_matches_local(host, local_aliases) {
+                    HostTarget::Local
+                } else {
+                    HostTarget::Remote {
+                        user: user.to_string(),
+                        host: host.to_string(),
+                    }
+                };
+                return JumpDestination {
+                    session: session.to_string(),
+                    host: host_target,
+                };
+            }
+        }
+    }
+
+    JumpDestination {
+        session: qualified_name.to_string(),
+        host: configured_host,
+    }
+}
+
+fn local_host_aliases() -> Vec<String> {
+    let mut aliases = ["COMPUTERNAME", "HOSTNAME"]
+        .iter()
+        .filter_map(|name| std::env::var(name).ok())
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>();
+
+    if let Ok(output) = std::process::Command::new("hostname").output() {
+        if output.status.success() {
+            let hostname = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !hostname.is_empty() {
+                aliases.push(hostname);
+            }
+        }
+    }
+    aliases
+}
+
+fn host_matches_local(host: &str, local_aliases: &[String]) -> bool {
+    let literal = host.trim().trim_end_matches('.').to_ascii_lowercase();
+    if matches!(
+        literal.as_str(),
+        "local" | "localhost" | "127.0.0.1" | "::1"
+    ) {
+        return true;
+    }
+    let expected = normalized_host(host);
+    local_aliases
+        .iter()
+        .any(|alias| normalized_host(alias) == expected)
+}
+
+fn normalized_host(host: &str) -> String {
+    host.trim()
+        .trim_end_matches('.')
+        .split('.')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
 }
 
 fn tmux_bin() -> String {
@@ -198,6 +322,79 @@ fn shell_escape(input: &str) -> String {
         return input.to_string();
     }
     format!("'{}'", input.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod jump_tests {
+    use super::*;
+
+    fn remote() -> HostTarget {
+        HostTarget::Remote {
+            user: "configured-user".to_string(),
+            host: "configured-host".to_string(),
+        }
+    }
+
+    #[test]
+    fn unqualified_name_retains_configured_host() {
+        let destination = resolve_jump_destination(remote(), "aidw-dev", &[]);
+        assert_eq!(destination.session, "aidw-dev");
+        assert!(matches!(
+            destination.host,
+            HostTarget::Remote { ref user, ref host }
+                if user == "configured-user" && host == "configured-host"
+        ));
+    }
+
+    #[test]
+    fn local_qualifier_selects_local_host_and_strips_routing_suffix() {
+        let destination = resolve_jump_destination(remote(), "hitl-dev@local", &[]);
+        assert_eq!(destination.session, "hitl-dev");
+        assert!(matches!(destination.host, HostTarget::Local));
+    }
+
+    #[test]
+    fn remote_qualifier_builds_ssh_target_and_strips_routing_suffix() {
+        let destination = resolve_jump_destination(
+            HostTarget::Local,
+            "aidw-dev@aidwlead@HITL2",
+            &["Radiant-MTP-MacBook-Pro.local".to_string()],
+        );
+        assert_eq!(destination.session, "aidw-dev");
+        assert!(matches!(
+            destination.host,
+            HostTarget::Remote { ref user, ref host }
+                if user == "aidwlead" && host == "HITL2"
+        ));
+    }
+
+    #[test]
+    fn computer_id_matching_current_hostname_skips_ssh() {
+        let destination = resolve_jump_destination(
+            remote(),
+            "aidw-dev@aidwlead@HITL2",
+            &["hitl2.local".to_string()],
+        );
+        assert_eq!(destination.session, "aidw-dev");
+        assert!(matches!(destination.host, HostTarget::Local));
+    }
+
+    #[test]
+    fn loopback_computer_ids_never_use_ssh() {
+        for computer_id in ["local", "localhost", "127.0.0.1", "::1"] {
+            let name = format!("aidw-dev@aidwlead@{computer_id}");
+            let destination = resolve_jump_destination(remote(), &name, &[]);
+            assert_eq!(destination.session, "aidw-dev");
+            assert!(matches!(destination.host, HostTarget::Local));
+        }
+    }
+
+    #[test]
+    fn malformed_qualifier_remains_a_legacy_session_name() {
+        let destination = resolve_jump_destination(HostTarget::Local, "aidw-dev@HITL2", &[]);
+        assert_eq!(destination.session, "aidw-dev@HITL2");
+        assert!(matches!(destination.host, HostTarget::Local));
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -290,5 +487,104 @@ exit 1
 
         // SAFETY: test teardown under global lock.
         unsafe { std::env::remove_var("SCMUX_TMUX_BIN") };
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "macos")]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "test-only process environment is serialized across the awaited launch"
+    )]
+    async fn host_qualified_jump_emits_ssh_before_tmux_attach() {
+        let _guard = with_env_lock();
+        let output = tempfile::NamedTempFile::new().expect("output file");
+        let script = write_script(&format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
+            output.path().display()
+        ));
+        // SAFETY: test-only env mutation under global lock.
+        unsafe { std::env::set_var("SCMUX_OSASCRIPT_BIN", script.to_string_lossy().to_string()) };
+
+        jump_session(
+            HostTarget::Local,
+            "aidw-dev@aidwlead@scmux-remote-test.invalid",
+            "iterm2",
+        )
+        .await
+        .expect("jump command");
+
+        // SAFETY: test teardown under global lock.
+        unsafe { std::env::remove_var("SCMUX_OSASCRIPT_BIN") };
+        let args = std::fs::read_to_string(output.path()).expect("captured osascript args");
+        assert!(args.contains("ssh aidwlead@scmux-remote-test.invalid tmux attach -t aidw-dev"));
+        assert!(!args.contains("tmux attach -t aidw-dev@aidwlead@"));
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "macos")]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "test-only process environment is serialized across the awaited launch"
+    )]
+    async fn local_jump_uses_operating_system_without_ssh() {
+        let _guard = with_env_lock();
+        let output = tempfile::NamedTempFile::new().expect("output file");
+        let script = write_script(&format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
+            output.path().display()
+        ));
+        // SAFETY: test-only env mutation under global lock.
+        unsafe { std::env::set_var("SCMUX_OSASCRIPT_BIN", script.to_string_lossy().to_string()) };
+
+        jump_session(
+            HostTarget::Remote {
+                user: "unused".to_string(),
+                host: "unused".to_string(),
+            },
+            "hitl-dev@unused@localhost",
+            "iterm2",
+        )
+        .await
+        .expect("local jump command");
+
+        // SAFETY: test teardown under global lock.
+        unsafe { std::env::remove_var("SCMUX_OSASCRIPT_BIN") };
+        let args = std::fs::read_to_string(output.path()).expect("captured osascript args");
+        assert!(args.contains("tmux attach -t hitl-dev"));
+        assert!(!args.contains("ssh "));
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "macos")]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "test-only process environment is serialized across the awaited launch"
+    )]
+    async fn missing_iterm_falls_back_to_terminal_without_networking() {
+        let _guard = with_env_lock();
+        let output = tempfile::NamedTempFile::new().expect("output file");
+        let script = write_script(&format!(
+            r#"#!/bin/sh
+case "$2" in
+  *iTerm2*) echo "iTerm2 not installed" 1>&2; exit 1 ;;
+esac
+printf '%s\n' "$@" > '{}'
+"#,
+            output.path().display()
+        ));
+        // SAFETY: test-only env mutation under global lock.
+        unsafe { std::env::set_var("SCMUX_OSASCRIPT_BIN", script.to_string_lossy().to_string()) };
+
+        let message = jump_session(HostTarget::Local, "hitl-dev@local", "iterm2")
+            .await
+            .expect("Terminal fallback");
+
+        // SAFETY: test teardown under global lock.
+        unsafe { std::env::remove_var("SCMUX_OSASCRIPT_BIN") };
+        assert_eq!(message, "launched Terminal (iTerm2 unavailable)");
+        let args = std::fs::read_to_string(output.path()).expect("captured osascript args");
+        assert!(args.contains("tell application \"Terminal\""));
+        assert!(args.contains("tmux attach -t hitl-dev"));
+        assert!(!args.contains("ssh "));
     }
 }

--- a/crates/scmux-daemon/src/tmux.rs
+++ b/crates/scmux-daemon/src/tmux.rs
@@ -160,7 +160,14 @@ pub async fn jump_session(
             }
         };
         let escaped_command = apple_script_escape(&command);
-        if terminal.eq_ignore_ascii_case("iterm2") {
+        // AppleScript against iTerm2 only compiles when iTerm2 is installed
+        // (a missing app means a missing scripting dictionary, surfacing as a
+        // bare osascript syntax error), and any Apple Event sent from a
+        // launchd daemon additionally needs a TCC Automation grant. Try
+        // iTerm2 only when it is actually installed; otherwise (or on
+        // failure) fall back to opening a .command file via LaunchServices,
+        // which sends no Apple Events and needs no grant.
+        if terminal.eq_ignore_ascii_case("iterm2") && iterm2_installed() {
             let script = format!(
                 "tell application \"iTerm2\"\n  create window with default profile\n  tell current session of current window\n    write text \"{escaped_command}\"\n  end tell\nend tell"
             );
@@ -168,33 +175,77 @@ pub async fn jump_session(
             if iterm.status.success() {
                 return Ok("launched iTerm2".to_string());
             }
+        }
 
-            let terminal_script = format!(
-                "tell application \"Terminal\"\n  activate\n  do script \"{escaped_command}\"\nend tell"
-            );
-            let fallback = run_applescript(&terminal_script).await?;
-            if fallback.status.success() {
-                return Ok("launched Terminal (iTerm2 unavailable)".to_string());
+        match launch_via_command_file(&destination.session, &command).await {
+            Ok(()) => Ok("launched Terminal".to_string()),
+            Err(open_err) => {
+                // Last resort: classic AppleScript path (works when the user
+                // has granted the daemon Automation access to Terminal).
+                let script = format!(
+                    "tell application \"Terminal\"\n  activate\n  do script \"{escaped_command}\"\nend tell"
+                );
+                let output = run_applescript(&script).await?;
+                if !output.status.success() {
+                    anyhow::bail!(
+                        "failed to launch Terminal via .command file ({open_err}) and via AppleScript ({})",
+                        applescript_error(&output, "Terminal")
+                    );
+                }
+                Ok("launched Terminal (AppleScript)".to_string())
             }
-            anyhow::bail!(
-                "failed to launch iTerm2 ({}) and Terminal fallback ({})",
-                applescript_error(&iterm, "iTerm2"),
-                applescript_error(&fallback, "Terminal")
-            );
         }
-
-        let script = format!(
-            "tell application \"Terminal\"\n  activate\n  do script \"{escaped_command}\"\nend tell"
-        );
-        let output = run_applescript(&script).await?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "failed to launch Terminal ({})",
-                applescript_error(&output, "Terminal")
-            );
-        }
-        Ok("launched Terminal".to_string())
     }
+}
+
+#[cfg(target_os = "macos")]
+fn iterm2_installed() -> bool {
+    // Test/ops override: "1"/"0" forces the answer without touching the disk.
+    if let Ok(forced) = std::env::var("SCMUX_ITERM_INSTALLED") {
+        return forced == "1";
+    }
+    if std::path::Path::new("/Applications/iTerm.app").exists() {
+        return true;
+    }
+    match std::env::var("HOME") {
+        Ok(home) => std::path::Path::new(&format!("{home}/Applications/iTerm.app")).exists(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn open_bin() -> String {
+    std::env::var("SCMUX_OPEN_BIN").unwrap_or_else(|_| "/usr/bin/open".to_string())
+}
+
+/// Launch Terminal by opening an executable `.command` file through
+/// LaunchServices. Unlike `osascript`, `open` sends no Apple Events, so it
+/// works from a launchd daemon without any TCC Automation grant.
+#[cfg(target_os = "macos")]
+async fn launch_via_command_file(session: &str, command: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let safe_name: String = session
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .collect();
+    let dir = std::env::temp_dir().join("scmux-jump");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("attach-{safe_name}.command"));
+
+    let mut file = std::fs::File::create(&path)?;
+    writeln!(file, "#!/bin/zsh")?;
+    writeln!(file, "exec {command}")?;
+    drop(file);
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
+
+    let out = Command::new(open_bin()).arg(&path).output().await?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        anyhow::bail!("open {} failed: {stderr}", path.display());
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -498,12 +549,14 @@ exit 1
     async fn host_qualified_jump_emits_ssh_before_tmux_attach() {
         let _guard = with_env_lock();
         let output = tempfile::NamedTempFile::new().expect("output file");
+        // Capture the launched .command file's contents instead of Apple Events.
         let script = write_script(&format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
+            "#!/bin/sh\ncat \"$1\" > '{}'\n",
             output.path().display()
         ));
         // SAFETY: test-only env mutation under global lock.
-        unsafe { std::env::set_var("SCMUX_OSASCRIPT_BIN", script.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("SCMUX_OPEN_BIN", script.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("SCMUX_ITERM_INSTALLED", "0") };
 
         jump_session(
             HostTarget::Local,
@@ -514,8 +567,9 @@ exit 1
         .expect("jump command");
 
         // SAFETY: test teardown under global lock.
-        unsafe { std::env::remove_var("SCMUX_OSASCRIPT_BIN") };
-        let args = std::fs::read_to_string(output.path()).expect("captured osascript args");
+        unsafe { std::env::remove_var("SCMUX_OPEN_BIN") };
+        unsafe { std::env::remove_var("SCMUX_ITERM_INSTALLED") };
+        let args = std::fs::read_to_string(output.path()).expect("captured .command contents");
         assert!(args.contains("ssh aidwlead@scmux-remote-test.invalid tmux attach -t aidw-dev"));
         assert!(!args.contains("tmux attach -t aidw-dev@aidwlead@"));
     }
@@ -529,12 +583,14 @@ exit 1
     async fn local_jump_uses_operating_system_without_ssh() {
         let _guard = with_env_lock();
         let output = tempfile::NamedTempFile::new().expect("output file");
+        // Capture the launched .command file's contents instead of Apple Events.
         let script = write_script(&format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\n",
+            "#!/bin/sh\ncat \"$1\" > '{}'\n",
             output.path().display()
         ));
         // SAFETY: test-only env mutation under global lock.
-        unsafe { std::env::set_var("SCMUX_OSASCRIPT_BIN", script.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("SCMUX_OPEN_BIN", script.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("SCMUX_ITERM_INSTALLED", "0") };
 
         jump_session(
             HostTarget::Remote {
@@ -548,8 +604,9 @@ exit 1
         .expect("local jump command");
 
         // SAFETY: test teardown under global lock.
-        unsafe { std::env::remove_var("SCMUX_OSASCRIPT_BIN") };
-        let args = std::fs::read_to_string(output.path()).expect("captured osascript args");
+        unsafe { std::env::remove_var("SCMUX_OPEN_BIN") };
+        unsafe { std::env::remove_var("SCMUX_ITERM_INSTALLED") };
+        let args = std::fs::read_to_string(output.path()).expect("captured .command contents");
         assert!(args.contains("tmux attach -t hitl-dev"));
         assert!(!args.contains("ssh "));
     }
@@ -563,17 +620,18 @@ exit 1
     async fn missing_iterm_falls_back_to_terminal_without_networking() {
         let _guard = with_env_lock();
         let output = tempfile::NamedTempFile::new().expect("output file");
+        // iTerm2 forced absent: jump must go straight to the .command file
+        // path (no Apple Events at all). The fake osascript would fail loudly
+        // if it were ever invoked.
+        let osascript = write_script("#!/bin/sh\necho 'osascript must not run' 1>&2; exit 1\n");
         let script = write_script(&format!(
-            r#"#!/bin/sh
-case "$2" in
-  *iTerm2*) echo "iTerm2 not installed" 1>&2; exit 1 ;;
-esac
-printf '%s\n' "$@" > '{}'
-"#,
+            "#!/bin/sh\ncat \"$1\" > '{}'\n",
             output.path().display()
         ));
         // SAFETY: test-only env mutation under global lock.
-        unsafe { std::env::set_var("SCMUX_OSASCRIPT_BIN", script.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("SCMUX_OSASCRIPT_BIN", osascript.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("SCMUX_OPEN_BIN", script.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("SCMUX_ITERM_INSTALLED", "0") };
 
         let message = jump_session(HostTarget::Local, "hitl-dev@local", "iterm2")
             .await
@@ -581,9 +639,10 @@ printf '%s\n' "$@" > '{}'
 
         // SAFETY: test teardown under global lock.
         unsafe { std::env::remove_var("SCMUX_OSASCRIPT_BIN") };
-        assert_eq!(message, "launched Terminal (iTerm2 unavailable)");
-        let args = std::fs::read_to_string(output.path()).expect("captured osascript args");
-        assert!(args.contains("tell application \"Terminal\""));
+        unsafe { std::env::remove_var("SCMUX_OPEN_BIN") };
+        unsafe { std::env::remove_var("SCMUX_ITERM_INSTALLED") };
+        assert_eq!(message, "launched Terminal");
+        let args = std::fs::read_to_string(output.path()).expect("captured .command contents");
         assert!(args.contains("tmux attach -t hitl-dev"));
         assert!(!args.contains("ssh "));
     }

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -1876,6 +1876,7 @@ async fn t_a_09_post_sessions_name_jump_returns_ok_true_when_iterm2_launched() {
     let _guard = env_lock().lock().await;
     let script = write_script("#!/bin/sh\nexit 0\n");
     let prev = set_env_var("SCMUX_OSASCRIPT_BIN", script.to_string_lossy().as_ref());
+    let prev_iterm = set_env_var("SCMUX_ITERM_INSTALLED", "1");
 
     let response = h
         .client
@@ -1885,6 +1886,7 @@ async fn t_a_09_post_sessions_name_jump_returns_ok_true_when_iterm2_launched() {
         .await
         .expect("jump request");
     restore_env_var("SCMUX_OSASCRIPT_BIN", prev);
+    restore_env_var("SCMUX_ITERM_INSTALLED", prev_iterm);
 
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     let body: Value = response.json().await.expect("json");

--- a/crates/scmux-daemon/tests/api_tests.rs
+++ b/crates/scmux-daemon/tests/api_tests.rs
@@ -358,6 +358,65 @@ async fn t_lc_01_post_sessions_name_start_launches_tmux_from_config() {
 }
 
 #[tokio::test]
+async fn t_lc_10_external_launcher_is_visible_and_owns_stop_lifecycle() {
+    let h = ApiHarness::new().await;
+    let script = write_script("#!/bin/sh\nexit 0\n");
+    let root_path = h._tmp.path().to_string_lossy().to_string();
+    let response = h
+        .client
+        .post(format!("{}/sessions", h.base_url))
+        .json(&json!({
+            "name": "external-team",
+            "project": "demo",
+            "config_json": {
+                "session_name": "external-team",
+                "root_path": root_path,
+                "launch": {"command": [script.to_string_lossy(), "{team_name}"]},
+                "panes": [{"name": "agent"}]
+            },
+            "auto_start": false
+        }))
+        .send()
+        .await
+        .expect("create external session");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let sessions: Vec<Value> = h
+        .client
+        .get(format!("{}/sessions", h.base_url))
+        .send()
+        .await
+        .expect("list sessions")
+        .json()
+        .await
+        .expect("session JSON");
+    assert_eq!(sessions[0]["launch_mode"], "external");
+
+    let start = h
+        .client
+        .post(format!("{}/sessions/external-team/start", h.base_url))
+        .send()
+        .await
+        .expect("start external session");
+    assert_eq!(start.status(), reqwest::StatusCode::OK);
+    let start_body: Value = start.json().await.expect("start JSON");
+    assert_eq!(
+        start_body["message"],
+        "session 'external-team' started via external"
+    );
+
+    let stop = h
+        .client
+        .post(format!("{}/sessions/external-team/stop", h.base_url))
+        .send()
+        .await
+        .expect("stop external session");
+    assert_eq!(stop.status(), reqwest::StatusCode::CONFLICT);
+    let stop_body: Value = stop.json().await.expect("stop JSON");
+    assert_eq!(stop_body["code"], "external_lifecycle");
+}
+
+#[tokio::test]
 async fn t_lc_07_start_rejects_invalid_crew_variant_binding() {
     let h = ApiHarness::new().await;
     h.create_session("crew-invalid").await;

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -273,6 +273,22 @@ function ciRunTone(run) {
   };
 }
 function buildJumpCommand(session, host) {
+  const localMatch = session.name.match(/^([^@]+)@local$/i);
+  if (localMatch) {
+    return `tmux attach -t ${localMatch[1]}`;
+  }
+  const remoteMatch = session.name.match(/^(.+)@([^@]+)@([^@]+)$/);
+  if (remoteMatch) {
+    const [, tmuxSession, sshUser, computerId] = remoteMatch;
+    const computerLiteral = computerId.toLowerCase().replace(/\.$/, "");
+    const normalizedComputer = computerLiteral.split(".")[0];
+    const localNames = [host?.name, host?.address].filter(Boolean).map(value => value.toLowerCase().split(".")[0]);
+    const loopback = ["local", "localhost", "127.0.0.1", "::1"].includes(computerLiteral);
+    if (loopback || localNames.includes(normalizedComputer)) {
+      return `tmux attach -t ${tmuxSession}`;
+    }
+    return `ssh ${sshUser}@${computerId} tmux attach -t ${tmuxSession}`;
+  }
   if (!host || host.is_local) {
     return `tmux attach -t ${session.name}`;
   }

--- a/dashboard/team-dashboard.jsx
+++ b/dashboard/team-dashboard.jsx
@@ -276,6 +276,24 @@ function ciRunTone(run) {
 }
 
 function buildJumpCommand(session, host) {
+  const localMatch = session.name.match(/^([^@]+)@local$/i);
+  if (localMatch) {
+    return `tmux attach -t ${localMatch[1]}`;
+  }
+  const remoteMatch = session.name.match(/^(.+)@([^@]+)@([^@]+)$/);
+  if (remoteMatch) {
+    const [, tmuxSession, sshUser, computerId] = remoteMatch;
+    const computerLiteral = computerId.toLowerCase().replace(/\.$/, "");
+    const normalizedComputer = computerLiteral.split(".")[0];
+    const localNames = [host?.name, host?.address]
+      .filter(Boolean)
+      .map(value => value.toLowerCase().split(".")[0]);
+    const loopback = ["local", "localhost", "127.0.0.1", "::1"].includes(computerLiteral);
+    if (loopback || localNames.includes(normalizedComputer)) {
+      return `tmux attach -t ${tmuxSession}`;
+    }
+    return `ssh ${sshUser}@${computerId} tmux attach -t ${tmuxSession}`;
+  }
   if (!host || host.is_local) {
     return `tmux attach -t ${session.name}`;
   }


### PR DESCRIPTION
Supersedes #55 (fork PR opened before write access was granted). Same two commits from the 2026-08-05/06 AIDW integration session, now on an in-repo branch.

**Commit 1 — launch.command seam, safe terminal jump, dashboard team view**
- `launcher.rs`: argv-based external launcher dispatch (`LaunchMode::External`) so definitions like AIDW teams can route Start through a manifest-aware launcher that registers pane identities with ATM; tmuxp stays the default
- `tmux.rs`: rewritten `jump_session` with shell/AppleScript escaping and iTerm2 → Terminal fallback (fixes osascript syntax-error on jump)
- `api.rs`/`start_cycle.rs`: launch dispatch wiring; api_tests cover both modes
- dashboard: team view additions

**Commit 2 — jump works without iTerm2 and without TCC Automation grants**
- Skips iTerm2 AppleScript when iTerm.app is absent (missing scripting dictionary made osascript fail with a bare syntax error)
- Launches Terminal by opening a generated `.command` file via LaunchServices (`/usr/bin/open`) — no Apple Events, so a launchd daemon needs no TCC Automation grant; AppleScript kept as last-resort fallback
- `SCMUX_OPEN_BIN` / `SCMUX_ITERM_INSTALLED` test seams; tests updated

The `/api/clients` presence endpoint is stacked on this branch as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)